### PR TITLE
Initialize uc and vc to 0d0 in computeMassFluxesR8

### DIFF
--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -2913,8 +2913,8 @@ subroutine fv_computeMassFluxes_r8(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
   integer     :: it, nsplt
 
 ! Fill Ghosted arrays and update halos
-  uc = 0d0
-  vc = 0d0
+  uc = MAPL_UNDEF
+  vc = MAPL_UNDEF
   uc(is:ie,js:je,:) = ucI
   vc(is:ie,js:je,:) = vcI
   call mpp_get_boundary(uc, vc, FV_Atm(1)%domain, &

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -2913,6 +2913,8 @@ subroutine fv_computeMassFluxes_r8(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
   integer     :: it, nsplt
 
 ! Fill Ghosted arrays and update halos
+  uc = 0d0
+  vc = 0d0
   uc(is:ie,js:je,:) = ucI
   vc(is:ie,js:je,:) = vcI
   call mpp_get_boundary(uc, vc, FV_Atm(1)%domain, &


### PR DESCRIPTION
This fixes #7 and is separate from my other PR which is for the dev/MAPL-2.0 branch while this is a hotfix for master.

Without this the CTM crashes, and this initialization is already present in the r4 version.