### PR TITLE
Fixes for FV3 standalone

### DIFF
--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -555,7 +555,7 @@ contains
      FV_Atm(1)%flagstruct%do_sat_adj = .true. ! only valid when nwat >= 6
      FV_Atm(1)%flagstruct%dz_min = 6.0
      FV_Atm(1)%flagstruct%RF_fast = .true.
-     FV_Atm(1)%flagstruct%tau = 2.0 
+     FV_Atm(1)%flagstruct%tau = 2.0
      FV_Atm(1)%flagstruct%rf_cutoff = 10.e2
     ! 6th order default damping options
      FV_Atm(1)%flagstruct%nord = 3
@@ -1186,7 +1186,7 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, RC)
 
   real(REAL4), pointer     :: PTR3D(:,:,:)
 
-  real(REAL4), pointer     :: LONS(:,:), LATS(:,:) 
+  real(REAL4), pointer     :: LONS(:,:), LATS(:,:)
   real(REAL8), pointer     :: lonptr(:,:), latptr(:,:)
   real(REAL4), allocatable :: griddiffs(:,:)
   type (ESMF_Grid)         :: ESMFGRID
@@ -1201,10 +1201,10 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, RC)
   integer :: qice = -1
   integer :: qlls = -1
   integer :: qlcn = -1
-  integer :: qlcnf= -1 
+  integer :: qlcnf= -1
   integer :: qils = -1
   integer :: qicn = -1
-  integer :: qicnf= -1 
+  integer :: qicnf= -1
   integer :: clls = -1
   integer :: clcn = -1
   integer :: clcnf= -1
@@ -1659,23 +1659,23 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, RC)
              else
                  FV_Atm(1)%q(i,j,k,qicnf) = 0.0
              endif
-           enddo 
-         enddo 
-       enddo 
+           enddo
+         enddo
+       enddo
     endif
     if ( (qcld /= -1) .and. (clcnf /= -1) ) then
        do k=1,npz
          do j=jsc,jec
-           do i=isc,iec      
-             if (FV_Atm(1)%q(i,j,k,qcld) > 0.0) then   
+           do i=isc,iec
+             if (FV_Atm(1)%q(i,j,k,qcld) > 0.0) then
                  FV_Atm(1)%q(i,j,k,clcnf) = FV_Atm(1)%q(i,j,k,clcnf) / &
                                             FV_Atm(1)%q(i,j,k,qcld)
              else
                  FV_Atm(1)%q(i,j,k,clcnf) = 0.0
              endif
-           enddo 
-         enddo 
-       enddo 
+           enddo
+         enddo
+       enddo
     endif
    ! Verify
     select case (FV_Atm(1)%flagstruct%nwat)
@@ -1779,7 +1779,7 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, RC)
 
   else
 
-    if (mpp_pe()==0) print*, 'Running In Adiabatic Mode'
+    if (fv_first_run .and. (mpp_pe()==0)) print*, 'Running In Adiabatic Mode'
 
    ! Report total number and names of advected tracers
       if (fv_first_run .and. STATE%GRID%NQ > 0) then
@@ -1788,7 +1788,7 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, RC)
       endif
    ! Advect all tracers
       do n=1,STATE%GRID%NQ
-         call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
+         if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
          nn = nn+1
          if (state%vars%tracer(n)%is_r4) then
             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
@@ -2189,25 +2189,25 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, RC)
          if ((clcnf /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'CLCN')) then
             CLCN_FILLED = .TRUE.
             nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then      
+            if (state%vars%tracer(n)%is_r4) then
                state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * &
                                         MIN(1.0,MAX(0.0,FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcnf)))
             else
                   state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * &
                                         MIN(1.0,MAX(0.0,FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcnf)))
             endif
-         endif    
+         endif
          if ((clcnf /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'CLLS')) then
             CLLS_FILLED = .TRUE.
             nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then     
+            if (state%vars%tracer(n)%is_r4) then
                state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * &
-                                   MIN(1.0,MAX(0.0,(1.0-FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcnf))))       
+                                   MIN(1.0,MAX(0.0,(1.0-FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcnf))))
             else
                   state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * &
                                    MIN(1.0,MAX(0.0,(1.0-FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcnf))))
             endif
-         endif   
+         endif
        else
          if ((clcn /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'CLCN')) then
             CLCN_FILLED = .TRUE.
@@ -2522,7 +2522,7 @@ subroutine State_To_FV ( STATE )
     else
        STATE%KSPLIT = FV_Atm(1)%flagstruct%k_split
        STATE%NSPLIT = MAX(  FV_Atm(1)%flagstruct%n_split,NINT(STATE%NSPLIT/1.25))
-    endif        
+    endif
     if (STATE%NSPLIT /= FV_Atm(1)%flagstruct%n_split) &
     call WRITE_PARALLEL( STATE%DT/real(STATE%KSPLIT*STATE%NSPLIT)   ,format='("Adjusted Dynamics time step : ",(F10.4))')
   endif
@@ -2857,7 +2857,7 @@ subroutine a2d3d(ua, va, ud, vd, wind_increment_limiter)
   ! end where
   ! where(abs(vatemp) > wind_increment_limiter)
   !     vatemp = (wind_increment_limiter/abs(vatemp)) * vatemp
-  ! end where        
+  ! end where
   ! endif
 
     if (FV_Atm(1)%flagstruct%grid_type<4) then

--- a/scripts/fv3.j
+++ b/scripts/fv3.j
@@ -353,11 +353,11 @@ endif
 if (-e $EXPDIR/StandAlone_FV3_Dycore.x) then
    echo "Found StandAlone_FV3_Dycore.x in $EXPDIR"
 
-   # If SINGULARITY_SANDBOX is non-empty and GEOSgcm.x is found in the experiment directory,
-   # force the use of GEOSgcm.x in the installation directory
+   # If SINGULARITY_SANDBOX is non-empty and StandAlone_FV3_Dycore.x is found in the experiment directory,
+   # force the use of StandAlone_FV3_Dycore.x in the installation directory
    if( $SINGULARITY_SANDBOX != "" ) then
       echo "NOTE: Testing has shown Singularity only works when running with"
-      echo "      the GEOSgcm.x executable directly from the installation bin directory"
+      echo "      the StandAlone_FV3_Dycore.x executable directly from the installation bin directory"
       echo ""
       echo "      So, we will *ignore* the local StandAlone_FV3_Dycore.x and "
       echo "      instead use $GEOSBIN/StandAlone_FV3_Dycore.x"


### PR DESCRIPTION
This PR has some minor changes for issue encountered while looking at the FV3 Standalone. The main change is to make some prints at `fv_first_run` only. Before you got:
```
 AGCM Date: 1891/03/01  Time: 04:30:00  Throughput(days/day)[Avg Tot Run]:      11024.2      13485.2      13612.8  TimeRemaining(Est) 000:00:06   19.5% :  18.1% Mem Comm:Used
 Running In Adiabatic Mode
 Q
 Q001
 AGCM Date: 1891/03/01  Time: 04:37:30  Throughput(days/day)[Avg Tot Run]:      11072.3      13370.5      13501.3  TimeRemaining(Est) 000:00:06   19.5% :  18.1% Mem Comm:Used
 Running In Adiabatic Mode
 Q
 Q001
 AGCM Date: 1891/03/01  Time: 04:45:00  Throughput(days/day)[Avg Tot Run]:      11120.2      13472.7      13597.2  TimeRemaining(Est) 000:00:06   19.5% :  18.1% Mem Comm:Used
 Running In Adiabatic Mode
 Q
 Q001
```

where

```
 Running In Adiabatic Mode
 Q
 Q001
```
is printed at every time step! Now it looks like:
```
 AGCM Date: 1891/03/01  Time: 04:30:00  Throughput(days/day)[Avg Tot Run]:      10657.9      13168.5      13293.0  TimeRemaining(Est) 000:00:06   19.7% :  18.6% Mem Comm:Used
 AGCM Date: 1891/03/01  Time: 04:37:30  Throughput(days/day)[Avg Tot Run]:      10708.5      13180.7      13308.9  TimeRemaining(Est) 000:00:06   19.7% :  18.6% Mem Comm:Used
 AGCM Date: 1891/03/01  Time: 04:45:00  Throughput(days/day)[Avg Tot Run]:      10757.5      13163.1      13289.4  TimeRemaining(Est) 000:00:06   19.7% :  18.6% Mem Comm:Used
```
Much nicer.