### PR TITLE
Updates for Spack Stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ esma_add_library (${this}
 if (FV_PRECISION STREQUAL R4)
    set (GFDL fms_r4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-   get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
+   get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
    target_include_directories(${this} PRIVATE
    $<BUILD_INTERFACE:${extra_incs}>
    )


### PR DESCRIPTION
This PR is needed for building GEOSgcm with spack-stack (see https://github.com/NOAA-EMC/spack/pull/174).

In it, we change an `INCLUDE_DIRECTORIES` to `INTERFACE_INCLUDE_DIRECTORIES`. This is needed as FMS-from-Spack uses a CMake config that does not provide `INCLUDE_DIRECTORIES`. 

Testing with GEOS using internal FMS and Baselibs show this still does work and is zero-diff.