### PR TITLE
Added "do k=1,npz" and "enddo" to the upper part of the if-else-endif…

### DIFF
--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -1619,6 +1619,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
       tqtot = 0.0
       if ( (.not. ADIABATIC) .AND. (FV_Atm(1)%flagstruct%nwat /= 0) ) then
        if (FV_Atm(1)%flagstruct%nwat == 6) then
+         do k=1,npz
             tqtot(:,:) = tqtot(:,:) + ( &
             FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
             FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
@@ -1626,6 +1627,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
             FV_Atm(1)%q(isc:iec,jsc:jec,k,rain) + & 
             FV_Atm(1)%q(isc:iec,jsc:jec,k,snow) + & 
             FV_Atm(1)%q(isc:iec,jsc:jec,k,grpl) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
+         enddo
        else
          do k=1,npz
             tqtot(:,:) = tqtot(:,:) + ( &


### PR DESCRIPTION
… block below:

      tqtot = 0.0
      if ( (.not. ADIABATIC) .AND. (FV_Atm(1)%flagstruct%nwat /= 0) ) then
       if (FV_Atm(1)%flagstruct%nwat == 6) then
         do k=1,npz
            tqtot(:,:) = tqtot(:,:) + ( &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,qice) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,rain) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,snow) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,grpl) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
         enddo
       else
         do k=1,npz
            tqtot(:,:) = tqtot(:,:) + ( &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,qlcn) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,qlls) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,qicn) + &
            FV_Atm(1)%q(isc:iec,jsc:jec,k,qils) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
         enddo
       endif
      endif