### PR TITLE
Fix interp_restarts.x to write AK/BK without precision change junk

### DIFF
--- a/fv_regrid_c2c.F90
+++ b/fv_regrid_c2c.F90
@@ -320,6 +320,8 @@ contains
          call prt_maxmin(' V_geos', v0, is_i, ie_i+1, js_i, je_i  , Atm_i(1)%ng, km, 1.0_FVPRC)
          allocate ( ud(isd:ied  ,jsd:jed+1,km) )
          allocate ( vd(isd:ied+1,jsd:jed  ,km) )
+         ud = 0.
+         vd = 0.
 !------------------------------------------------------------------!
 ! D->A : regrid : A-> D interpolation for U and V components
 !------------------------------------------------------------------!
@@ -986,6 +988,8 @@ end subroutine xyz_to_dgrid
     integer :: i,j,n
     integer :: is, ie, js, je
 
+    va_xyz_o = 0.d0
+    tmp_o = 0.
     is = Atm_i%bd%is
     ie = Atm_i%bd%ie
     js = Atm_i%bd%js

--- a/interp_restarts.F90
+++ b/interp_restarts.F90
@@ -39,7 +39,6 @@ program interp_restarts
 
    real(ESMF_KIND_R8), allocatable :: r8_ak(:)
    real(ESMF_KIND_R8), allocatable :: r8_bk(:)
-   real(ESMF_KIND_R8), allocatable :: r8_akbk(:)
 
    real(ESMF_KIND_R4), pointer :: r4_local(:,:,:)
    real(ESMF_KIND_R8), pointer :: r8_local(:,:,:), pt_local(:,:,:)
@@ -302,7 +301,6 @@ program interp_restarts
    call set_eta(npz,ks,ptop,pint,r8_ak,r8_bk)
    Atm(1)%ak = r8_ak
    Atm(1)%bk = r8_bk
-   deallocate ( r8_ak,r8_bk )
    nq = nmoist
    Atm(1)%ncnst = nq/km
    if( is_master() ) then
@@ -503,12 +501,8 @@ program interp_restarts
 
 
 ! AK and BK
-      allocate ( r8_akbk(npz+1) )
-      r8_akbk = Atm(1)%ak
-      if (AmWriter) call MAPL_VarWrite(OutFmt,"AK",r8_akbk)
-      r8_akbk = Atm(1)%bk
-      if (AmWriter) call MAPL_VarWrite(OutFmt,"BK",r8_akbk)
-      deallocate ( r8_akbk )
+      if (AmWriter) call MAPL_VarWrite(OutFmt,"AK",r8_ak)
+      if (AmWriter) call MAPL_VarWrite(OutFmt,"BK",r8_bk)
 
       allocate(r4_local(is:ie,js:je,npz+1))
       allocate(r8_local(is:ie,js:je,npz+1))


### PR DESCRIPTION
Fixes #309, this will write the ak/bk into the fvcore restart without the extra junk one gets from doing an r8->r4->r8 conversion. user @rtodling pointed out that the restart files do not quite match was is m_set_eta.