### PR TITLE
Dev/aoloso/use moist gfdl mp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,9 @@ set (srcs
   )
 
 if (ESMA_USE_GFE_NAMESPACE)
-  set(dependencies MAPL GFTL_SHARED::gftl-shared GMAO_hermes GEOS_Shared)
+  set(dependencies MAPL GFTL_SHARED::gftl-shared GMAO_hermes GEOS_Shared GEOSmoist_GridComp)
 else ()
-  set(dependencies MAPL gftl-shared GMAO_hermes GEOS_Shared)
+  set(dependencies MAPL gftl-shared GMAO_hermes GEOS_Shared GEOSmoist_GridComp)
 endif ()
 
 esma_add_library (${this}

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -31,7 +31,7 @@ module FV_StateMod
    use fv_update_phys_mod, only: fv_update_phys
    use sw_core_mod, only: d2a2c_vect
    use fv_sg_mod, only: fv_subgrid_z
-   use gfdl_cloud_microphys_mod, only: gfdl_cloud_microphys_init
+   use gfdl2_cloud_microphys_mod, only: gfdl_cloud_microphys_init ! gfdl_cloud_microphys_mod as gfdl2_cloud_microphysics from moist
 
    use fv_diagnostics_mod, only: prt_maxmin, prt_minmax
 


### PR DESCRIPTION
With these changes, the duplicate GFDL cloud microphysics code in dycore i.e. @FVdycoreCubed_GridComp/@fvdycore/model/lin_cloud_microphys.F90 is removed. dycore now uses the same code in moist i.e. GEOSmoist_GridComp/gfdl_cloud_microphys.F90.