### PR TITLE
Handmerge develop into MAPL3 - 2023-Jun-09

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.25.0
+baselibs_version: &baselibs_version v7.13.0
+bcs_version: &bcs_version v11.00.0
 
 
 orbs:

--- a/StandAlone_AdvCore.F90
+++ b/StandAlone_AdvCore.F90
@@ -19,9 +19,7 @@ program StandAlone_AdvCore
    type (MAPL_CapOptions) :: cap_options
    integer :: status
 
-   cap_options = FlapCLI( &
-        description = 'FV Standalone dvCore', &
-        authors     = 'S.J. Lin, R. Rood, W. Putman')
+   cap_options = FargparseCLI()
 
    cap = MAPL_Cap('Standalone FV3 AdvCore', SetServices, cap_options=cap_options)
    call cap%run(_RC)

--- a/StandAlone_DynAdvCore.F90
+++ b/StandAlone_DynAdvCore.F90
@@ -19,9 +19,7 @@ program StandAlone_DynAdvCore
    type (MAPL_CapOptions) :: cap_options
    integer :: status
 
-   cap_options = FlapCLI( &
-        description = 'FV Standalone DyAdvCore', &
-        authors     = 'S.J. Lin, R. Rood, W. Putman')
+   cap_options = FargparseCLI()
    cap = MAPL_Cap('Standalone FV3 DynAdvCore', SetServices, cap_options = cap_options)
    call cap%run(_RC)
 

--- a/StandAlone_FV3_Dycore.F90
+++ b/StandAlone_FV3_Dycore.F90
@@ -18,8 +18,7 @@ program StandAlone_FV3_Dycore
    type (MAPL_CapOptions) :: cap_options
    integer :: status
 
-   cap_options = FlapCLI(description = 'FV Standalone Dycore',&
-                              authors      =  'S.J. Lin, R. Rood, W. Putman')
+   cap_options = FargparseCLI()
    cap = MAPL_Cap('GCM', SetServices, cap_options = cap_options)
    call cap%run(_RC)
 


### PR DESCRIPTION
Supersedes #239 

This is a handmerge of `develop` into `release/MAPL-v3` where I'm using the CI to make sure all the edits are right. Or at least the one we test.