### PR TITLE
Add automatic PR for develop to MAPL3 branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
@@ -1,0 +1,10 @@
+## :memo:  Automatic PR: `develop` → `release/MAPL-v3`
+
+### Description
+
+<!-- Write your description here -->
+
+## :file_folder:  Modified files
+<!-- Diff files - START -->
+<!-- Diff files - END -->
+

--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -1,0 +1,30 @@
+name: Push to Develop
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  pull_request:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run the action
+        uses: devops-infra/action-pull-request@v0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: develop
+          target_branch: release/MAPL-v3
+          label: automatic,MAPL3,Skip Changelog
+          template: .github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+          get_diff: true
+          assignee: ${{ github.actor }}
+          old_string: "<!-- Write your description here -->"
+          new_string: ${{ github.event.commits[0].message }}
+          title: Auto PR - develop → MAPL-v3 - ${{ github.event.commits[0].message }}
+


### PR DESCRIPTION
MAPL will soon be working toward a version 3 that will have incompatibilities to MAPL 2. The branch holding these changes is called `release/MAPL-v3` and will allow the SI Team to make changes to this repository while not affecting `develop` directly.

What this PR does is add a GitHub Action so that any push to `develop` (aka, any PR merged into `develop`) also automatically makes a PR from `develop` into `release/MAPL-v3`.

This way, our tracking branch can "keep up" with `develop` and once MAPL 3 is ready to go, all that is needed is to merge `release/MAPL-v3` into `develop` and we are good.