### PR TITLE
v11: Add dependency to fms_r4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
   message(STATUS "Building GEOS-gtFV3 interface")
 
   add_definitions(-DRUN_GTFV3)
-  
+
   # The Python library creation requires mpiexec/mpirun to run on a
   # compute node. Probably a weird SLURM thing?
   find_package(MPI REQUIRED)
@@ -124,6 +124,12 @@ endif ()
 if (FV_PRECISION STREQUAL R4)
    set (GFDL fms_r4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
+   # We need to add_dependencies for fms_r4 because CMake doesn't know we
+   # need it for include purposes. In R4R8, we only ever link against
+   # fms_r4, so it doesn't know we need to build it.
+   # NOTE NOTE NOTE: This should *not* be included in GEOSgcm v12
+   #     because FMS is pre-built library in that case.
+   add_dependencies (${this} fms_r4)
    get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
    target_include_directories(${this} PRIVATE
    $<BUILD_INTERFACE:${extra_incs}>


### PR DESCRIPTION
This PR adds a dependency to `fms_r4`. We need this because of the weird way we build FV3 as r4 but link to the r8 version of FMS. In that case, we still need to point to the include files from r4 FMS. 

But, CMake in that case has no idea that to build, say, Moist, that we need to build `fms_r4` before building this.

## NOTE NOTE NOTE

This change is *NOT* needed in GEOSgcm v12 because in that case FMS is in Baselibs/Spack and so CMake doesn't need to know. I've added a big fat comment for the inevitable case when a merge to v12 happens and the build fails.