### PR TITLE
Fix standalone dynadv driver

### DIFF
--- a/StandAlone_DynAdvCore_GridCompMod.F90
+++ b/StandAlone_DynAdvCore_GridCompMod.F90
@@ -85,9 +85,8 @@ contains
       call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,    Finalize,   RC=status )
       VERIFY_(STATUS)
 
-      ! Create childrens gridded components and invoke their SetServices
+      ! Creat childrens gridded components and invoke their SetServices
       !-----------------------------------------------------------------
-
       DynCore = MAPL_AddChild(GC, NAME='DYN',   SS=DynCoreSetServices, RC=status)
       VERIFY_(STATUS)
 
@@ -173,13 +172,7 @@ contains
       real                          :: cdt         ! time step in secs
 
       character(len=ESMF_MAXSTR)    :: comp_name
-      type (ESMF_FieldBundle)             :: BUNDLE1, BUNDLE2
-      type (ESMF_GridComp),      pointer  :: GCS(:)
-      type (ESMF_State),         pointer  :: GIM(:)
-      type (ESMF_State),         pointer  :: GEX(:)
       type (MAPL_MetaComp), pointer :: MAPL
-      INTEGER :: numTracers, I
-      type (ESMF_Field)            :: field
 !-------------------------------------------------------------------------
 !BOC
       Iam = 'Initialize'
@@ -190,7 +183,7 @@ contains
       VERIFY_(STATUS)
       Iam = trim(comp_name) // trim(Iam)
 
-     !if ( MAPL_AM_I_ROOT() ) print *, trim(Iam) // ':  Generic Init...'
+     if ( MAPL_AM_I_ROOT() ) print *, trim(Iam) // ':  Generic Init...'
 
       !  Create grid for this GC
       !  ------------------------
@@ -205,35 +198,6 @@ contains
 
       call MAPL_GenericInitialize ( gc, IMPORT, EXPORT, clock,  RC=status )
       VERIFY_(STATUS)
-
-      ! Get children and their im/ex states from my generic state.
-      !----------------------------------------------------------
-
-      call MAPL_Get ( MAPL, GCS=GCS, GIM=GIM, GEX=GEX, RC=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_StateGet  (GIM(DynCore), 'TRADV', BUNDLE1, RC=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_FieldBundleGet(BUNDLE1, fieldCount=numTracers,  rc=STATUS)
-      VERIFY_(STATUS)
-
-      IF ( MAPL_AM_I_ROOT() ) PRINT*, 'Number of tracers: ', numTracers
-
-      call ESMF_StateGet  (GIM(AdvCore), 'TRADV', BUNDLE2, RC=STATUS )
-      VERIFY_(STATUS)
-
-      if (numTracers > 0) then
-         do I=1, numTracers
-            call ESMF_FieldBundleGet (BUNDLE1, fieldIndex=I, field=FIELD, RC=STATUS)
-            VERIFY_(STATUS)
-
-            call MAPL_FieldBundleAdd ( BUNDLE2, field, rc=STATUS )
-            VERIFY_(STATUS)
-
-         end do
-      end if
-
 
 !  All done
 !  --------


### PR DESCRIPTION
Fixes #21 

This fixes issue 21 that the standalone dynadv core driver was broken. The driver's main grid comp was trying to add the fields in the tradv bundle from dyncore into the tradv bundle in the advcore. Apparently this is no longer necessary as somehow thru the magic of mapl the fact that dyncore has populated the tradv bundle means that advcore's tradv bundle has also been filled, must be sharing pointers underneath. 

In addition to look at the advected tracers it was necessary to add code.  The tradv bundle is not exported. In standalone mode an export bundle tradvex is created and the fields in tradv are copied to this bundle. Just copying the fields in the tradv bundle to tradvex that history can use is not enough. They need extra decoration that the mapl field creation normally performs. With these changes the fields can be pulled out of the bundle and output in History.