### PR TITLE
Fix interp_restart.x build when FV_PRECISION is r8

### DIFF
--- a/fv_regrid_c2c_bin.F90
+++ b/fv_regrid_c2c_bin.F90
@@ -97,14 +97,14 @@ contains
          if (extra_rst(i)%have_descriptor) then
             do j=1,size(extra_rst(i)%vars)
                if (extra_rst(i)%vars(j)%nLev/=1) then
-                  allocate(extra_rst(i)%vars(j)%ptr3d(isd:ied,jsd:jed,extra_rst(i)%vars(j)%nLev),source=0.0 )
+                  allocate(extra_rst(i)%vars(j)%ptr3d(isd:ied,jsd:jed,extra_rst(i)%vars(j)%nLev),source=0.0_FVPRC )
                else
-                  allocate(extra_rst(i)%vars(j)%ptr2d(isd:ied,jsd:jed), source=0.0 )
+                  allocate(extra_rst(i)%vars(j)%ptr2d(isd:ied,jsd:jed), source=0.0_FVPRC )
                end if
             enddo
          else
             do j=1,size(extra_rst(i)%vars) 
-               allocate(extra_rst(i)%vars(j)%ptr3d(isd:ied,jsd:jed,extra_rst(i)%vars(j)%nLev),source=0.0 )
+               allocate(extra_rst(i)%vars(j)%ptr3d(isd:ied,jsd:jed,extra_rst(i)%vars(j)%nLev),source=0.0_FVPRC )
             enddo 
          end if
       enddo

--- a/fv_regridding_utils.F90
+++ b/fv_regridding_utils.F90
@@ -73,17 +73,17 @@ contains
     integer :: km_use
 
     if (this%rank==2) then
-       allocate(this%ptr2d(is:ie,js:je),source=0.0)
+       allocate(this%ptr2d(is:ie,js:je),source=0.0_FVPRC)
     else if (this%rank==3) then
        if (this%n_ungrid > 0) then
-          allocate(this%ptr3d(is:ie,js:je,this%n_ungrid),source=0.0)
+          allocate(this%ptr3d(is:ie,js:je,this%n_ungrid),source=0.0_FVPRC)
        else if (this%n_ungrid == 0) then
           if (present(km)) then 
              km_use = km
           else
              km_use = this%nlev
           end if
-          allocate(this%ptr3d(is:ie,js:je,km_use),source=0.0)
+          allocate(this%ptr3d(is:ie,js:je,km_use),source=0.0_FVPRC)
        end if
     else if (this%rank == 4) then
        if (present(km)) then 
@@ -91,7 +91,7 @@ contains
        else
           km_use = this%nlev
        end if
-       allocate(this%ptr4d(is:ie,js:je,km_use,this%n_ungrid),source=0.0)
+       allocate(this%ptr4d(is:ie,js:je,km_use,this%n_ungrid),source=0.0_FVPRC)
     end if
     _RETURN(_SUCCESS)
 


### PR DESCRIPTION
When the CTM was updated the build of interp_restarts.x failed because that uses FV_PRECISION = r8.
This PR fixes that.
It is also dependent on this PR in MAPL.
https://github.com/GEOS-ESM/MAPL/pull/1258