### PR TITLE
Remove manage_externals support

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,0 @@
-[fvdycore]
-required = True
-repo_url = git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git
-local_path = ./@fvdycore
-tag = geos/v1.1.3
-protocol = git
-
-[externals_description]
-schema_version = 1.0.0


### PR DESCRIPTION
This is in relation to the move to `mepo`. Just removes `Externals.cfg`