### PR TITLE
Fixes for fv3 standalone

### DIFF
--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -2480,7 +2480,7 @@ contains
   type (ESMF_State)                  :: INTERNAL
   type (DynGrid),  pointer           :: DycoreGrid
 
-  real, pointer                      :: temp2d(:,:)
+  real(r4), pointer                      :: temp2d(:,:)
 
   integer                            :: ifirst
   integer                            :: ilast

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -2954,6 +2954,8 @@ subroutine Run(gc, import, export, clock, rc)
     logical                             :: doEnergetics
     logical                             :: doTropvars
 
+    integer :: FV3_STANDALONE
+
   Iam = "Run"
   call ESMF_GridCompGet( GC, name=COMP_NAME, CONFIG=CF, grid=ESMFGRID, RC=STATUS )
   VERIFY_(STATUS)
@@ -3252,11 +3254,19 @@ subroutine Run(gc, import, export, clock, rc)
       end do
 
 ! WMP Begin REPLAY/ANA section
-      call MAPL_TimerOn(MAPL,"-DYN_ANA")
-      call ESMF_ClockGetAlarm(Clock,'ReplayShutOff',Alarm,rc=Status)
-      VERIFY_(status)
-      is_shutoff = ESMF_AlarmIsRinging( Alarm,rc=Status)
-      VERIFY_(status)
+!-----------------------------
+
+      call ESMF_ConfigGetAttribute ( CF, FV3_STANDALONE, Label="FV3_STANDALONE:", default=0, RC=STATUS)
+      VERIFY_(STATUS)
+      if (FV3_STANDALONE == 0) then
+         call MAPL_TimerOn(MAPL,"-DYN_ANA")
+         call ESMF_ClockGetAlarm(Clock,'ReplayShutOff',Alarm,rc=Status)
+         VERIFY_(status)
+         is_shutoff = ESMF_AlarmIsRinging( Alarm,rc=Status)
+         VERIFY_(status)
+      else
+         is_shutoff = .true.
+      end if
 
       if (.not. is_shutoff) then
 ! If requested, do Intermittent Replay
@@ -4013,7 +4023,9 @@ subroutine Run(gc, import, export, clock, rc)
       call Energetics (ur,vr,tempxy,vars%pe,delp,vars%pkz,phisxy,kenrg,penrg,tenrg)
 
       endif
-      call MAPL_TimerOff(MAPL,"-DYN_ANA")
+      if (FV3_STANDALONE == 0) then
+         call MAPL_TimerOff(MAPL,"-DYN_ANA")
+      endif
 
 
       call MAPL_TimerOn(MAPL,"-DYN_PROLOGUE")

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -218,7 +218,7 @@ private
     real(REAL8)                             :: hlv      ! latent heat of evaporation
     real(FVPRC)                             :: zvir     ! RWV/RAIR-1
 
-  real, pointer :: phis(:,:), varflt(:,:)
+  real(kind=4), pointer :: phis(:,:), varflt(:,:)
 
   logical :: fv_first_run = .true.
 

--- a/scripts/fv3_setup
+++ b/scripts/fv3_setup
@@ -156,7 +156,7 @@ endif
 
 ASKHYDRO:
 
-set DEFAULT_NON_HYDROSTATIC = @CFG_NONHYDROSTATIC@
+set DEFAULT_NON_HYDROSTATIC = FALSE
 echo "Do you wish to run ${C1}NON-HYDROSTATIC${CN} dynamics? (Default: ${C2}${DEFAULT_NON_HYDROSTATIC}${CN})"
 
 set   DO_NONHYDRO  = $<
@@ -362,7 +362,7 @@ else if( $AGCM_IM <= 360 ) then
    set FV_NX = 12
    set NUM_READERS = 4
    set DEF_IOS_NDS = 2
-elsif( $AGCM_IM <= 500 ) then
+else if( $AGCM_IM <= 500 ) then
    set DT = 450
    set FV_NX = 12
    set NUM_READERS = 4


### PR DESCRIPTION
Proposed changes to let the FV3 Standalone work again. The issue seems to be the standalone cannot call some replay timers that only exist in the full GCM.