### PR TITLE
Update gitignore for mepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 /@fvdycore
+/fvdycore
+/fvdycore@


### PR DESCRIPTION
Soon, `mepo` will have the ability to checkout subrepos as `repo`, `repo@`, or `@repo`. This commit updates the `.gitignore` files to support this flexibility.