### PR TITLE
Update to fvdycore geos/v1.1.2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git
 local_path = ./@fvdycore
-tag = geos/v1.1.1
+tag = geos/v1.1.2
 protocol = git
 
 [externals_description]


### PR DESCRIPTION
This moves `Externals.cfg` to version v1.1.2 of GFDL_atmos_cubed_sphere (aka fvdycore). 

Needed for release to GCM.