### PR TITLE
v11: Initialize q_con

### DIFF
--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -2626,6 +2626,7 @@ subroutine State_To_FV ( STATE )
 
     endif
 
+   FV_Atm(1)%q_con = tiny_number
 
    return
 


### PR DESCRIPTION
In current tests of GEOSgcm v11 with ifx 2025.2, Debug runs were crashing in dyn_core (in fvdycore) on a line concerning the use of `q_con`. 

Running in a graphical debugger found that `q_con` was full of NaNs. Tracing the code, it was found that `q_con` was never initialized.

GEOSgcm v12 Debug did run because the line that v11 failed on was *removed* by @wmputman.

So this PR initializes `q_con` to `tiny_number`. My tests show that GEOSgcm v11 with ifort is zero-diff both with Release and Debug flags.