### PR TITLE
Add experimental support for Singularity

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 configure_file(fv3_setup fv3_setup @ONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fv3_setup DESTINATION bin)
 
-configure_file(fv3.j fv3.j COPYONLY)
+configure_file(fv3.j fv3.j @ONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fv3.j DESTINATION bin)
 
 configure_file(.FV3_VERSION .FV3_VERSION @ONLY)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -4,10 +4,12 @@ else()
    set(CFG_NONHYDROSTATIC TRUE)
 endif()
 
+set(CFG_FV_PRECISION ${FV_PRECISION})
+
 configure_file(fv3_setup fv3_setup @ONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fv3_setup DESTINATION bin)
 
-configure_file(fv3.j fv3.j @ONLY)
+configure_file(fv3.j fv3.j COPYONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/fv3.j DESTINATION bin)
 
 configure_file(.FV3_VERSION .FV3_VERSION @ONLY)

--- a/scripts/fv3.j
+++ b/scripts/fv3.j
@@ -142,7 +142,7 @@ module list
 @SETENVS
 
          setenv EXETAG "$TAG"
-         setenv FV3EXE '@FV_PRECISION@'
+         setenv FV3EXE '@FV_PRECISION'
          setenv EXPID   "c${AGCM_IM}_L${AGCM_LM}_T${N_TRACERS}_${NX}x${NY}_${N_OMP}threads"
          setenv EXPDSC  "c${AGCM_IM}_L${AGCM_LM}_T${N_TRACERS}_${NX}x${NY}_${N_OMP}threads"
          setenv EXPDIR  @EXPDIR
@@ -365,7 +365,7 @@ endif
 # ---------------------------------------
 
 # If you are using singularity, set the path to the singularity sandbox here
-setenv SINGULARITY_SANDBOX = ""
+setenv SINGULARITY_SANDBOX ""
 
 # If SINGULARITY_SANDBOX is non-empty and FOUND_EXE_IN_EXPDIR is set to 1, error out
 if( $FOUND_EXE_IN_EXPDIR == 1 && $SINGULARITY_SANDBOX != "" ) then
@@ -374,13 +374,15 @@ if( $FOUND_EXE_IN_EXPDIR == 1 && $SINGULARITY_SANDBOX != "" ) then
    exit 1
 endif
 
-# Set Singularity Bind Paths. Note: These are dependent on where you are running. 
-# By default, we'll assume you are running this script from NOBACKUP
-setenv SINGULARITY_BIND_PATH = "-B ${NOBACKUP}:${NOBACKUP}"
-
 # If SINGULARITY_SANDBOX is non-empty, then run executable in singularity sandbox
 if( $SINGULARITY_SANDBOX != "" ) then
+   # Load the Singularity module
    module load singularity
+
+   # Set Singularity Bind Paths. Note: These are dependent on where you are running.
+   # By default, we'll assume you are running this script from NOBACKUP
+   setenv SINGULARITY_BIND_PATH = "-B ${NOBACKUP}:${NOBACKUP}"
+
    $RUN_CMD $NPES singularity exec $SINGULARITY_BIND_PATH $SINGULARITY_SANDBOX $EXE $IOSERVER_OPTIONS |& tee ${SCRDIR}.log
 else
    $RUN_CMD $NPES $EXE $IOSERVER_OPTIONS |& tee ${SCRDIR}.log

--- a/scripts/fv3.j
+++ b/scripts/fv3.j
@@ -370,7 +370,7 @@ setenv SINGULARITY_SANDBOX ""
 # If SINGULARITY_SANDBOX is non-empty and FOUND_EXE_IN_EXPDIR is set to 1, error out
 if( $FOUND_EXE_IN_EXPDIR == 1 && $SINGULARITY_SANDBOX != "" ) then
    echo "ERROR: Testing has shown Singularity only works when running with"
-   echo "       the executable directly from the installation bin dirctory"
+   echo "       the executable directly from the installation bin directory"
    exit 1
 endif
 
@@ -381,12 +381,15 @@ if( $SINGULARITY_SANDBOX != "" ) then
 
    # Set Singularity Bind Paths. Note: These are dependent on where you are running.
    # By default, we'll assume you are running this script from NOBACKUP
-   setenv SINGULARITY_BIND_PATH = "-B ${NOBACKUP}:${NOBACKUP}"
+   setenv SINGULARITY_BIND_PATH "-B ${NOBACKUP}:${NOBACKUP}"
 
-   $RUN_CMD $NPES singularity exec $SINGULARITY_BIND_PATH $SINGULARITY_SANDBOX $EXE $IOSERVER_OPTIONS |& tee ${SCRDIR}.log
+   # Set a variable to encapsulate all Singularity details
+   setenv SINGULARITY_RUN "singularity exec $SINGULARITY_BIND_PATH $SINGULARITY_SANDBOX"
 else
-   $RUN_CMD $NPES $EXE $IOSERVER_OPTIONS |& tee ${SCRDIR}.log
+   setenv SINGULARITY_RUN ""
 endif
+
+$RUN_CMD $NPES $SINGULARITY_RUN $EXE $IOSERVER_OPTIONS |& tee ${SCRDIR}.log
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 

--- a/scripts/fv3_setup
+++ b/scripts/fv3_setup
@@ -1,4 +1,3 @@
-#!/bin/tcsh -f
 
 #######################################################################
 #                            Define Colors
@@ -52,12 +51,14 @@ if (! -x ${BINDIR}/StandAlone_FV3_Dycore.x) then
    exit 1
 endif
 
+# Set TMPDIR to /tmp due to issues with heredocs in Singularity sandboxes
+# -----------------------------------------------------------------------
+
+setenv TMPDIR /tmp
+
 #######################################################################
 #                   Test for Command Line Flags
 #######################################################################
-
-# Set default behavior of switches
-set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -67,11 +68,6 @@ while ( $#argv > 0 )
       case -[Cc]:
       case --[Cc][Oo][Ll][Oo][Rr]:
          goto SETCOLOR
-
-      # Symlink StandAlone_FV3_Dycore.x
-      case --link:
-         set LINKX = TRUE
-         breaksw
 
       # Here any string not above will trigger USAGE
       case -[Hh]:
@@ -591,16 +587,6 @@ if( -e $HOME/.GROUProot ) /bin/rm $HOME/.GROUProot
 echo $GROUP > $HOME/.GROUProot
 
 #######################################################################
-#      Copy Model Executable and RC Files to Experiment Directory
-#######################################################################
-
-if ( $LINKX == "TRUE" ) then
-  if ( -e $GEOSBIN/StandAlone_FV3_Dycore.x ) ln -s $GEOSBIN/StandAlone_FV3_Dycore.x $EXPDIR
-else
-  if ( -e $GEOSBIN/StandAlone_FV3_Dycore.x ) cp -v $GEOSBIN/StandAlone_FV3_Dycore.x $EXPDIR
-endif
-
-#######################################################################
 #               Set Recommended MPI Stack Settings
 #######################################################################
 
@@ -814,6 +800,12 @@ chmod   +x $EXPDIR/fv3.j
 
 echo "Done!"
 echo "-----"
+echo ""
+echo "NOTE: fv3.j by default will run StandAlone_FV3_Dycore.x from the installation directory:"
+echo "      $GEOSBIN
+echo ""
+echo ""     However, if you copy an executable into the experiment directory, the script will"
+echo "      run that executable instead."
 
 #######################################################################
 #                              Clean-Up

--- a/scripts/fv3_setup
+++ b/scripts/fv3_setup
@@ -789,9 +789,9 @@ echo "Done!"
 echo "-----"
 echo ""
 echo "NOTE: fv3.j by default will run StandAlone_FV3_Dycore.x from the installation directory:"
-echo "      $GEOSBIN
+echo "      $GEOSBIN"
 echo ""
-echo ""     However, if you copy an executable into the experiment directory, the script will"
+echo "      However, if you copy an executable into the experiment directory, the script will"
 echo "      run that executable instead."
 
 #######################################################################

--- a/scripts/fv3_setup
+++ b/scripts/fv3_setup
@@ -2,7 +2,7 @@
 
 #######################################################################
 #                            Define Colors
-#         Note:  For No Colors, set C1 and C2 to NONE 
+#         Note:  For No Colors, set C1 and C2 to NONE
 #######################################################################
 
 set BLACK   = `tput setaf 0`
@@ -129,7 +129,7 @@ if( $WORD !=  $EXPDSC ) set EXPDSC = `echo ${EXPDSC}_${WORD}`
 end
 
 #######################################################################
-#          Continue to enter in experiment parameters 
+#          Continue to enter in experiment parameters
 #######################################################################
 
 HRCODE:
@@ -359,7 +359,7 @@ else if( $AGCM_IM <=  180 ) then
    set DEF_IOS_NDS = 2
 else if( $AGCM_IM <= 360 ) then
    set DT = 450
-   set FV_NX = 12 
+   set FV_NX = 12
    set NUM_READERS = 4
    set DEF_IOS_NDS = 2
 elsif( $AGCM_IM <= 500 ) then
@@ -376,7 +376,7 @@ else if( $AGCM_IM <= 720 ) then
    set DEF_IOS_NDS = 3
 else if( $AGCM_IM <= 1440 ) then
    set DT = 450
-   set FV_NX = 30 
+   set FV_NX = 30
    set NUM_READERS = 6
    set USE_SHMEM = 1
    set DEF_IOS_NDS = 4
@@ -386,7 +386,7 @@ else if( $AGCM_IM <= 1536 ) then
    set NUM_READERS = 6
    set USE_SHMEM = 1
    set DEF_IOS_NDS = 4
-else 
+else
    set DT = 45
    set FV_NX = 64
    set NUM_READERS = 6
@@ -403,6 +403,8 @@ endif
 set FV_NY = `expr $FV_NX \* 6`
 
 set AGCM_GRIDNAME   = "PE${AGCM_IM}x${AGCM_JM}-CF"
+
+set FV_PRECISION = @CFG_FV_PRECISION@
 
 #######################################################################
 #                  Architecture Specific Variables
@@ -483,7 +485,7 @@ else
 
    setenv RUN_Q "DELETE"
    setenv RUN_P "SBATCH --ntasks=${MODEL_NPES}" # PE Configuration for fv3.j
-   
+
    # By default on desktop, just ignore IOSERVER for now until testing
    set USE_IOSERVER   = 0
    set IOS_NDS        = 0
@@ -518,7 +520,7 @@ while( $check == FALSE )
   else
        setenv EXPDIR  $EXPDIR_def
   endif
-  
+
   if( "$EXPID" != `basename $EXPDIR` ) then
        echo "\!\! The ${C1}EXPERIMENT${CN} Directory MUST point to the ${C1}EXPID${CN}: ${C2}${EXPID}${CN}"
        echo " "
@@ -709,6 +711,7 @@ s^@BOOT^YES^g
 s/@DT/$DT/g
 s/@FV_NX/$FV_NX/g
 s/@FV_NY/$FV_NY/g
+s/@FV_PRECISION/$FV_PRECISION/g
 s/@USE_SHMEM/$USE_SHMEM/g
 s/@USE_IOSERVER/$USE_IOSERVER/g
 s/@USE_NONHYDRO/$USE_NONHYDRO/g

--- a/scripts/fv3_setup
+++ b/scripts/fv3_setup
@@ -1,3 +1,4 @@
+#!/bin/tcsh -f
 
 #######################################################################
 #                            Define Colors
@@ -682,20 +683,6 @@ r $EXPDIR/SETENV.commands
 d
 }
 
-/@GPUSTART/ {
-t success1
-: success1
-r $EXPDIR/GPUSTART.commands
-d
-}
-
-/@GPUEND/ {
-t success2
-: success2
-r $EXPDIR/GPUEND.commands
-d
-}
-
 s?@EXPID?$EXPID?g
 s?@RUN_N?$RUN_N?g
 s?@RUN_T?$RUN_T?g
@@ -824,18 +811,6 @@ TRAP:
    /bin/rm $FILES_TO_PROCESS $OLDEXPFILES $NEWEXPFILES $COPYSCRIPT $SEDFILE
    exit 1
 
-CONTACTMATT:
-cat <<EOF
-
-It appears your environment is not set correctly to
-run with the GPUs. If you wish to build and run the
-model using GPUs, please contact Matt Thompson at:
-
-            matthew.thompson@nasa.gov
-
-EOF
-exit 1
-
 SETCOLOR:
 echo
 echo "\033[1;4mGCM Setup Utility${RESET}"
@@ -878,7 +853,6 @@ fv3_setup, a setup script for the GEOS-5 FV3 Standalone
    Usage: $0:t [optional flag]
 
    -c --color      Set the colors for $0:t
-   -g --gpu        Run the model using the GPUs
    -h --help       Show usage
 
    If invoked alone, the script runs as normal.


### PR DESCRIPTION
This PR is an attempt to add support for Singularity testing. It actually does something more fundamental, though. Now, by default, `fv3_setup` does not copy over `StandAlone_FV3_Dycore.x` into the experiment and `fv3.j` by default will run the executable in the `install/bin` directory that was built.

It was found in Singularity testing that this was needed for Singularity runs and, in truth, is the right way to do things with CMake and RPATHs.

But, code is currently in the script that *IF* there is a `StandAlone_FV3_Dycore.x` executable in the experiment directory, it will use that one instead of the one in `install/bin`