### PR TITLE
v12: Update CMake to use FMS:: targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ workflows:
           #baselibs_version: *baselibs_version
           repo: GEOSfvdycore
           checkout_fixture: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
           mepodevelop: false
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
       - ci/run_fv3:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.3.0
-
+#baselibs_version: &baselibs_version v8.9.0
+#bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:
@@ -17,11 +16,14 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort, gfortran]
+              compiler: [gfortran, ifort]
           #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
-          mepodevelop: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
+          # We comment out this as it will "undo" the fixture_branch
+          #mepodevelop: false
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
       - ci/run_fv3:
           name: run-FV3-on-<< matrix.compiler >>-with-GEOSgcm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
   message(STATUS "Building GEOS-gtFV3 interface")
 
   add_definitions(-DRUN_GTFV3)
-  
+
   # The Python library creation requires mpiexec/mpirun to run on a
   # compute node. Probably a weird SLURM thing?
   find_package(MPI REQUIRED)
@@ -122,19 +122,17 @@ else ()
 endif ()
 
 if (FV_PRECISION STREQUAL R4)
-   set (GFDL fms_r4)
+  set (GFDL FMS::fms_r4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-   get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
-   target_include_directories(${this} PRIVATE
-   $<BUILD_INTERFACE:${extra_incs}>
-   )
-   set (GFDL fms_r8)
+  get_target_property (extra_incs FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(${this} PRIVATE $<BUILD_INTERFACE:${extra_incs}>)
+  set (GFDL FMS::fms_r8)
 elseif (FV_PRECISION STREQUAL R8)
-   set (GFDL fms_r8)
-   string(REPLACE " " ";" tmp ${FREAL8})
-   foreach(flag ${tmp})
-     target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
-   endforeach()
+  set (GFDL FMS::fms_r8)
+  string(REPLACE " " ";" tmp ${FREAL8})
+  foreach(flag ${tmp})
+    target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
+  endforeach()
 endif ()
 
 if (FV_PRECISION MATCHES R4)


### PR DESCRIPTION
Testing with spack showed there were still non-standard fms targets in the CMake code. This converts them all to the "correct" `FMS::` style targets.