### PR TITLE
Update CircleCI to use Orb v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.14.0
-#bcs_version: &bcs_version v11.1.0
+#baselibs_version: &baselibs_version v7.17.0
+#bcs_version: &bcs_version v11.3.0
 
 
 orbs:
-  ci: geos-esm/circleci-tools@1
+  ci: geos-esm/circleci-tools@2
 
 workflows:
   build-test:


### PR DESCRIPTION
This PR updates the CircleCI config the v2 orb. This has updated needed for changes in GEOSgcm_App and Baselibs