### PR TITLE
Squash unnecessary warning from FVdycore

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -599,6 +599,9 @@ contains
                adjustTracers = .true.
             end if
          end if
+      else if (adjustTracerMode == 'NO') then
+         ! Proceed without warning
+         adjustTracers = .false.
       else
          call WRITE_PARALLEL('Invalid option, ignored')
          adjustTracers = .false.


### PR DESCRIPTION
When the user does NOT want to exclude advection tracers, there is currently no way to safely ensure this without causing a warning to be pushed to stdout on every time step. This can now be prevented by setting `EXCLUDE_ADVECTION_TRACERS: NO` in the relevant resource file.