### PR TITLE
Fixes #165. Initialze ks with bk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,277 +1,33 @@
 version: 2.1
 
-executors:
-  gfortran:
-    docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    environment:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-      MPIEXEC_PREFLAGS: --oversubscribe
-    resource_class: large
-    #MEDIUM# resource_class: medium
+# Anchor to prevent forgetting to update a version
+baselibs_version: &baselibs_version v6.3.1
 
-  ifort:
-    docker:
-      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.2.0-intel_2021.2.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    resource_class: large
-    #MEDIUM# resource_class: medium
+orbs:
+  ci: geos-esm/circleci-tools@1
 
 workflows:
   build-test:
     jobs:
-      - build-GEOSgcm:
+      - ci/build:
           name: build-GEOSgcm-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [ifort, gfortran]
+          baselibs_version: *baselibs_version
+          repo: GEOSgcm
+          mepodevelop: false
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
+      - ci/run_fv3:
+          name: run-FV3-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          context: 
-            - docker-hub-creds
-      ###################################################
-      # - make-FV3-exp:                                 #
-      #     name: make-FV3-exp-on-<< matrix.compiler >> #
-      #     matrix:                                     #
-      #       parameters:                               #
-      #         compiler: [gfortran, ifort]             #
-      #     context:                                    #
-      #       - docker-hub-creds                        #
-      #     requires:                                   #
-      #       - build-GEOSgcm-on-<< matrix.compiler >>  #
-      # - run-FV3:                                      #
-      #     name: run-FV3-on-<< matrix.compiler >>      #
-      #     matrix:                                     #
-      #       parameters:                               #
-      #         compiler: [gfortran, ifort]             #
-      #     context:                                    #
-      #       - docker-hub-creds                        #
-      #     requires:                                   #
-      #       - make-FV3-exp-on-<< matrix.compiler >>   #
-      ###################################################
-
-commands:
-  versions:
-    description: "Versions, etc."
-    parameters:
-      compiler:
-        type: string
-    steps:
-      - run:
-          name: "Versions, etc."
-          command: | 
-            mpirun --version && << parameters.compiler >> --version && echo $BASEDIR && pwd && ls && echo "$(nproc)"
-
-  compress_artifacts:
-    description: "Compress artifacts"
-    steps:
-      - run:
-          name: "Compress artifacts"
-          command: |
-            gzip -9 /logfiles/*
-
-  checkout_fixture:
-    description: "Checkout fixture"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Checkout fixture"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}
-            git clone https://github.com/GEOS-ESM/<< parameters.repo >>.git
-
-  mepoclone:
-    description: "Mepo clone external repos"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Mepo clone external repos"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            mepo clone
-            mepo status
-
-  mepodevelop:
-    description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared
-            mepo status
-
-  checkout_feature_branch:
-    description: "Mepo checkout-if-exists feature branch"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Mepo checkout-if-exists feature branch"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            echo "${CIRCLE_BRANCH}"
-            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
-            then
-                mepo checkout-if-exists ${CIRCLE_BRANCH}
-            fi
-            mepo status
-
-  cmake:
-    description: "Run CMake"
-    parameters:
-      repo:
-        type: string
-      compiler:
-        type: string
-    steps:
-      - run:
-          name: "Run CMake"
-          command: |
-            mkdir -p /logfiles
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            mkdir -p ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-            cmake ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >> -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=<< parameters.compiler >> -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS} -DCMAKE_INSTALL_PREFIX=${CIRCLE_WORKING_DIRECTORY}/workspace/install-<< parameters.repo >> |& tee /logfiles/cmake.log
-
-  buildinstall:
-    description: "Build and install"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Build and install"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-            make -j"$(nproc)" install |& tee /logfiles/make.log
-            #MEDIUM# make -j4 install |& tee /logfiles/make.log
-
-jobs:
-  build-GEOSgcm:
-    parameters:
-      compiler:
-        type: string
-    executor: << parameters.compiler >>
-    working_directory: /root/project
-    steps:
-      - run:
-          name: "GMAO_Shared branch"
-          command: echo ${CIRCLE_BRANCH}
-      - checkout_fixture:
+          baselibs_version: *baselibs_version
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
-      - versions:
-          compiler: << parameters.compiler >>
-      - mepoclone:
-          repo: GEOSgcm
-      - mepodevelop:
-          repo: GEOSgcm
-      - checkout_feature_branch:
-          repo: GEOSgcm
-      - cmake:
-          repo: GEOSgcm
-          compiler: << parameters.compiler >>
-      - buildinstall:
-          repo: GEOSgcm
-      - compress_artifacts
-      - store_artifacts:
-          path: /logfiles
-      ###########################
-      # - persist_to_workspace: #
-      #     root: workspace     #
-      #     paths:              #
-      #       - install-GEOSgcm #
-      ###########################
-
-  make-FV3-exp:
-    parameters:
-      compiler:
-        type: string
-    executor: << parameters.compiler >>
-    working_directory: /root/project
-    steps:
-      - attach_workspace:
-          at: workspace
-      - run:
-          name: "Run fv3_setup"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/install-GEOSgcm/bin
-
-            INPUT_FOR_SETUP=$(cat \<<END_HEREDOC
-            test-fv3-c12
-            test-fv3-c12
-            12
-            72
-            NO
-            NO
-            ${CIRCLE_WORKING_DIRECTORY}/workspace/test-fv3-c12
-            NULL
-            END_HEREDOC
-            )
-            echo "$INPUT_FOR_SETUP" > /tmp/input.txt
-
-            cat /tmp/input.txt | ./fv3_setup
-      - run:
-          name: "Change FV_NX, FV_NY, and RUN_CMD"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/test-fv3-c12
-            sed -i.bak -e '/set FV_NX/ s/\([0-9]\+\)/1/' -e '/set FV_NY/ s/\([0-9]\+\)/6/' -e '/set RUN_CMD/ c\set RUN_CMD = "mpirun -np "' fv3.j
-      - run:
-          name: "Cat fv3.j"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/test-fv3-c12
-            cat fv3.j
-
-      # We need to persist the install for the next step
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - test-fv3-c12
-
-  run-FV3:
-    parameters:
-      compiler:
-        type: string
-    executor: << parameters.compiler >>
-    working_directory: /root/project
-    steps:
-      - attach_workspace:
-          at: workspace
-      - run:
-          name: "Run fv3.j"
-          command: |
-            mkdir -p /logfiles
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/test-fv3-c12
-            ./fv3.j |& tee /logfiles/fv3_run.log
-      - run:
-          name: "Check for EGRESS"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/test-fv3-c12
-
-            # The scratch directory for fv3 standalone isn't consistent
-            SCRDIR=$(find . -type d -name 'scratch*')
-
-            if [[ -f $SCRDIR/EGRESS ]]
-            then
-               echo "EGRESS found!"
-            else
-               echo "EGRESS not found!"
-               exit 1
-            fi
-      - compress_artifacts
-      - store_artifacts:
-          path: /logfiles
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ workflows:
               compiler: [ifort, gfortran]
           baselibs_version: *baselibs_version
           repo: GEOSgcm
-          mepodevelop: false
+          checkout_fixture: true
+          mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
       - ci/run_fv3:
           name: run-FV3-on-<< matrix.compiler >>

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -90,11 +90,11 @@
 !     \item {\tt PE}:   Edge pressures
 !     \item {\tt Q}:    Tracers
 !     \item {\tt PKZ}:  Consistent mean for p$^\kappa$
-!     \item {\tt DZ}:   Height thickness (Non-Hydrostatic)  
+!     \item {\tt DZ}:   Height thickness (Non-Hydrostatic)
 !   \end{itemize}
 !
-!  as well as a GRID (to be mentioned later) 
-!  and same additional run-specific variables 
+!  as well as a GRID (to be mentioned later)
+!  and same additional run-specific variables
 !
 ! Note: {\tt PT} is not updated if the flag {\tt CONVT} is true.
 !
@@ -102,7 +102,7 @@
 !
 ! \paragraph*{Import State}
 !
-! The import state consists of the tendencies of the 
+! The import state consists of the tendencies of the
 ! control variables plus the surface geopotential heights:
 !
 !   \begin{itemize}
@@ -151,24 +151,24 @@
 !
 !   The current version supports only a 1D latitude-based
 !   decomposition of the domain (with OMP task-parallelism
-!   in the vertical, resulting in reasonable scalability 
-!   on large PE configurations).  In the near future it will 
+!   in the vertical, resulting in reasonable scalability
+!   on large PE configurations).  In the near future it will
 !   support a 2D domain decomposition, in which import and
 !   export state are decomposed in longitude and latitude,
-!   while the internal state (for the most part) is 
-!   decomposed in latitude and level.  When needed, 
+!   while the internal state (for the most part) is
+!   decomposed in latitude and level.  When needed,
 !   the data is redistributed (``transposed'') internally.
 !
 !   There are two fundamental ESMF grids in use;
 !   \begin{itemize}
 !     \item {GRIDXY}: longitude-latitude ESMF grid (public)
 !     \item {GRIDYZ}: A latitude-level cross-sectional
-!                     decomposition (private to this module) 
+!                     decomposition (private to this module)
 !   \end{itemize}
 !
-!   PILGRIM will be used for communication until ESMF has 
-!   sufficient functionality and performance to take over 
-!   the task.  The use of pilgrim requires a call to 
+!   PILGRIM will be used for communication until ESMF has
+!   sufficient functionality and performance to take over
+!   the task.  The use of pilgrim requires a call to
 !   {\tt INIT\_SPMD} to set SPMD parameters, decompositions,
 !   etc.
 !
@@ -209,7 +209,7 @@
 !
 ! !REVISION HISTORY:
 !
-! 11Jul2003  Sawyer    From Trayanov/da Silva EVAC 
+! 11Jul2003  Sawyer    From Trayanov/da Silva EVAC
 ! 23Jul2003  Sawyer    First informal tiptoe-through
 ! 29Jul2003  Sawyer    Modifications based on comments from 23Jul2003
 ! 28Aug2003  Sawyer    First check-in; Internal state to D-grid
@@ -255,8 +255,8 @@
 ! -------------------------------------
     integer, parameter         :: nlevs=5
     integer, parameter         :: ntracers=11
-    integer                    :: nlev, ntracer                    
-    integer                    :: plevs(nlevs)          
+    integer                    :: nlev, ntracer
+    integer                    :: plevs(nlevs)
     character(len=ESMF_MAXSTR) :: myTracer
     data plevs /850,700,600,500,300/
 
@@ -291,7 +291,7 @@ contains
 
 ! !DESCRIPTION:  SetServices registers Initialize, Run, and Finalize
 !   methods for FV. Two stages of the FV run method are registered. The
-!   first one does the dynamics calculations, and the second adds 
+!   first one does the dynamics calculations, and the second adds
 !   increments from external sources that appear in the Import state.
 !   SetServices also creates a private internal state in which FV
 !   keeps invariant or auxilliary state variables, as well as pointers to
@@ -300,14 +300,14 @@ contains
 !
 !  The component uses all three states (Import, Export
 !  and Internal), in addition to a Private (non-ESMF) Internal state. All
-!  three are managed by MAPL. 
+!  three are managed by MAPL.
 !
 !  The Private Internal state contains invariant
-!  quantities defined by an FV specific routine, as well as pointers 
-!  to the true state variables, kept in the MAPL Internal state. 
+!  quantities defined by an FV specific routine, as well as pointers
+!  to the true state variables, kept in the MAPL Internal state.
 !  The MAPL Internal is kept at FV's real*8 precision.
 !
-!  The Import State conatins tendencies to be added in the second 
+!  The Import State conatins tendencies to be added in the second
 !  run stage, the geopotential at the lower boundary, and a bundle
 !  of Friendly tracers to be advected. The Import and Export states
 !  are both at the default precision.
@@ -322,15 +322,15 @@ contains
 
    type(ESMF_GridComp), intent(inout) :: gc     ! gridded component
    integer, intent(out), optional     :: rc     ! return code
-    
+
 
 ! !DESCRIPTION: Set services (register) for the FVCAM Dynamical Core
 !               Grid Component.
-!         
-!EOP         
+!
+!EOP
 !----------------------------------------------------------------------
-  
-   type (DynState), pointer :: dyn_internal_state 
+
+   type (DynState), pointer :: dyn_internal_state
     type (DYN_wrap)                  :: wrap
 
     integer                          :: FV3_STANDALONE
@@ -364,7 +364,7 @@ contains
     allocate( dyn_internal_state, stat=status )
     VERIFY_(STATUS)
     wrap%dyn_state => dyn_internal_state
- 
+
 ! Save pointer to the wrapped internal state in the GC
 ! ----------------------------------------------------
 
@@ -1594,7 +1594,7 @@ contains
      do ntracer=1,ntracers
         do nlev=1,nlevs
            write(myTracer, "('Q',i5.5,'_',i3.3)") ntracer-1, plevs(nlev)
-           call MAPL_AddExportSpec ( gc,                             &     
+           call MAPL_AddExportSpec ( gc,                             &
                 SHORT_NAME = TRIM(myTracer),                              &
                 LONG_NAME  = TRIM(myTracer),                             &
                 UNITS      = '1',                                         &
@@ -1610,7 +1610,7 @@ contains
              DIMS       = MAPL_DimsHorzVert,                      &
              VLOCATION  = MAPL_VLocationCenter,               RC=STATUS  )
         VERIFY_(STATUS)
-     enddo         
+     enddo
 
     call MAPL_AddExportSpec ( gc,                                  &
          SHORT_NAME = 'UH25',                                      &
@@ -1709,14 +1709,14 @@ contains
          VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
      VERIFY_(STATUS)
 
-    call MAPL_AddExportSpec ( gc,                             &     
+    call MAPL_AddExportSpec ( gc,                             &
          SHORT_NAME = 'U700',                                      &
          LONG_NAME  = 'eastward_wind_at_700_hPa',                  &
          UNITS      = 'm s-1',                                     &
          DIMS       = MAPL_DimsHorzOnly,                           &
          FIELD_TYPE = MAPL_VectorField,                            &
          VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
-     VERIFY_(STATUS)         
+     VERIFY_(STATUS)
 
     call MAPL_AddExportSpec ( gc,                             &
          SHORT_NAME = 'U500',                                      &
@@ -2015,7 +2015,7 @@ contains
     call MAPL_AddExportSpec ( gc,                             &
          SHORT_NAME = 'W200',                                      &
          LONG_NAME  = 'w_at_200_hPa',                              &
-         UNITS      = 'm s-1',                                     & 
+         UNITS      = 'm s-1',                                     &
          DIMS       = MAPL_DimsHorzOnly,                           &
          VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
      VERIFY_(STATUS)
@@ -2023,7 +2023,7 @@ contains
     call MAPL_AddExportSpec ( gc,                             &
          SHORT_NAME = 'W10',                                       &
          LONG_NAME  = 'w_at_10_hPa',                               &
-         UNITS      = 'm s-1',                                     & 
+         UNITS      = 'm s-1',                                     &
          DIMS       = MAPL_DimsHorzOnly,                           &
          VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
      VERIFY_(STATUS)
@@ -2101,7 +2101,7 @@ contains
          UNITS      = 'radians',                                   &
          DIMS       = MAPL_DimsHorzOnly,                           &
          VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
-     VERIFY_(STATUS)      
+     VERIFY_(STATUS)
 
     call MAPL_AddExportSpec ( gc,                                  &
        SHORT_NAME         = 'DYNTIMER',                            &
@@ -2161,7 +2161,7 @@ contains
 
 ! !INTERNAL STATE:
 
-!ALT: technically the first 2 records of "old" style FV restart have 
+!ALT: technically the first 2 records of "old" style FV restart have
 !     6 ints: YYYY MM DD H M S
 !     5 ints: I,J,K, KS (num true pressure levels), NQ (num tracers) headers
 
@@ -2261,8 +2261,8 @@ contains
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,    name="RUN2"        ,RC=STATUS)
     VERIFY_(STATUS)
-    call MAPL_TimerAdd(GC,    name="-DYN_INIT"    ,RC=STATUS)       
-    VERIFY_(STATUS)          
+    call MAPL_TimerAdd(GC,    name="-DYN_INIT"    ,RC=STATUS)
+    VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,    name="--FMS_INIT"  ,RC=STATUS)
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,    name="--FV_INIT"  ,RC=STATUS)
@@ -2296,7 +2296,8 @@ contains
     VERIFY_(STATUS)
     call MAPL_GetResource ( MAPL, LAYOUT_FILE, 'LAYOUT:', default='fvcore_layout.rc', rc=status )
     VERIFY_(STATUS)
-    call DynSetup(GC, LAYOUT_FILE)
+    call DynSetup(GC, LAYOUT_FILE, RC=STATUS)
+    VERIFY_(STATUS)
 
 ! Register prototype of cubed sphere grid and associated regridders
 !------------------------------------------------------------------
@@ -2307,7 +2308,7 @@ contains
     call ESMF_ConfigGetAttribute ( CF, FV3_STANDALONE, Label="FV3_STANDALONE:", default=0, RC=STATUS)
     VERIFY_(STATUS)
     if (FV3_STANDALONE /=0) then
-        call MAPL_GridCreate(GC, rc=status) 
+        call MAPL_GridCreate(GC, rc=status)
         VERIFY_(STATUS)
         call MAPL_AddExportSpec( gc,                              &
             SHORT_NAME = 'TRADVEX',                                    &
@@ -2336,11 +2337,11 @@ contains
 
 ! !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: gc       ! composite gridded component 
+  type(ESMF_GridComp), intent(inout) :: gc       ! composite gridded component
   type(ESMF_State),    intent(inout) :: import   ! import state
   type(ESMF_State),    intent(inout) :: export   ! export state
   type(ESMF_Clock),    intent(inout) :: clock    ! the clock
-  
+
   integer, intent(out), OPTIONAL     :: rc       ! Error code:
                                                  ! = 0 all is well
                                                  ! otherwise, error
@@ -2349,7 +2350,7 @@ contains
   type (DYN_wrap)                    :: wrap
   type (DynState),  pointer  :: STATE
 
-  type (MAPL_MetaComp),      pointer :: mapl 
+  type (MAPL_MetaComp),      pointer :: mapl
 
   character (len=ESMF_MAXSTR)        :: layout_file
 
@@ -2377,7 +2378,7 @@ contains
   type (ESMF_TimeInterval)           :: Intv
   type (ESMF_Alarm)                  :: Alarm
   integer                            :: ColdRestart=0
-  
+
   integer                            :: status
   character(len=ESMF_MAXSTR)         :: IAm
   character(len=ESMF_MAXSTR)         :: COMP_NAME
@@ -2385,7 +2386,7 @@ contains
   type (ESMF_State)                  :: INTERNAL
   type (DynGrid),  pointer           :: DycoreGrid
   real, pointer                      :: temp2d(:,:)
-  
+
   integer                            :: ifirst
   integer                            :: ilast
   integer                            :: jfirst
@@ -2438,7 +2439,7 @@ contains
 !EOR
     VERIFY_(STATUS)
 
-! Check for ColdStart from the configuration 
+! Check for ColdStart from the configuration
 !--------------------------------------
     call MAPL_GetResource ( MAPL, ColdRestart, 'COLDSTART:', default=0, rc=status )
     VERIFY_(STATUS)
@@ -2454,7 +2455,7 @@ contains
     VERIFY_(STATUS)
 
     call MAPL_TimerOn(MAPL,"-DYN_INIT")
-    call DynInit ( STATE, CLOCK, INTERNAL, IMPORT, GC, status)
+    call DynInit ( STATE, CLOCK, INTERNAL, IMPORT, GC, RC=status)
     VERIFY_(STATUS)
     call MAPL_TimerOff(MAPL,"-DYN_INIT")
 
@@ -2544,7 +2545,7 @@ contains
     call ESMF_StateGet(EXPORT, 'PREF', FIELD, RC=STATUS)
     VERIFY_(STATUS)
     call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, RC=STATUS)
-    VERIFY_(STATUS)      
+    VERIFY_(STATUS)
 
     call ESMF_StateGet(EXPORT, 'PLE', FIELD, RC=STATUS)
     VERIFY_(STATUS)
@@ -2615,7 +2616,7 @@ contains
 
     RETURN_(ESMF_SUCCESS)
   end subroutine Initialize
-  
+
 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2627,10 +2628,10 @@ contains
 ! !IROUTINE: Run
 
 ! !DESCRIPTION: This is the first Run stage of FV. It is the container
-!    for the dycore calculations. Subroutines from the core are 
+!    for the dycore calculations. Subroutines from the core are
 !    invoked to do most of the work. A second run method, descibed below,
-!    adds the import tendencies from external sources to the FV 
-!    variables. 
+!    adds the import tendencies from external sources to the FV
+!    variables.
 !
 !    In addition to computing and adding all dynamical contributions
 !    to the FV variables (i.e., winds, pressures, and temperatures),
@@ -2649,12 +2650,12 @@ subroutine Run(gc, import, export, clock, rc)
   type (ESMF_State),   intent(inout) :: import
   type (ESMF_State),   intent(inout) :: export
   type (ESMF_Clock),   intent(inout) :: clock
-  integer, intent(out), optional     :: rc 
+  integer, intent(out), optional     :: rc
 
 !EOP
 
 ! !Local Variables:
-  
+
     integer                                          :: status
     type (ESMF_FieldBundle)                          :: bundle
     type (ESMF_FieldBundle)                          :: ANA_Bundle
@@ -2669,13 +2670,13 @@ subroutine Run(gc, import, export, clock, rc)
     class (AbstractRegridder), pointer :: L2C
     class (AbstractRegridder), pointer :: C2L
 
-    type (MAPL_MetaComp), pointer :: mapl 
+    type (MAPL_MetaComp), pointer :: mapl
 
     type (DYN_wrap) :: wrap
     type (DynState), pointer :: STATE
     type (DynGrid),  pointer :: GRID
     type (DynVars),  pointer :: VARS
-    
+
     integer  :: NQ
     integer  :: IM, JM, KM
     integer  :: NKE, NPHI
@@ -2887,7 +2888,7 @@ subroutine Run(gc, import, export, clock, rc)
     character(len=ESMF_MAXSTR), allocatable :: biggerlist(:)
     integer, parameter                  :: XLIST_MAX = 60
     logical                             :: isPresent
-    
+
   Iam = "Run"
   call ESMF_GridCompGet( GC, name=COMP_NAME, CONFIG=CF, grid=ESMFGRID, RC=STATUS )
   VERIFY_(STATUS)
@@ -2935,7 +2936,7 @@ subroutine Run(gc, import, export, clock, rc)
   jm       = grid%npy
   km       = grid%npz
 
-  is_ringing = ESMF_AlarmIsRinging( STATE%ALARMS(TIME_TO_RUN),rc=status); VERIFY_(status) 
+  is_ringing = ESMF_AlarmIsRinging( STATE%ALARMS(TIME_TO_RUN),rc=status); VERIFY_(status)
   if (.not. is_ringing) return
 
 
@@ -3156,7 +3157,7 @@ subroutine Run(gc, import, export, clock, rc)
                         call move_alloc(from=biggerlist, to=xlist)
                      end if
                      xlist(n) = TRIM(fieldname)
-               end if  
+               end if
                !loop over exclude_list
                exclude = .false.
                do j = 1, n
@@ -3252,12 +3253,12 @@ subroutine Run(gc, import, export, clock, rc)
 !---------------------------------------------------
 
          call ESMF_ClockGetAlarm(Clock,'INTERMITTENT',Alarm,rc=Status)
-         VERIFY_(status) 
+         VERIFY_(status)
          call ESMF_ClockGet(Clock, CurrTime=currentTIME, rc=status)
          VERIFY_(status)
 
          is_ringing = ESMF_AlarmIsRinging( Alarm,rc=status )
-         VERIFY_(status) 
+         VERIFY_(status)
 
          RefTime = currentTime
 
@@ -3272,7 +3273,7 @@ subroutine Run(gc, import, export, clock, rc)
             VERIFY_(status)
             call MAPL_GetResource ( MAPL,ReplayType,'REPLAY_TYPE:', Default="FULL", RC=STATUS )
             VERIFY_(status)
-   
+
             call MAPL_GetResource ( MAPL, im_replay, Label="REPLAY_IM:", RC=status )
             VERIFY_(STATUS)
             call MAPL_GetResource ( MAPL, jm_replay, Label="REPLAY_JM:", RC=status )
@@ -3350,7 +3351,7 @@ subroutine Run(gc, import, export, clock, rc)
 ! soon dump_n_splash will go; we'll have instead:
 !    call get_inc_on_anagrid_ - this will convert the internal state to
 !      ana-grid, diff with what's in file and produce what incremental_
-!      normally works from - a knob will tell incremental_ where fields 
+!      normally works from - a knob will tell incremental_ where fields
 !      are in memory or need reading from file.
 !    call incremental_
 !    call state_remap_
@@ -3448,7 +3449,7 @@ subroutine Run(gc, import, export, clock, rc)
       do N = 1,size(names)
            if( trim(names(N)).eq.'QLCN' .or. &
                trim(names(N)).eq.'QLLS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      QL = QL + state%vars%tracer(N)%content_r4
                  else
                      QL = QL + state%vars%tracer(N)%content
@@ -3456,7 +3457,7 @@ subroutine Run(gc, import, export, clock, rc)
            endif
            if( trim(names(N)).eq.'QICN' .or. &
                trim(names(N)).eq.'QILS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      QI = QI + state%vars%tracer(N)%content_r4
                  else
                      QI = QI + state%vars%tracer(N)%content
@@ -3559,7 +3560,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(N)).eq.'QLCN' .or. &
                  trim(names(N)).eq.'QLLS' ) then
                  do k=1,km
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      dqldtanaint1 = dqldtanaint1 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                  else
                      dqldtanaint1 = dqldtanaint1 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
@@ -3582,7 +3583,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(N)).eq.'QICN' .or. &
                  trim(names(N)).eq.'QILS' ) then
                  do k=1,km
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      dqidtanaint1 = dqidtanaint1 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                  else
                      dqidtanaint1 = dqidtanaint1 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
@@ -3868,7 +3869,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(N)).eq.'QLCN' .or. &
                  trim(names(N)).eq.'QLLS' ) then
                  do k=1,km
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      dqldtanaint2 = dqldtanaint2 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                  else
                      dqldtanaint2 = dqldtanaint2 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
@@ -3889,7 +3890,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(N)).eq.'QICN' .or. &
                  trim(names(N)).eq.'QILS' ) then
                  do k=1,km
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      dqidtanaint2 = dqidtanaint2 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                  else
                      dqidtanaint2 = dqidtanaint2 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
@@ -3967,8 +3968,8 @@ subroutine Run(gc, import, export, clock, rc)
           dqidt = 0.0
           do k = 1,size(names)
              if( trim(names(k)).eq.'QICN' .or. &
-                 trim(names(k)).eq.'QILS' ) then    
-                 if( state%vars%tracer(k)%is_r4 ) then 
+                 trim(names(k)).eq.'QILS' ) then
+                 if( state%vars%tracer(k)%is_r4 ) then
                      if (size(dqidt)==size(state%vars%tracer(k)%content_r4)) &
                               dqidt = dqidt - state%vars%tracer(k)%content_r4
                  else
@@ -3985,7 +3986,7 @@ subroutine Run(gc, import, export, clock, rc)
              pos = index(names(k),'::')
              if(pos > 0) then
                if( (names(k)(pos+2:))=='OX' ) then
-                 if( state%vars%tracer(k)%is_r4 ) then 
+                 if( state%vars%tracer(k)%is_r4 ) then
                      if (size(doxdt)==size(state%vars%tracer(k)%content_r4)) &
                               doxdt = doxdt - state%vars%tracer(k)%content_r4
                  else
@@ -4017,7 +4018,7 @@ subroutine Run(gc, import, export, clock, rc)
           do N = 1,size(names)
              if( trim(names(N)).eq.'QLCN' .or. &
                  trim(names(N)).eq.'QLLS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      do k=1,km
                      temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
@@ -4037,7 +4038,7 @@ subroutine Run(gc, import, export, clock, rc)
           do N = 1,size(names)
              if( trim(names(N)).eq.'QICN' .or. &
                  trim(names(N)).eq.'QILS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      do k=1,km
                      temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
@@ -4058,7 +4059,7 @@ subroutine Run(gc, import, export, clock, rc)
              pos = index(names(N),'::')
              if(pos > 0) then
                if( (names(N)(pos+2:))=='OX' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      do k=1,km
                      temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
@@ -4155,7 +4156,7 @@ subroutine Run(gc, import, export, clock, rc)
     if(associated(temp2d)) temp2d = 0 !WMP need to get from MAPL gid
 
 !#define DEBUG_WINDS
-#if defined(DEBUG_WINDS)         
+#if defined(DEBUG_WINDS)
   call Write_Profile(grid, vars%u, 'U-after-DynRun')
   call Write_Profile(grid, vars%v, 'V-after-DynRun')
 #endif
@@ -4375,7 +4376,7 @@ subroutine Run(gc, import, export, clock, rc)
       call MAPL_GetPointer(export, temp3D, 'PV', rc=status)
       VERIFY_(STATUS)
       if(associated(temp3d)) temp3d = epvxyz/vars%pt
- 
+
       call MAPL_GetPointer(export, temp3D, 'S', rc=status)
       VERIFY_(STATUS)
       if(associated(temp3d)) temp3d = tempxy*cp
@@ -4419,7 +4420,7 @@ subroutine Run(gc, import, export, clock, rc)
           do N = 1,size(names)
              if( trim(names(N)).eq.'QLCN' .or. &
                  trim(names(N)).eq.'QLLS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      dqldt = dqldt + state%vars%tracer(N)%content_r4
                  else
                      dqldt = dqldt + state%vars%tracer(N)%content
@@ -4433,7 +4434,7 @@ subroutine Run(gc, import, export, clock, rc)
           do N = 1,size(names)
              if( trim(names(N)).eq.'QICN' .or. &
                  trim(names(N)).eq.'QILS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      dqidt = dqidt + state%vars%tracer(N)%content_r4
                  else
                      dqidt = dqidt + state%vars%tracer(N)%content
@@ -4448,7 +4449,7 @@ subroutine Run(gc, import, export, clock, rc)
              pos = index(names(N),'::')
              if(pos > 0) then
                if( (names(N)(pos+2:))=='OX' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      doxdt = doxdt + state%vars%tracer(N)%content_r4
                  else
                      doxdt = doxdt + state%vars%tracer(N)%content
@@ -4497,7 +4498,7 @@ subroutine Run(gc, import, export, clock, rc)
           do N = 1,size(names)
              if( trim(names(N)).eq.'QICN' .or. &
                  trim(names(N)).eq.'QILS' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      do k=1,km
                      temp2d = temp2d + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
@@ -4518,7 +4519,7 @@ subroutine Run(gc, import, export, clock, rc)
              pos = index(names(N),'::')
              if(pos > 0) then
                if( (names(N)(pos+2:))=='OX' ) then
-                 if( state%vars%tracer(N)%is_r4 ) then 
+                 if( state%vars%tracer(N)%is_r4 ) then
                      do k=1,km
                      temp2d = temp2d + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
@@ -4657,7 +4658,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(n)).eq.'QLCN' .or. &
                  trim(names(n)).eq.'QLLS' ) then
                  do k=1,km
-                 if( state%vars%tracer(n)%is_r4 ) then 
+                 if( state%vars%tracer(n)%is_r4 ) then
                       temp2d = temp2d + ua(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                  else
                       temp2d = temp2d + ua(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
@@ -4676,7 +4677,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(n)).eq.'QLCN' .or. &
                  trim(names(n)).eq.'QLLS' ) then
                  do k=1,km
-                 if( state%vars%tracer(n)%is_r4 ) then 
+                 if( state%vars%tracer(n)%is_r4 ) then
                       temp2d = temp2d + va(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                  else
                       temp2d = temp2d + va(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
@@ -4697,7 +4698,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(n)).eq.'QICN' .or. &
                  trim(names(n)).eq.'QILS' ) then
                  do k=1,km
-                 if( state%vars%tracer(n)%is_r4 ) then 
+                 if( state%vars%tracer(n)%is_r4 ) then
                       temp2d = temp2d + ua(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                  else
                       temp2d = temp2d + ua(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
@@ -4716,7 +4717,7 @@ subroutine Run(gc, import, export, clock, rc)
              if( trim(names(n)).eq.'QICN' .or. &
                  trim(names(n)).eq.'QILS' ) then
                  do k=1,km
-                 if( state%vars%tracer(n)%is_r4 ) then 
+                 if( state%vars%tracer(n)%is_r4 ) then
                       temp2d = temp2d + va(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                  else
                       temp2d = temp2d + va(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
@@ -4909,11 +4910,11 @@ subroutine Run(gc, import, export, clock, rc)
 ! Vorticity Exports
 
       call getVorticity(vars%u, vars%v, tmp3d)
-  
+
       call MAPL_GetPointer(export,temp3d,'VORT',  rc=status)
       VERIFY_(STATUS)
       if(associated(temp3d)) temp3d = tmp3d
-  
+
       call MAPL_GetPointer(export,temp2d,'VORT200',  rc=status)
       VERIFY_(STATUS)
       if(associated(temp2d)) then
@@ -4927,7 +4928,7 @@ subroutine Run(gc, import, export, clock, rc)
          call VertInterp(temp2d,dble(tmp3d),zle,log(50000.)  ,  status)
          VERIFY_(STATUS)
       end if
- 
+
       call MAPL_GetPointer(export,temp2d,'VORT700',  rc=status)
       VERIFY_(STATUS)
       if(associated(temp2d)) then
@@ -5016,8 +5017,8 @@ subroutine Run(gc, import, export, clock, rc)
       endif
 
      end if   ! SW_DYNAMICS
-      
-  
+
+
 ! De-Allocate Arrays
 ! ------------------
 
@@ -5196,7 +5197,7 @@ subroutine check_replay_time_(lring)
                                     startTime = currentTime, &
                                                 rc = STATUS  ); VERIFY_(STATUS)
 
-      RefTime = RefTime - RefTGap 
+      RefTime = RefTime - RefTGap
   endif
 
 ! check if it's time to replay
@@ -5210,7 +5211,7 @@ subroutine check_replay_time_(lring)
 ! In this case, increment RefTime to proper time
 ! ----------------------------------------------
   if (REPLAY_REF_TGAP>0) then
-      RefTime = currentTime + RefTGap 
+      RefTime = currentTime + RefTGap
   endif
 
 end subroutine check_replay_time_
@@ -5315,7 +5316,7 @@ subroutine dump_n_splash_
           allocate(cubeVTMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
           allocate( UAtmpR4(grid%is:grid%ie  ,grid%js:grid%je  ,km) )
           allocate( VAtmpR4(grid%is:grid%ie  ,grid%js:grid%je  ,km) )
-          ! get background A-grid winds 
+          ! get background A-grid winds
           call getAgridWinds (vars%u,vars%v,ana_u,ana_v,rotate=.true.)
           ! transform background A-grid winds to lat-lon
           call regridder_manager%make_regridder(ESMFGRID, ANAGrid, REGRID_METHOD_BILINEAR, RC=STATUS)
@@ -5453,7 +5454,7 @@ subroutine dump_n_splash_
 !      Ozone needs to be adjusted to OX
 !      --------------------------------
        call WRITE_PARALLEL('Replaying '//trim(o3name))
-    
+
        call MAPL_Get(MAPL, LONS=LONS, LATS=LATS, ORBIT=ORBIT, RC=STATUS )
        VERIFY_(STATUS)
 
@@ -5466,7 +5467,7 @@ subroutine dump_n_splash_
        pl = ( vars%pe(:,:,2:) + vars%pe(:,:,:km) ) * 0.5
 
        do L=1,km
-          if( ooo%is_r4 ) then 
+          if( ooo%is_r4 ) then
              where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
                   ooo%content_r4(:,:,L) = max(0.,cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6)
           else
@@ -5703,7 +5704,7 @@ subroutine incremental_
 !      Ozone needs to be adjusted to OX
 !      --------------------------------
        call WRITE_PARALLEL('Replaying increment of '//trim(o3name))
-    
+
        call MAPL_Get(MAPL, LONS=LONS, LATS=LATS, ORBIT=ORBIT, RC=STATUS )
        VERIFY_(STATUS)
 
@@ -5719,7 +5720,7 @@ subroutine incremental_
           where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
                 dqox(:,:,L) = cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6
        enddo
-   
+
        deallocate( ZTH, SLR )
        deallocate(cubeTEMP3D)
     endif
@@ -5754,7 +5755,7 @@ subroutine incremental_
        call l2c%regrid(TEMP3D, cubeTEMP3D, RC=STATUS )
        VERIFY_(STATUS)
        call WRITE_PARALLEL('Replaying increment of '//trim(tname))
-       ! have an incremental change to virtual temperature; 
+       ! have an incremental change to virtual temperature;
        ! want an incremental change to dry potential temperature
        ! calculate first incremental change to t-dry (save in dth for now)
        if( qqq%is_r4 ) then
@@ -5773,7 +5774,7 @@ subroutine incremental_
   vars%u   = vars%u   + sclinc * du(grid%is:grid%ie,grid%js:grid%je,1:km)
   vars%v   = vars%v   + sclinc * dv(grid%is:grid%ie,grid%js:grid%je,1:km)
       pkxy =     pkxy + sclinc * dpkxy
-  vars%pkz = vars%pkz + sclinc * dpkz 
+  vars%pkz = vars%pkz + sclinc * dpkz
   vars%pe  = vars%pe  + sclinc * dpe
   vars%pt  = vars%pt  + sclinc * dth
   if( qqq%is_r4 ) then  ! protection for negative qv is slightly inconsistent w/ update of temperature
@@ -6050,7 +6051,7 @@ end subroutine RUN
             VERIFY_(STATUS)
 
             state%vars%tracer(n)%content => PTR_R8
-            if (fieldname == QFieldName) then 
+            if (fieldname == QFieldName) then
                qqq%is_r4   = .false.
                qqq%content => state%vars%tracer(n)%content
             end if
@@ -6070,10 +6071,10 @@ end subroutine RUN
 
 ! !IROUTINE: RunAddIncs
 
-! !DESCRIPTION: This is the second registered stage of FV. 
-!    It calls an Fv supplied routine to add external contributions 
+! !DESCRIPTION: This is the second registered stage of FV.
+!    It calls an Fv supplied routine to add external contributions
 !    to FV's state variables. It does not touch the Friendly tracers.
-!    It also computes additional diagnostics and updates the 
+!    It also computes additional diagnostics and updates the
 !    FV internal state to reflect the added tendencies.
 !
 !
@@ -6087,23 +6088,23 @@ end subroutine RUN
     type (ESMF_State),   intent(inout) :: import
     type (ESMF_State),   intent(inout) :: export
     type (ESMF_Clock),   intent(in)    :: clock
-    integer, intent(out), optional     :: rc 
+    integer, intent(out), optional     :: rc
 
 !EOP
 
 ! !Local Variables:
-  
+
     integer                                          :: status
     character(len=ESMF_MAXSTR) :: IAm
 
-    type (MAPL_MetaComp), pointer :: genstate 
+    type (MAPL_MetaComp), pointer :: genstate
 
     type (DYN_wrap) :: wrap
     type (DynState), pointer :: STATE
     type (DynGrid),  pointer :: GRID
     type (DynVars),  pointer :: VARS
     type (DynTracers)                 :: qqq     ! Specific Humidity
-    
+
     real(r8), allocatable :: penrg (:,:)   ! Vertically Integrated Cp*T
     real(r8), allocatable :: kenrg (:,:)   ! Vertically Integrated K
     real(r8), allocatable :: tenrg (:,:)   ! PHIS*(Psurf-Ptop)
@@ -6301,7 +6302,7 @@ end subroutine RUN
     call FILLOUT3 (export, 'V_CGRID', vc      , rc=status); VERIFY_(STATUS)
     call FILLOUT3 (export, 'U_AGRID', ua      , rc=status); VERIFY_(STATUS)
     call FILLOUT3 (export, 'V_AGRID', va      , rc=status); VERIFY_(STATUS)
- 
+
 ! Create A-Grid Winds
 ! -------------------
     call getAgridWinds(vars%u, vars%v, ua, va, rotate=.true.)
@@ -6311,7 +6312,7 @@ end subroutine RUN
 
     thv = vars%pt*(1.0+eps*qv)
 
-#if defined(DEBUG_VPT)         
+#if defined(DEBUG_VPT)
   call Write_Profile(grid, thv, 'VPT')
 #endif
 
@@ -6345,7 +6346,7 @@ end subroutine RUN
 
     tempxy = vars%pt * vars%pkz   ! Dry Temperature
 
-#if defined(DEBUG_T)         
+#if defined(DEBUG_T)
   call Write_Profile(grid, tempxy, 'T')
 #endif
 
@@ -6401,14 +6402,14 @@ end subroutine RUN
 
 ! Fill Single Level Variables
 ! ---------------------------
- 
+
     call MAPL_GetPointer(export,temp2d,'U200',  rc=status)
     VERIFY_(STATUS)
     if(associated(temp2d)) then
        call VertInterp(temp2d,ua,pke,log(20000.)  ,  status)
        VERIFY_(STATUS)
     end if
- 
+
     call MAPL_GetPointer(export,temp2d,'U250',  rc=status)
     VERIFY_(STATUS)
     if(associated(temp2d)) then
@@ -6614,7 +6615,7 @@ end subroutine RUN
     do k=1,km+1
     zle(:,:,k) = zle(:,:,k) - zle(:,:,km+1)
     enddo
-    
+
     call MAPL_GetPointer(export,temp2d,'U50M',  rc=status)
     VERIFY_(STATUS)
     if(associated(temp2d)) then
@@ -6695,10 +6696,10 @@ end subroutine RUN
           enddo
        enddo
 
-!#define DEBUG_SLP           
-#if defined(DEBUG_SLP)         
-       call Write_Profile(grid, slp/100.0, 'SLP') 
-#endif                       
+!#define DEBUG_SLP
+#if defined(DEBUG_SLP)
+       call Write_Profile(grid, slp/100.0, 'SLP')
+#endif
 
        if(associated(temp2d)) temp2d = slp
        if(associated(ztemp1)) where( ztemp1.eq.MAPL_UNDEF ) ztemp1 = H1000
@@ -6755,7 +6756,7 @@ end subroutine RunAddIncs
    use fms_mod, only: set_domain, nullify_domain
    use fv_diagnostics_mod, only: prt_maxmin
    use time_manager_mod,   only: time_type
-   use fv_update_phys_mod, only: fv_update_phys 
+   use fv_update_phys_mod, only: fv_update_phys
 !
 ! !INPUT PARAMETERS:
 
@@ -7068,14 +7069,14 @@ end subroutine RunAddIncs
 
           ! Update T
           STATE%VARS%PT =  STATE%VARS%PT                         *DPOLD
-          STATE%VARS%PT = (STATE%VARS%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW 
+          STATE%VARS%PT = (STATE%VARS%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
 
           ! update DZ with new T
           STATE%VARS%DZ = STATE%VARS%DZ * STATE%VARS%PT
        else
           ! Update T
           STATE%VARS%PT =  STATE%VARS%PT                         *DPOLD
-          STATE%VARS%PT = (STATE%VARS%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW 
+          STATE%VARS%PT = (STATE%VARS%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
        endif
 
        ! Update PKZ from hydrostatic pressures
@@ -7088,7 +7089,7 @@ end subroutine RunAddIncs
 
        !if (DYN_DEBUG) then
        !call prt_maxmin('AI PT2', STATE%VARS%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
-       !endif                  
+       !endif
 
        DEALLOCATE (DPNEW)
        DEALLOCATE (DPOLD)
@@ -7238,7 +7239,7 @@ end subroutine RunAddIncs
 ! !IROUTINE: Finalize
 
 ! !DESCRIPTION: Writes restarts and cleans-up through MAPL\_GenericFinalize and
-!   deallocates memory from the Private Internal state. 
+!   deallocates memory from the Private Internal state.
 !
 ! !INTERFACE:
 
@@ -7251,18 +7252,18 @@ subroutine Finalize(gc, import, export, clock, rc)
     type (ESMF_State),    intent(inout) :: export
     type (ESMF_Clock),    intent(inout) :: clock
     integer, optional,    intent(  out) :: rc
- 
+
 !EOP
 
 ! Local variables
     type (DYN_wrap) :: wrap
     type (DynState), pointer  :: STATE
- 
+
     character(len=ESMF_MAXSTR)        :: IAm
     character(len=ESMF_MAXSTR)        :: COMP_NAME
     integer                           :: status
 
-    type (MAPL_MetaComp),     pointer :: MAPL 
+    type (MAPL_MetaComp),     pointer :: MAPL
     type (ESMF_Config)                :: cf
 
 
@@ -7287,11 +7288,11 @@ subroutine Finalize(gc, import, export, clock, rc)
 
     call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, status)
     VERIFY_(STATUS)
-  
+
     state => wrap%dyn_state
- 
+
     call DynFinalize( STATE )
- 
+
 ! Call Generic Finalize
 !----------------------
 
@@ -7302,7 +7303,7 @@ subroutine Finalize(gc, import, export, clock, rc)
     VERIFY_(STATUS)
 
   RETURN_(ESMF_SUCCESS)
- 
+
   contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -7311,10 +7312,10 @@ subroutine Finalize(gc, import, export, clock, rc)
   integer(kind=8), intent(INOUT) :: TIMES(:,:)
   real(r8),        intent(IN   ) :: DAYS
   TIMES = 0
- 
+
   return
  end subroutine PRINT_TIMES
- 
+
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 end subroutine FINALIZE
@@ -7342,7 +7343,7 @@ end subroutine FINALIZE
       real(r8), parameter :: p_offset = 15000.
       real(r8), parameter :: gg       = gamma/MAPL_GRAV
 
-      real(r8), parameter :: factor   = MAPL_grav / ( MAPL_Rgas * gamma ) 
+      real(r8), parameter :: factor   = MAPL_grav / ( MAPL_Rgas * gamma )
       real(r8), parameter :: yfactor  = MAPL_Rgas * gg
 
       integer k_bot, k, k1, k2
@@ -7464,7 +7465,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
     character(len=ESMF_MAXSTR)        :: COMP_NAME
     integer                           :: status
 
-    type (MAPL_MetaComp),     pointer :: MAPL 
+    type (MAPL_MetaComp),     pointer :: MAPL
     type (ESMF_State)                 :: INTERNAL
 
     real(REAL8), pointer                 :: AK(:), BK(:)
@@ -7507,7 +7508,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
     real(r4), pointer                :: TRACER(:,:,:)
     real(REAL8), allocatable            :: Q5(:,:,:)
     real(REAL8), allocatable            :: Q6(:,:,:)
-    type (ESMF_Grid)                 :: esmfGRID 
+    type (ESMF_Grid)                 :: esmfGRID
     type (ESMF_FieldBundle)          :: TRADV_BUNDLE
     character(len=ESMF_MAXSTR)       :: FIELDNAME
     character(len=ESMF_MAXSTR)       :: STRING
@@ -7531,7 +7532,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
     state => wrap%dyn_state
     grid  => state%grid   ! direct handle to grid
 
-!BOR    
+!BOR
 ! !RESOURCE_ITEM: K :: Value of isothermal temperature on coldstart
     call MAPL_GetResource ( MAPL, T0, 'T0:', default=273., RC=STATUS )
     VERIFY_(STATUS)
@@ -7715,7 +7716,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
               !     print*, i, j, T_PERTURB
               !     PT(i,j,k) = PT(i,j,k) + T_PERTURB
               !  endif
-              !endif 
+              !endif
             enddo
          enddo
       enddo
@@ -8071,7 +8072,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
                       0.95943169315531E+04,  0.73965459465018E+04,  0.50700062290314E+04,  0.26071531411601E+04, &
                       0.00000000000000E+00 /
 
-      data b20_0178 / 0.00000000000000E+00,  0.27599078219223E-01,  0.56815203138214E-01,  0.87743118501982E-01, & 
+      data b20_0178 / 0.00000000000000E+00,  0.27599078219223E-01,  0.56815203138214E-01,  0.87743118501982E-01, &
                       0.12048311914891E+00,  0.15514137625266E+00,  0.19183028162025E+00,  0.23066881216269E+00, &
                       0.27178291572025E+00,  0.31530591949337E+00,  0.36137896240390E+00,  0.41015145278854E+00, &
                       0.46178155290889E+00,  0.51643669184922E+00,  0.57429410846515E+00,  0.63554142614418E+00, &
@@ -8158,7 +8159,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
           0.975078, 0.980072, 0.984542, 0.988500, 0.991984, 0.995003, 0.997630, 1.000000/
 
       SELECT CASE(km)
-  
+
       CASE(20)
 
           do k=1,km+1
@@ -8190,7 +8191,7 @@ subroutine Coldstart(gc, import, export, clock, rc)
              endif
           enddo
 126   continue
- 
+
       CASE(40)
 !--------------------------------------------------
 ! Pure sigma-coordinate with uniform spacing in "z"
@@ -8382,19 +8383,19 @@ subroutine addTracer_r4(state, bundle, var, grid, fieldname)
   type(DynTracers), pointer        :: t(:)
 
   character(len=ESMF_MAXSTR)       :: IAm='FV:addTracer_r4'
-         
+
   type (ESMF_Field)                :: field
   real(r4),              pointer   :: ptr(:,:,:)
-         
+
       call ESMF_GridGet (GRID,  distGrid=distgrid,       RC=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_FieldBundleGet(BUNDLE, fieldCount=NQ, RC=STATUS)
       VERIFY_(STATUS)
 
-      NQ = NQ + 1 
-               
-      field = ESMF_FieldCreate(GRID, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, RC=STATUS ) 
+      NQ = NQ + 1
+
+      field = ESMF_FieldCreate(GRID, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, RC=STATUS )
       VERIFY_(STATUS)
       call ESMF_AttributeSet(field,name='VLOCATION',value=MAPL_VLocationCenter,rc=status)
       VERIFY_(STATUS)
@@ -8447,19 +8448,19 @@ end subroutine freeTracers
     real(r8) :: arr_global(grid%npx,grid%ntiles*grid%npy)
     real(r8) :: rng(3)
     real(r8) :: GSUM
-    
+
     real(kind=ESMF_KIND_R8)     :: locArr(grid%is:grid%ie,grid%js:grid%je)
     real(kind=ESMF_KIND_R8)     :: glbArr(grid%npx,grid%ntiles*grid%npy)
-    
+
     istrt = grid%is
     iend  = grid%ie
     jstrt = grid%js
-    jend  = grid%je 
+    jend  = grid%je
     im    = grid%npx
-    jm    = grid%npy*grid%ntiles      
-    
+    jm    = grid%npy*grid%ntiles
+
    !call write_parallel('GlobalSUm')
-    locArr(:,:) = arr(:,:)       
+    locArr(:,:) = arr(:,:)
     call ArrayGather(locArr, glbArr, grid%grid)
     arr_global(:,:) = glbArr
 
@@ -8490,19 +8491,19 @@ end subroutine freeTracers
     real(r4) :: arr_global(grid%npx,grid%ntiles*grid%npy)
     real(r4) :: rng(3)
     real(r4) :: GSUM
-    
+
     real(kind=ESMF_KIND_R4)     :: locArr(grid%is:grid%ie,grid%js:grid%je)
     real(kind=ESMF_KIND_R4)     :: glbArr(grid%npx,grid%ntiles*grid%npy)
-    
+
     istrt = grid%is
     iend  = grid%ie
     jstrt = grid%js
-    jend  = grid%je 
+    jend  = grid%je
     im    = grid%npx
-    jm    = grid%npy*grid%ntiles      
+    jm    = grid%npy*grid%ntiles
 
   ! call write_parallel('GlobalSUm')
-    locArr(:,:) = arr(:,:)     
+    locArr(:,:) = arr(:,:)
     call ArrayGather(locArr, glbArr, grid%grid)
     arr_global(:,:) = glbArr
 
@@ -8585,22 +8586,22 @@ end subroutine freeTracers
     real(r4) :: rng(3,grid%npz)
     real(r8) :: gsum_p
     real(r4) :: GSUM
-    
+
     real(kind=ESMF_KIND_R8)     :: locArr(grid%is:grid%ie,grid%js:grid%je)
     real(kind=ESMF_KIND_R8)     :: glbArr(grid%npx,grid%ntiles*grid%npy)
-      
+
     istrt = grid%is
     iend  = grid%ie
     jstrt = grid%js
-    jend  = grid%je 
+    jend  = grid%je
     kstrt = 1
     kend  = grid%npz
     im    = grid%npx
-    jm    = grid%npy*grid%ntiles      
+    jm    = grid%npy*grid%ntiles
     km    = grid%npz
-    
+
     do k=kstrt,kend
-       locArr(:,:) = arr(:,:,k)       
+       locArr(:,:) = arr(:,:,k)
        call ArrayGather(locArr, glbArr, grid%grid)
        arr_global(:,:,k) = glbArr
     enddo

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -91,7 +91,7 @@ private
   interface fv_computeMassFluxes
      module procedure fv_computeMassFluxes_r4
      module procedure fv_computeMassFluxes_r8
-  end interface  
+  end interface
 
   INTERFACE INTERP_DGRID_TO_AGRID
 
@@ -166,12 +166,12 @@ private
                                                        ! cubed-sphere = 6
 
     real(REAL8), allocatable           :: DXC(:,:)     ! local C-Grid DeltaX
-    real(REAL8), allocatable           :: DYC(:,:)     ! local C-Grid DeltaY 
+    real(REAL8), allocatable           :: DYC(:,:)     ! local C-Grid DeltaY
 
     real(REAL8), allocatable           :: AREA(:,:)    ! local cell area
     real(REAL8)                        :: GLOBALAREA   ! global area
 
-    integer                         :: KS              ! Number of true pressure levels (out of NPZ+1)
+    integer                            :: KS              ! Number of true pressure levels (out of NPZ+1)
     real(REAL8)                        :: PTOP            ! pressure at top (ak(1))
     real(REAL8)                        :: PINT            ! initial pressure (ak(npz+1))
     real(REAL8), dimension(:), pointer :: AK => NULL()    ! Sigma mapping
@@ -319,7 +319,6 @@ contains
   integer              :: status
   real(FVPRC) :: DT
 
-  integer   :: ks                 !  True # press. levs
   integer   :: ndt,nx,ny
 
   type (MAPL_MetaComp),          pointer :: MAPL  => NULL()
@@ -348,7 +347,7 @@ contains
     call MAPL_TimerOff(MAPL,"--FMS_INIT")
     call MAPL_MemUtilsWrite(VM, 'FV_StateMod: FMS_INIT', RC=STATUS )
     VERIFY_(STATUS)
-! Start up FV                   
+! Start up FV
     call MAPL_TimerOn(MAPL,"--FV_INIT")
     call fv_init1(FV_Atm, DT, grids_on_this_pe, p_split)
     call MAPL_TimerOff(MAPL,"--FV_INIT")
@@ -385,7 +384,7 @@ contains
       call MAPL_GetResource( MAPL, ny, 'NY:', default=0, RC=STATUS )
       VERIFY_(STATUS)
       if (FV_Atm(1)%flagstruct%grid_type == 4) then
-         FV_Atm(1)%layout(2) = ny 
+         FV_Atm(1)%layout(2) = ny
       else
          FV_Atm(1)%layout(2) = ny / 6
       end if
@@ -452,7 +451,7 @@ contains
 !    These can be overrided in fv_core_nml in fvcore_layout.rc linked to input.nml
 !-------------------------------------------------------------
   ! Number of water species for FV3 determined later
-  ! when reading the tracer bundle in fv_first_run 
+  ! when reading the tracer bundle in fv_first_run
    FV_Atm(1)%flagstruct%nwat = 0
   ! Veritical resolution dependencies
    FV_Atm(1)%flagstruct%external_eta = .true.
@@ -517,7 +516,7 @@ contains
    FV_Atm(1)%flagstruct%p_fac = 0.1
   ! Cubed-Sphere Global Resolution Specific adjustments
    if (FV_Atm(1)%flagstruct%ntiles == 6) then
-     ! Cubed-sphere grid resolution and DT dependence 
+     ! Cubed-sphere grid resolution and DT dependence
      !              based on ideal remapping DT
       if (FV_Atm(1)%flagstruct%npx >= 48) then
          FV_Atm(1)%flagstruct%k_split = CEILING(DT/1800.0  )
@@ -559,8 +558,8 @@ contains
        FV_Atm(1)%flagstruct%hord_tr =  8
      ! NonMonotonic defaults for c360 (~25km) and finer
        if (FV_Atm(1)%flagstruct%npx >= 360) then
-       ! This combination of horizontal advection schemes is critical 
-       ! for anomaly correlation NWP skill. 
+       ! This combination of horizontal advection schemes is critical
+       ! for anomaly correlation NWP skill.
        ! Using all = 5 (like GFS) produces a substantial degredation in skill
          FV_Atm(1)%flagstruct%hord_mt =  5
          FV_Atm(1)%flagstruct%hord_vt =  6
@@ -610,7 +609,7 @@ contains
       endif
    endif
 
-!! Start up FV                   
+!! Start up FV
     call MAPL_TimerOn(MAPL,"--FV_INIT")
     call fv_init2(FV_Atm, DT, grids_on_this_pe, p_split)
     call MAPL_TimerOff(MAPL,"--FV_INIT")
@@ -628,14 +627,6 @@ contains
 
   call WRITE_PARALLEL((/FV_Atm(1)%flagstruct%npx,FV_Atm(1)%flagstruct%npy,FV_Atm(1)%flagstruct%npz/)       , &
     format='("Resolution of dynamics restart     =",3I5)'  )
-
-  ks = FV_Atm(1)%ks ! ALT: this was the value when we read "old" style FV_internal restart
-                    !      if needed, we could compute, ks by count(BK==0.0)
-                    !      then FV will try to run slightly more efficient code
-                    !      So far, GEOS-5 has used ks = 0
-  _ASSERT(ks <= FV_Atm(1)%flagstruct%NPZ+1,'ks must be smaller than NPZ+1')
-  call WRITE_PARALLEL(ks                          , &
-     format='("Number of true pressure levels =", I5)'   )
 
   FV_HYDROSTATIC = FV_Atm(1)%flagstruct%hydrostatic
   DEBUG          = FV_Atm(1)%flagstruct%fv_debug
@@ -662,11 +653,11 @@ contains
     integer, intent(in)   :: npx,npy    !  Global horizontal resolution
 
 ! !DESCRIPTION:
-! 
+!
 !    If nsplit=0 (module variable) then determine a good value
 !    for ns (used in fvdycore) based on resolution and the large-time-step
 !    (dtime). The user may have to set this manually if instability occurs.
-! 
+!
 ! !REVISION HISTORY:
 !   00.10.19   Lin     Creation
 !   01.03.26   Sawyer  ProTeX documentation
@@ -680,14 +671,14 @@ contains
     real (REAL8)   umax
     real (REAL8)   dimx
     real (REAL8)   dim0                      ! base dimension
-    real (REAL8)   dt0                       ! base time step              
+    real (REAL8)   dt0                       ! base time step
     real (REAL8)   ns0                       ! base nsplit for base dimension
     integer     ns                        ! final value to be returned
-                     
+
     parameter ( dim0 = 180.  )
     parameter ( dt0  = 1800. )
     parameter ( umax = 350.  )
- 
+
     ns0  = 7.
     dimx = 4.0*npx
     if (FV_Atm(1)%flagstruct%grid_type < 4) then
@@ -709,7 +700,7 @@ contains
 
  subroutine FV_InitState (STATE, CLOCK, INTERNAL, IMPORT, GC, RC)
 
-  use test_cases_mod, only : test_case, init_double_periodic 
+  use test_cases_mod, only : test_case, init_double_periodic
 
   type (T_FVDYCORE_STATE),pointer              :: STATE
 
@@ -841,15 +832,21 @@ contains
   GRID%AK     = ak
   GRID%BK     = bk
 
+  ! We set ks to be one less than the number of levels in bk that are zero.
+  ! This matches the number that would be provided by m_set_eta.
+  FV_Atm(1)%ks = count(bk == 0.0) - 1
+  _ASSERT(FV_Atm(1)%ks <= FV_Atm(1)%flagstruct%NPZ+1,'FV_Atm(1)%ks must be smaller than NPZ+1')
+  call WRITE_PARALLEL(FV_Atm(1)%ks, format='("Number of true pressure levels =", I5)'   )
+
 ! Local Copy of dimensions
 
   IS     = FV_Atm(1)%bd%isc
   IE     = FV_Atm(1)%bd%iec
   JS     = FV_Atm(1)%bd%jsc
   JE     = FV_Atm(1)%bd%jec
-  ISC    = FV_Atm(1)%bd%isc         
-  IEC    = FV_Atm(1)%bd%iec 
-  JSC    = FV_Atm(1)%bd%jsc 
+  ISC    = FV_Atm(1)%bd%isc
+  IEC    = FV_Atm(1)%bd%iec
+  JSC    = FV_Atm(1)%bd%jsc
   JEC    = FV_Atm(1)%bd%jec
   ISD    = FV_Atm(1)%bd%isd
   IED    = FV_Atm(1)%bd%ied
@@ -928,7 +925,7 @@ contains
   ! ---------------------------------------
 
   ! Set an interval for printing. Currently hard-coded to
-  ! six hours, but could be a MAPL_GetResource value 
+  ! six hours, but could be a MAPL_GetResource value
   call ESMF_TimeIntervalSet(MassAlarmInt, H=6, rc=STATUS)
   VERIFY_(STATUS)
 
@@ -941,7 +938,7 @@ contains
      Enabled      = .true.,                   &
      sticky       = .false.,                  &
      RC           = STATUS                    )
-  VERIFY_(STATUS) 
+  VERIFY_(STATUS)
 
   call MAPL_GetPointer ( import, phis, 'PHIS', RC=STATUS )
   VERIFY_(STATUS)
@@ -1166,7 +1163,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
   call MAPL_GetObjectFromGC (GC, MAPL,  RC=STATUS )
   VERIFY_(STATUS)
 
-  call ESMF_ClockGet( CLOCK, currTime=fv_time, rc=STATUS ) 
+  call ESMF_ClockGet( CLOCK, currTime=fv_time, rc=STATUS )
   VERIFY_(STATUS)
   call ESMF_TimeGet( fv_time, dayOfYear=days, s=seconds, rc=STATUS )
   VERIFY_(STATUS)
@@ -1233,7 +1230,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
                    (FV_Atm(1)%flagstruct%nwat == 6) )
      _ASSERT( NWAT_TEST , 'NWAT must be either 0, 1, 3 or 6')
      select case ( FV_Atm(1)%flagstruct%nwat )
-     case (6) 
+     case (6)
           FV_Atm(1)%ncnst = STATE%GRID%NQ + 3 ! NQ + Combined QLIQ,QICE,QCLD
      case (3)
           FV_Atm(1)%ncnst = STATE%GRID%NQ + 2 ! NQ + Combined QLIQ,QICE
@@ -1257,8 +1254,8 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
     grpl = 6
     qcld = 7
   ! Advect around split CN/LS species still for now...
-    qlcn = 8 
-    qlls = 9 
+    qlcn = 8
+    qlls = 9
     qicn = 10
     qils = 11
     clcn = 12
@@ -1585,7 +1582,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
                      FV_Atm(1)%flagstruct%adjust_dry_mass,  FV_Atm(1)%flagstruct%mountain, &
                      FV_Atm(1)%flagstruct%moist_phys,  FV_Atm(1)%flagstruct%hydrostatic, &
                      FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%domain, FV_Atm(1)%flagstruct%make_nh)
-          FV_Atm(1)%flagstruct%Make_NH=.false. 
+          FV_Atm(1)%flagstruct%Make_NH=.false.
         endif
       endif
      ! Mark FV setup complete
@@ -1624,8 +1621,8 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
             FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
             FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
             FV_Atm(1)%q(isc:iec,jsc:jec,k,qice) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,rain) + & 
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,snow) + & 
+            FV_Atm(1)%q(isc:iec,jsc:jec,k,rain) + &
+            FV_Atm(1)%q(isc:iec,jsc:jec,k,snow) + &
             FV_Atm(1)%q(isc:iec,jsc:jec,k,grpl) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
          enddo
        else
@@ -1651,7 +1648,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
       if(ESMF_AlarmIsRinging(MASSALARM) .AND. check_mass) then
          if (ABS((massD-massD0)/massD0) >= epsilon(1.0_REAL4)) then
             if (mpp_pe()==mpp_root_pe()) then
-               write(6,126) 
+               write(6,126)
                write(6,127) massD0
                write(6,128) massD
                write(6,129) massD0/massD, (massD-massD0)/massD0
@@ -1850,7 +1847,7 @@ subroutine FV_Run (STATE, CLOCK, GC, RC)
           endif
        endif
        endif ! nwat >= 1
-       
+
        if (FV_Atm(1)%flagstruct%nwat == 6) then
        if (TRIM(state%vars%tracer(n)%tname) == 'QRAIN') then
           RAIN_FILLED = .TRUE.
@@ -2020,7 +2017,7 @@ end subroutine FV_Run
                         u_inc, v_inc, t_inc, dp_inc, q_inc, o3_inc)
  use fv_treat_da_inc_mod, only : geos_get_da_increments
 ! The ANA Lat-Lon Grid
- integer, intent(in) :: IM,JM,KM 
+ integer, intent(in) :: IM,JM,KM
  real, intent(inout) :: LONS(IM), LATS(JM)
 ! ANA-BKG fields on the ANA Lat-Lon Grid
  real, dimension(IM,JM,KM), intent(inout) :: u_amb, v_amb, t_amb, dp_amb, q_amb, o3_amb
@@ -2074,7 +2071,7 @@ subroutine State_To_FV ( STATE )
    type(T_FVDYCORE_STATE),      pointer   :: STATE
 
     integer               :: ISC,IEC, JSC,JEC
-    integer               :: ISD,IED, JSD,JED 
+    integer               :: ISD,IED, JSD,JED
     integer               :: KM, NG
     integer               :: I,J,K
     real(REAL8)              :: akap
@@ -2140,7 +2137,7 @@ subroutine State_To_FV ( STATE )
   endif
 
    if (.not. FV_Atm(1)%flagstruct%hydrostatic) FV_Atm(1)%w(isc:iec,jsc:jec,:) = STATE%VARS%W
- 
+
 !------------
 ! Update Pressures
 !------------
@@ -2187,7 +2184,7 @@ subroutine State_To_FV ( STATE )
     do k=1,km
       do j=jsc,jec
         do i=isc,iec
-          FV_Atm(1)%delp(i,j,k) = FV_Atm(1)%pe(i,k+1,j) - FV_Atm(1)%pe(i,k,j) 
+          FV_Atm(1)%delp(i,j,k) = FV_Atm(1)%pe(i,k+1,j) - FV_Atm(1)%pe(i,k,j)
         enddo
       enddo
     enddo
@@ -2195,7 +2192,7 @@ subroutine State_To_FV ( STATE )
     if (.not. SW_DYNAMICS) then
 
 !-----------------------
-! Copy PT and make Dry T 
+! Copy PT and make Dry T
 !-----------------------
        FV_Atm(1)%pt(:,:,:) = tiny_number
        FV_Atm(1)%pt(isc:iec,jsc:jec,:) = STATE%VARS%PT*STATE%VARS%PKZ
@@ -2257,7 +2254,7 @@ subroutine FV_To_State ( STATE )
 ! Get delz from FV3
 !------------------------------
        if (.not. FV_Atm(1)%flagstruct%hydrostatic) STATE%VARS%DZ = FV_Atm(1)%delz(isc:iec,jsc:jec,:)
-       
+
 !--------------------------------
 ! Get pkz from FV3
 !--------------------------------
@@ -2282,7 +2279,7 @@ subroutine fv_getDELZ(delz,temp,pe)
   peln = log(pe)
   rdg   = -rgas / grav
   delz = rdg*temp*(peln(:,:,2:)-peln(:,:,1:))
-return 
+return
 end subroutine fv_getDELZ
 
 subroutine fv_getQ(Q, qNAME)
@@ -2369,7 +2366,7 @@ subroutine a2d3d(ua, va, ud, vd)
       real(REAL8), intent(inout) :: ud(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec  ,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec+1,FV_Atm(1)%npz) ! U-Wind
       real(REAL8), intent(inout) :: vd(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec+1,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec  ,FV_Atm(1)%npz) ! V-Wind
 ! !Local Variables
-      integer :: is ,ie , js ,je 
+      integer :: is ,ie , js ,je
       integer :: npx, npy, npz
       integer :: i,j,k, im2,jm2
 
@@ -2885,13 +2882,13 @@ subroutine fv_computeMassFluxes_r4(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
 ! Compute Mass Fluxes and Fill Courant number outputs
      do j=js,je
         do i=is,ie
-       ! X-Dir 
+       ! X-Dir
          if (crx(i,j) > 0.) then
             fx(i,j) = xfx(i,j) * delp(i-1,j)
          else
             fx(i,j) = xfx(i,j) * delp(i,j)
          endif
-       ! Y-Dir 
+       ! Y-Dir
          if (cry(i,j) > 0.) then
             fy(i,j) = yfx(i,j) * delp(i,j-1)
          else
@@ -2950,7 +2947,7 @@ subroutine fv_computeMassFluxes_r8(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
   integer     :: it, nsplt
 
 ! Fill Ghosted arrays and update halos
-  uc = MAPL_UNDEF 
+  uc = MAPL_UNDEF
   vc = MAPL_UNDEF
   uc(is:ie,js:je,:) = ucI
   vc(is:ie,js:je,:) = vcI
@@ -3067,13 +3064,13 @@ subroutine fv_computeMassFluxes_r8(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
 ! Compute Mass Fluxes and Fill Courant number outputs
      do j=js,je
         do i=is,ie
-       ! X-Dir 
+       ! X-Dir
          if (crx(i,j) > 0.) then
             fx(i,j) = xfx(i,j) * delp(i-1,j)
          else
             fx(i,j) = xfx(i,j) * delp(i,j)
          endif
-       ! Y-Dir 
+       ! Y-Dir
          if (cry(i,j) > 0.) then
             fy(i,j) = yfx(i,j) * delp(i,j-1)
          else
@@ -3104,8 +3101,8 @@ subroutine fv_fillMassFluxes(mfx, mfy, cx, cy)
 
   mfx(:,:,:) = FV_Atm(1)%mfx(isc:iec,jsc:jec,:)
   mfy(:,:,:) = FV_Atm(1)%mfy(isc:iec,jsc:jec,:)
-   cx(:,:,:) = FV_Atm(1)%cx(isc:iec,jsc:jec,:) 
-   cy(:,:,:) = FV_Atm(1)%cy(isc:iec,jsc:jec,:) 
+   cx(:,:,:) = FV_Atm(1)%cx(isc:iec,jsc:jec,:)
+   cy(:,:,:) = FV_Atm(1)%cy(isc:iec,jsc:jec,:)
 
 return
 end subroutine fv_fillMassFluxes
@@ -3219,7 +3216,7 @@ subroutine compute_utvt(uc, vc, ut, vt, dt)
 ! Local vars
   real(FVPRC) :: damp
   integer i,j,npx,npy
-  
+
   npx = FV_Atm(1)%flagstruct%npx
   npy = FV_Atm(1)%flagstruct%npy
 
@@ -3314,7 +3311,7 @@ subroutine compute_utvt(uc, vc, ut, vt, dt)
            enddo
        endif
 
-!The following code solves a 2x2 system to get the interior parallel-to-edge 
+!The following code solves a 2x2 system to get the interior parallel-to-edge
 ! uc,vc values near the corners (ex: for the sw corner ut(2,1) and vt(1,2) are solved for simultaneously).
 ! It then computes the halo uc, vc values so as to be consistent with the computations on the facing panel.
 
@@ -3396,7 +3393,7 @@ subroutine compute_utvt(uc, vc, ut, vt, dt)
                             ut(1,npy-1)+ut(1,npy-2)+ut(2,npy-2)+uc(2,npy-1) -   &
                       0.25*fv_atm(1)%gridstruct%cosa_u(2,npy-1)*(vt(1,npy)+vt(2,npy)+vt(2,npy-1))) ) * damp
         endif
-           
+
  else
 ! grid_type >= 3
 
@@ -3695,7 +3692,7 @@ subroutine fv_getEPV(pt, vort, ua, va, epv)
 ! i-component of EPV
              vort_i = (1./area_dydz) * ( va_e(i,j,k+1)*fv_atm(1)%gridstruct%dya(i,j) - va_e(i,j,k)*fv_atm(1)%gridstruct%dya(i,j) - &
                                                  w_jm1*dz_jm1   +       w_jp1*dz_jp1 )
-! j-component of EPV 
+! j-component of EPV
              vort_j = (1./area_dxdz) * ( ua_e(i,j,k)*fv_atm(1)%gridstruct%dxa(i,j)   - ua_e(i,j,k+1)*fv_atm(1)%gridstruct%dxa(i,j) - &
                                                  w_ip1*dz_ip1   +       w_im1*dz_im1 ) + &
                                          2.*MAPL_OMEGA*COS(FV_Atm(1)%gridstruct%agrid(i,j,2))
@@ -3739,19 +3736,19 @@ subroutine fv_getEPV(pt, vort, ua, va, epv)
 end subroutine fv_getEPV
 
 !------------------------------------------------------------------------------
-!BOP         
+!BOP
 !
 ! !IROUTINE: fv_getAgridWinds_3D
 !
 ! !INTERFACE:
-!    
+!
 subroutine fv_getAgridWinds_3D(u, v, ua, va, uc, vc, rotate)
 
 ! !INPUT PARAMETERS:
   real(REAL8), intent(IN)  ::  u(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec,1:FV_Atm(1)%npz)
   real(REAL8), intent(IN)  ::  v(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec,1:FV_Atm(1)%npz)
   logical, optional, intent(IN) :: rotate
-! 
+!
 ! !OUTPUT PARAMETERS:
   real(REAL8),           intent(OUT) :: ua(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec,1:FV_Atm(1)%npz)
   real(REAL8),           intent(OUT) :: va(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec,1:FV_Atm(1)%npz)
@@ -3759,7 +3756,7 @@ subroutine fv_getAgridWinds_3D(u, v, ua, va, uc, vc, rotate)
   real(REAL8), optional, intent(OUT) :: vc(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec,1:FV_Atm(1)%npz)
 !
 ! !DESCRIPTION:
-! 
+!
 ! !LOCAL VARIABLES:
   real(FVPRC) :: wbuffer(FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec,FV_Atm(1)%npz)
   real(FVPRC) :: sbuffer(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%npz)
@@ -3770,7 +3767,7 @@ subroutine fv_getAgridWinds_3D(u, v, ua, va, uc, vc, rotate)
   integer isd,ied,jsd,jed
   integer npz
   integer i,j,k
-  
+
   real(FVPRC) :: ut(FV_Atm(1)%bd%isd:FV_Atm(1)%bd%ied, FV_Atm(1)%bd%jsd:FV_Atm(1)%bd%jed)
   real(FVPRC) :: vt(FV_Atm(1)%bd%isd:FV_Atm(1)%bd%ied, FV_Atm(1)%bd%jsd:FV_Atm(1)%bd%jed)
 
@@ -3788,7 +3785,7 @@ subroutine fv_getAgridWinds_3D(u, v, ua, va, uc, vc, rotate)
   isd=FV_Atm(1)%bd%isd ; ied=FV_Atm(1)%bd%ied
   jsd=FV_Atm(1)%bd%jsd ; jed=FV_Atm(1)%bd%jed
   npz = FV_Atm(1)%npz
-  
+
   utemp  = 0
   vtemp  = 0
   uatemp = 0
@@ -3817,11 +3814,11 @@ subroutine fv_getAgridWinds_3D(u, v, ua, va, uc, vc, rotate)
     do k=1,npz
        do i=isc,iec
           utemp(i,jec+1,k) = nbuffer(i,k)
-       enddo  
+       enddo
        do j=jsc,jec
           vtemp(iec+1,j,k) = ebuffer(j,k)
-       enddo  
-    enddo   
+       enddo
+    enddo
   endif
 
   call mpp_update_domains(utemp, vtemp, FV_Atm(1)%domain, gridtype=DGRID_NE, complete=.true.)
@@ -3832,7 +3829,7 @@ subroutine fv_getAgridWinds_3D(u, v, ua, va, uc, vc, rotate)
                    FV_Atm(1)%gridstruct,FV_Atm(1)%bd, FV_Atm(1)%flagstruct%npx, FV_Atm(1)%flagstruct%npy, &
                    FV_Atm(1)%gridstruct%nested, FV_Atm(1)%gridstruct%grid_type)
   enddo
-  if (FV_Atm(1)%flagstruct%grid_type<4 .AND. present(rotate)) then 
+  if (FV_Atm(1)%flagstruct%grid_type<4 .AND. present(rotate)) then
    if (rotate) call cubed_to_latlon(utemp  , vtemp  , &
                                     uatemp , vatemp , &
                                     FV_Atm(1)%gridstruct, &
@@ -3935,7 +3932,7 @@ subroutine fv_getAgridWinds_2D(u, v, ua, va, rotate)
                   FV_Atm(1)%gridstruct,FV_Atm(1)%bd, FV_Atm(1)%flagstruct%npx, FV_Atm(1)%flagstruct%npy, &
                   FV_Atm(1)%gridstruct%nested, FV_Atm(1)%gridstruct%grid_type)
 
-  if (FV_Atm(1)%flagstruct%grid_type<4 .AND. present(rotate)) then 
+  if (FV_Atm(1)%flagstruct%grid_type<4 .AND. present(rotate)) then
    if (rotate) call cubed_to_latlon(utemp  , vtemp  , &
                                     uatemp , vatemp , &
                                     FV_Atm(1)%gridstruct, &
@@ -4043,7 +4040,7 @@ end subroutine fv_getAgridWinds_2D
 
       end subroutine get_latlon_vector
 
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 !BOP
 ! !ROUTINE:  ppme --- PPM scheme at vertical edges
 !
@@ -4179,7 +4176,7 @@ end subroutine fv_getAgridWinds_2D
       return
 !EOC
       end subroutine ppme
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 
 subroutine echo_fv3_setup()
 
@@ -4202,7 +4199,7 @@ subroutine echo_fv3_setup()
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%kord_tr ,format='("FV3 kord_tr: ",(I3))' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%lim_fac ,format='("FV3 lim_fac: ",(F7.5))' )
 !  real(FVPRC)    :: scale_z = 0.   ! diff_z = scale_z**2 * 0.25
-!  real(FVPRC)    :: w_max = 75.    ! max w (m/s) threshold for hydostatiic adjustment 
+!  real(FVPRC)    :: w_max = 75.    ! max w (m/s) threshold for hydostatiic adjustment
 !  real(FVPRC)    :: z_min = 0.05   ! min ratio of dz_nonhydrostatic/dz_hydrostatic
    call WRITE_PARALLEL ( 'FV3 Damping options:' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%nord ,format='("FV3 nord: ",(I3))' )
@@ -4222,27 +4219,27 @@ subroutine echo_fv3_setup()
 !! Additional FV3 options
 !   logical :: consv_am  = .false.   ! Apply Angular Momentum Correction (to zonal wind component)
    call WRITE_PARALLEL_L ( FV_Atm(1)%flagstruct%do_sat_adj ,format='("FV3 do_sat_adj: ",(A))' )
-!   logical :: do_f3d    = .false.   ! 
+!   logical :: do_f3d    = .false.   !
 !   logical :: no_dycore = .false.   ! skip the dycore
-!   logical :: convert_ke = .false. 
+!   logical :: convert_ke = .false.
    call WRITE_PARALLEL_L ( FV_Atm(1)%flagstruct%do_vort_damp ,format='("FV3 do_vort_damp: ",(A))' )
-!   logical :: use_old_omega = .true. 
+!   logical :: use_old_omega = .true.
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%beta ,format='("FV3 beta: ",(F7.4))' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%n_zfilter ,format='("FV3 n_zfilter: ",(I3))' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%n_sponge ,format='("FV3 n_sponge: ",(I3))' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%d_ext ,format='("FV3 d_ext: ",(F7.5))' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%nwat ,format='("FV3 nwat: ",(I3))' )
-!  logical :: warm_start = .false. 
+!  logical :: warm_start = .false.
 !  logical :: inline_q = .true.
 !  logical :: adiabatic = .true.     ! Run without physics (full or idealized).
 ! Grid options:
 !  real(FVPRC) :: shift_fac   =  18.   ! shift west by 180/shift_fac = 10 degrees
-!  logical :: do_schmidt = .false. 
+!  logical :: do_schmidt = .false.
 !  real(kind=R_GRID) :: stretch_fac =   1.   ! No stretching
-!  real(kind=R_GRID) :: target_lat  = -90.   ! -90: no grid rotation 
-!  real(kind=R_GRID) :: target_lon  =   0.   ! 
+!  real(kind=R_GRID) :: target_lat  = -90.   ! -90: no grid rotation
+!  real(kind=R_GRID) :: target_lon  =   0.   !
 ! NH core and splitting options
-!   logical :: reset_eta = .false. 
+!   logical :: reset_eta = .false.
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%p_fac ,format='("FV3 p_fac: ",(F7.5))' )
    call WRITE_PARALLEL ( FV_Atm(1)%flagstruct%a_imp ,format='("FV3 a_imp: ",(F7.5))' )
    call WRITE_PARALLEL ( 'FV3 Splitting options:' )
@@ -4302,7 +4299,7 @@ subroutine echo_fv3_setup()
 !   logical :: fv_land = .false.       ! To cold starting the model with USGS terrain
 !   logical :: nudge = .false.         ! Perform nudging
 !   logical :: nudge_ic = .false.      ! Perform nudging on IC
-!   logical :: ncep_ic = .false.       ! use NCEP ICs 
+!   logical :: ncep_ic = .false.       ! use NCEP ICs
 !   logical :: fv_diag_ic = .false.    ! reconstruct IC from fv_diagnostics on lat-lon grid
 !   logical :: external_ic = .false.   ! use ICs from external sources; e.g. lat-lon FV core
 !   character(len=128) :: res_latlon_dynamics = 'INPUT/fv_rst.res.nc'


### PR DESCRIPTION
Closes #165 

This PR initializes `FV_Atm(1)%ks` by doing:
```fortran
  FV_Atm(1)%ks = count(bk == 0.0) - 1
```
per @atrayano 

ETA: Note I also updated the CI because it was old and broken.

Note: use "hide whitespace" to see easier. My editor removes unneeded trailing spaces and went a bit crazy here:

<img width="400" alt="Screen Shot 2022-06-30 at 1 37 27 PM" src="https://user-images.githubusercontent.com/2982494/176741935-0f7624a8-a8b0-458a-9977-598e99e327a8.png">

