### PR TITLE
Lower FV3 standalone stacksize

### DIFF
--- a/scripts/fv3.j
+++ b/scripts/fv3.j
@@ -257,7 +257,7 @@ cat >      input.nml << EOF
 
 &fms_nml
         print_memory_usage=.false.
-        domains_stack_size = 240000000
+        domains_stack_size = 24000000
 /
 EOF
 


### PR DESCRIPTION
As found by @karthik-vm of OSU, the default value of `domains_stack_size` in `fv3.j` is a rather impressive 240,000,000:

https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/blob/6b8ea53d00102a124d590a70d8f0103736f1d1b1/scripts/fv3.j#L258-L261

Compared to the value in the default `fvcore_layout.rc` in GEOSgcm_App it is 10x larger:
```
&fms_nml
  print_memory_usage=.false.
  domains_stack_size = 24000000
/
```

As we cannot guarantee systems outside of NASA are configured such that it would allow 240,000,000, reduce stacksize to be consistent with the default for the GEOS GCM.