### PR TITLE
Porting dyncore to mapl3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,18 @@ workflows:
           mepodevelop: false
           checkout_mapl3_release_branch: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
-      - ci/run_fv3:
-          name: run-FV3-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>-with-GEOSfvdycore
-          context:
-            - docker-hub-creds
-          matrix:
-            parameters:
-              compiler: [gfortran, ifort]
-              fv_precision: ["R4", "R8"]
-          #baselibs_version: *baselibs_version
-          requires:
-            - build-GEOSfvdycore-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>
-          repo: GEOSfvdycore
+      # We also turn off the FV3 dycore runs for now
+      #############################################################################################
+      # - ci/run_fv3:                                                                             #
+      #     name: run-FV3-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>-with-GEOSfvdycore #
+      #     context:                                                                              #
+      #       - docker-hub-creds                                                                  #
+      #     matrix:                                                                               #
+      #       parameters:                                                                         #
+      #         compiler: [gfortran, ifort]                                                       #
+      #         fv_precision: ["R4", "R8"]                                                        #
+      #     #baselibs_version: *baselibs_version                                                  #
+      #     requires:                                                                             #
+      #       - build-GEOSfvdycore-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>          #
+      #     repo: GEOSfvdycore                                                                    #
+      #############################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,12 @@ else ()
     SRCS ${srcs}
     SUBCOMPONENTS fvdycore
     DEPENDENCIES ${dependencies}
-    DEPENDENCIES ${GFDL})
+    DEPENDENCIES ${GFDL}
+    TYPE SHARED
+  )
 endif ()
 
-mapl_acg (${this} DynCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS)
+mapl_acg (${this} DynCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 3g)
 mapl_acg (${this} AdvCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS)
 
 if (FV_PRECISION STREQUAL R4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 
 endif ()
 
-set(dependencies MAPL GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared esmf OpenMP::OpenMP_Fortran)
+set(dependencies MAPL MAPL.generic3g GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared esmf OpenMP::OpenMP_Fortran)
 
 if (BUILD_GEOS_GTFV3_INTERFACE)
   esma_add_library (${this}

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -15,7 +15,7 @@ module FVdycoreCubed_GridComp
 
    !USES:
    use ESMF
-   use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
+   use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return
 
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
@@ -466,7 +466,7 @@ contains
       real(r4), pointer :: temp2d(:,:)
 
       real(r8), pointer ::  ak(:), bk(:)
-      real(r4), pointer ::  ak4(:), bk4(:)
+      real(r4), pointer ::  ak4(:), bk4(:) ! exports are 32-bit
       real(r8), pointer ::  ud(:,:,:), vd(:,:,:)
       real(r8), pointer ::  pe(:,:,:), pt(:,:,:), pk(:,:,:)
       real(r8), allocatable ::  ur(:,:,:), vr(:,:,:)
@@ -788,55 +788,36 @@ contains
       real(r8),     allocatable ::   udtmp(:,:,:)
       real(r8),     allocatable ::   vdtmp(:,:,:)
 
-      character(len=ESMF_MAXSTR), ALLOCATABLE       :: NAMES (:)
-      character(len=ESMF_MAXSTR), ALLOCATABLE       :: NAMES0(:)
+      character(len=ESMF_MAXSTR), allocatable :: names(:), names0(:)
       character(len=ESMF_MAXSTR) :: STRING
       character(len=:), allocatable :: ReplayMode, ReplayFile, ReplayType
       character(len=:), allocatable :: cremap,tremap
-      character(len=:), allocatable :: uname,vname,tname,qname,psname,dpname,o3name,rgrid,tvar
+      character(len=:), allocatable :: uname, vname, tname, qname, psname, dpname, o3name, rgrid, tvar
 
       type(MAPL_SunOrbit) :: ORBIT
       real(r4), pointer :: lats(:,:), lons(:,:)
-      real(r4), allocatable  ::  ZTH(:,:)
-      real(r4), allocatable  ::  SLR(:,:)
+      real(r4), allocatable :: ZTH(:,:), SLR(:,:)
 
-      real                  :: rc_blend_p_above
-      real                  :: rc_blend_p_below
-      real                  :: sclinc
-      integer               :: rc_blend
-
-      real                  :: HGT_SURFACE
+      real :: rc_blend_p_above, rc_blend_p_below, sclinc
+      integer :: rc_blend
+      real :: HGT_SURFACE
 
       character(len=:), allocatable :: ANA_IS_WEIGHTED
-      logical                    ::     is_weighted
+      logical :: is_weighted
 
-      type(DynTracers)            :: qqq       ! Specific Humidity
-      type(DynTracers)            :: ooo       ! ox
-      logical LCONSV, LFILL
-      integer  CONSV,  FILL
-      integer nx_ana, ny_ana
+      type(DynTracers) :: qqq       ! Specific Humidity
+      type(DynTracers) :: ooo       ! ox
+      logical :: LCONSV, LFILL
+      integer :: CONSV,  FILL, nx_ana, ny_ana
 
-      logical, save                       :: firstime=.true.
-      logical                             :: adjustTracers
-      type(ESMF_Alarm)                    :: predictorAlarm
-      type(ESMF_Grid)                     :: bgrid
-      integer                             :: pos
-      integer                             :: nqt
-      logical                             :: tend
-      logical                             :: exclude
-      character(len=ESMF_MAXSTR)          :: tmpstring
-      character(len=ESMF_MAXSTR)          :: fieldname
-      character(len=:), allocatable :: adjustTracerMode, xlist(:)
+      logical, save :: firstime = .true.
+      logical :: adjustTracers, tend, exclude, isPresent, doEnergetics, doTropvars
+      integer :: pos, nqt, FV3_STANDALONE, itracer
+      type(ESMF_Alarm) :: predictorAlarm
+      type(ESMF_Grid) :: bgrid
+      character(len=ESMF_MAXSTR) :: tmpstring, fieldname, myTracer
       character(len=ESMF_MAXSTR), allocatable :: biggerlist(:)
-      logical                             :: isPresent
-
-      logical                             :: doEnergetics
-      logical                             :: doTropvars
-
-      integer :: FV3_STANDALONE
-
-      character(len=ESMF_MAXSTR) :: myTracer
-      integer :: itracer
+      character(len=:), allocatable :: adjustTracerMode, xlist(:)
       real(kind=r8) :: t1, t2, dyn_run_timer
       class(logger_t), pointer :: logger
 
@@ -1056,11 +1037,11 @@ contains
       call ESMF_FieldBundleGet(bundle, fieldCount=NQ, _RC)
 
       if (NQ > 0) then
-         allocate(NAMES(NQ), _STAT)
-         call ESMF_FieldBundleGet(bundle, itemorderflag=ESMF_ITEMORDER_ADDORDER, fieldNameList=NAMES, _RC)
+         allocate(names(NQ), _STAT)
+         call ESMF_FieldBundleGet(bundle, itemorderflag=ESMF_ITEMORDER_ADDORDER, fieldNameList=names, _RC)
          if( .not.allocated(names0) ) then
-            allocate(NAMES0(NQ), _STAT)
-            NAMES0 = NAMES
+            allocate(names0(NQ), _STAT)
+            names0 = names
          endif
       endif
 
@@ -1743,7 +1724,6 @@ contains
       !    call MAPL_TimerOff(MAPL,"-DYN_ANA")
       ! endif
 
-
       ! call MAPL_TimerOn(MAPL,"-DYN_PROLOGUE")
       ! Create FV Thermodynamic Variables
       tempxy = vars%pt * vars%pkz      ! Compute Dry Temperature
@@ -1764,9 +1744,9 @@ contains
       call FILLOUT3(export, "PLE_DYN_IN", vars%pe, _RC)
 
       ! Initialize 3-D Tracer Dynamics Tendencies
-      call MAPL_GetPointer( export,dqldt,"DQLDTDYN", _RC)
-      call MAPL_GetPointer( export,dqidt,"DQIDTDYN", _RC)
-      call MAPL_GetPointer( export,doxdt,"DOXDTDYN", _RC)
+      call MAPL_GetPointer(export, dqldt, "DQLDTDYN", _RC)
+      call MAPL_GetPointer(export, dqidt, "DQIDTDYN", _RC)
+      call MAPL_GetPointer(export, doxdt, "DOXDTDYN", _RC)
 
       if (allocated(names)) then
 
@@ -2111,7 +2091,8 @@ contains
          call FILLOUT3(export, 'DTDTDYN'   , dtdt , _RC)
          call FILLOUT3(export, 'DQVDTDYN'  , dqdt , _RC)
          call FILLOUT3(export, 'DDELPDTDYN', ddpdt, _RC)
-         call FILLOUT3(export, 'DPLEDTDYN' , dpedt, _RC)
+         ! pchakrab - TODO: figure out the issue with DPLEDTDYN
+         ! call FILLOUT3(export, 'DPLEDTDYN' , dpedt, _RC)
 
          ! fill pressure exports (PLE0: Before) & (PLE1: After) from FV3
          call FILLOUT3r8(export, 'PLE0', pe0, _RC)
@@ -4684,51 +4665,49 @@ contains
 
    end subroutine ADD_INCS
 
-   subroutine FILLOUT3r8(export, name, V, RC)
-      type (ESMF_State),  intent(inout) :: export
-      character(len=*),   intent(IN   ) :: name
-      real(r8),           intent(IN   ) :: V(:,:,:)
-      integer, optional,  intent(  out) :: rc
+   subroutine FILLOUT3r8(export, name, v, rc)
+      type(ESMF_State), intent(inout) :: export
+      character(len=*), intent(in) :: name
+      real(r8), intent(in) :: v(:,:,:)
+      integer, optional, intent(out) :: rc
 
-      real(r8), pointer          :: CPL(:,:,:)
-      integer                    :: status
-      character(len=ESMF_MAXSTR) :: IAm="Fillout3r8"
+      real(r8), pointer :: cpl(:,:,:)
+      integer :: status
 
-      call MAPL_GetPointer(export, cpl, name, RC=STATUS)
-      VERIFY_(STATUS)
-      if(associated(cpl)) cpl=v
+      call MAPL_GetPointer(export, cpl, name, _RC)
+      if(associated(cpl)) cpl = v
+
+      _RETURN(_SUCCESS)
    end subroutine FILLOUT3r8
 
-   subroutine FILLOUT3(export, name, V, RC)
-      type (ESMF_State),  intent(inout) :: export
-      character(len=*),   intent(IN   ) :: name
-      real(r8),           intent(IN   ) :: V(:,:,:)
-      integer, optional,  intent(  out) :: rc
+   subroutine FILLOUT3(export, name, v, rc)
+      type(ESMF_State), intent(inout) :: export
+      character(len=*), intent(in) :: name
+      real(r8), intent(in) :: v(:,:,:)
+      integer, optional, intent(out) :: rc
 
-      real(r4), pointer          :: CPL(:,:,:)
-      integer                    :: status
-      character(len=ESMF_MAXSTR) :: IAm="Fillout3"
+      real(r4), pointer :: cpl(:,:,:)
+      integer :: status
 
-      call MAPL_GetPointer(export, cpl, name, RC=STATUS)
-      VERIFY_(STATUS)
-      if(associated(cpl)) cpl=v
+      call MAPL_GetPointer(export, cpl, name, _RC)
+      if(associated(cpl)) cpl = v
+
+      _RETURN(_SUCCESS)
    end subroutine FILLOUT3
 
-   subroutine FILLOUT2(export, name, V, rc)
-     type (ESMF_State),  intent(inout) :: export
-     character(len=*),   intent(IN   ) :: name
-     real(r8),           intent(IN   ) :: V(:,:)
-     integer, optional,  intent(  out) :: rc
+   subroutine FILLOUT2(export, name, v, rc)
+     type(ESMF_State), intent(inout) :: export
+     character(len=*), intent(in) :: name
+     real(r8), intent(in) :: v(:,:)
+     integer, optional, intent(out) :: rc
 
-     real(r4), pointer      :: CPL(:,:)
-     integer                    :: status
-     character(len=ESMF_MAXSTR) :: IAm="Fillout2"
+     real(r4), pointer :: cpl(:,:)
+     integer :: status
 
-     call MAPL_GetPointer(export, cpl, name, RC=STATUS)
-     VERIFY_(STATUS)
-     if(associated(cpl)) cpl=v
+     call MAPL_GetPointer(export, cpl, name, _RC)
+     if(associated(cpl)) cpl = v
 
-     return
+      _RETURN(_SUCCESS)
    end subroutine FILLOUT2
 
    subroutine Energetics (ua,va,thv,ple,delp,pk,phiS,keint,peint,teint,ke,cpt,gze)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -22,14 +22,14 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
    use MAPL_Constants, only: MAPL_VectorField, MAPL_BundleItem
    use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
-   use MAPL_Constants, only: MAPL_VLocationCenter, MAPL_VLocationEdge, MAPL_VLocationNone
+   ! use MAPL_Constants, only: MAPL_VLocationCenter, MAPL_VLocationEdge, MAPL_VLocationNone
    use MAPL_Constants, only: MAPL_DimsHorzVert, MAPL_DimsHorzOnly, MAPL_DimsVertOnly
 
    use MAPL_GenericMod, only: MAPL_MetaComp, MAPL_TimerAdd, MAPL_TimerOn
    use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff
    use MAPL_GenericMod, only: MAPL_GenericFinalize
    use MAPL_GenericMod, only: MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_GridCreate, MAPL_Get
-   use MAPL_GenericMod, only: MAPL_AddImportSpec, MAPL_AddExportSpec, MAPL_AddInternalSpec
+   ! use MAPL_GenericMod, only: MAPL_AddImportSpec, MAPL_AddExportSpec, MAPL_AddInternalSpec
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
    use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_FieldBundleAdd
@@ -47,6 +47,8 @@ module FVdycoreCubed_GridComp
 
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
+   use mapl3g_generic, only: MAPL_GridCompAddSpec, MAPL_STATEITEM_FIELDBUNDLE
+   use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
    use pflogger, only: logger_t => logger
 
    use m_set_eta, only: set_eta
@@ -361,30 +363,34 @@ contains
 #include "DynCore_Export___.h"
 #include "DynCore_Internal___.h"
 
-      call MAPL_AddImportSpec(gc, &
-           SHORT_NAME='TRADV', &
-           LONG_NAME='advected_quantities', &
-           UNITS='unknown', &
-           DATATYPE=MAPL_BundleItem, _RC)
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_IMPORT, &
+           short_name='TRADV', &
+           standard_name='advected_quantities', &
+           ! pchakrab: TODO - we shouldn't need dims and vstagger for a bundle
+           dims="xyz", &
+           vstagger=VERTICAL_STAGGER_NONE, &
+           units='unknown', &
+           itemtype=MAPL_STATEITEM_FIELDBUNDLE, _RC)
 
 #ifdef SKIP_TRACERS
       do itracer = 1, ntracers
          do ilev = 1, size(plevs)
             write(myTracer, "('Q',i5.5,'_',i3.3)") itracer-1, plevs(ilev)
             call MAPL_AddExportSpec(gc, &
-                 SHORT_NAME=TRIM(myTracer), &
-                 LONG_NAME =TRIM(myTracer), &
-                 UNITS='1', &
-                 DIMS=MAPL_DimsHorzOnly, &
-                 VLOCATION=MAPL_VLocationNone, _RC)
+                 short_name=TRIM(myTracer), &
+                 long_name =TRIM(myTracer), &
+                 units='1', &
+                 dims=MAPL_DimsHorzOnly, &
+                 vlocation=MAPL_VLocationNone, _RC)
          enddo
          write(myTracer, "('Q',i5.5)") itracer-1
          call MAPL_AddExportSpec(gc, &
-              SHORT_NAME=TRIM(myTracer), &
-              LONG_NAME=TRIM(myTracer), &
-              UNITS='1', &
-              DIMS=MAPL_DimsHorzVert, &
-              VLOCATION=MAPL_VLocationCenter, _RC)
+              short_name=TRIM(myTracer), &
+              long_name=TRIM(myTracer), &
+              units='1', &
+              dims=MAPL_DimsHorzVert, &
+              vlocation=MAPL_VLocationCenter, _RC)
       enddo
 #endif
 
@@ -426,11 +432,14 @@ contains
       call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", FV3_STANDALONE, default=0, _RC)
       if (FV3_STANDALONE /= 0) then
          ! call MAPL_GridCreate(gc, _RC)
-         call MAPL_AddExportSpec(gc, &
+         call MAPL_GridCompAddSpec(gc, &
+              state_intent=ESMF_STATEINTENT_EXPORT, &
               short_name='TRADVEX', &
-              long_name='advected_quantities', &
+              standard_name='advected_quantities', &
+              dims="xyz", &
+              vstagger=VERTICAL_STAGGER_NONE, &
               units='unknown', &
-              datatype=MAPL_BundleItem, _RC)
+              itemtype=MAPL_STATEITEM_FIELDBUNDLE, _RC)
       endif
 
       call MAPL_GridCompGetResource(gc, "DEBUG_DYN", DEBUG_DYN, default=.false., _RC)
@@ -6083,115 +6092,93 @@ contains
 #endif
 
    subroutine addTracer_r8(state, bundle, var, grid, fieldname)
-      type (DynState), pointer         :: STATE
-      type (ESMF_FieldBundle)          :: BUNDLE
-      real(r8), pointer                :: var(:,:,:)
-      type (ESMF_Grid)                 :: GRID
-      type (ESMF_DistGrid)             :: DistGRID
-      character(len=ESMF_MAXSTR)       :: FIELDNAME
+      type(DynState), pointer :: state
+      type(ESMF_FieldBundle) :: bundle
+      real(r8), pointer :: var(:, :, :)
+      type(ESMF_Grid) :: grid
+      type(ESMF_DistGrid) :: dist_grid
+      character(len=ESMF_MAXSTR) :: fieldname
 
       integer :: nq,rc,status
-      type(DynTracers), pointer        :: t(:)
+      type(DynTracers), pointer :: t(:)
+      type(ESMF_Field) :: field
+      real(r8), pointer :: ptr(:, :, :)
 
-      character(len=ESMF_MAXSTR)       :: IAm='FV:addTracer_r8'
+      call ESMF_GridGet(grid, distGrid=dist_grid, _RC)
+      call ESMF_FieldBundleGet(bundle, fieldCount=nq, _RC)
 
-      type (ESMF_Field)                :: field
-      real(r8),              pointer   :: ptr(:,:,:)
+      nq = nq + 1
 
-      call ESMF_GridGet (GRID,  distGrid=distgrid,       RC=STATUS)
-      VERIFY_(STATUS)
+      field = ESMF_FieldCreate(grid, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, _RC)
+      ! pchakrab - TODO: Need to replace MAPL_VLocationCenter with VERTICAL_STAGGER_CENTER
+      ! pchakrab - TODO: need a replacement for MAPL_DimsHorzVert
+      ! call ESMF_AttributeSet(field, name='VLOCATION', value=MAPL_VLocationCenter, _RC)
+      ! call ESMF_AttributeSet(field, name='DIMS', value=MAPL_DimsHorzVert, rc=status)
+      call MAPL_FieldBundleAdd(bundle, field, _RC)
 
-      call ESMF_FieldBundleGet(BUNDLE, fieldCount=NQ, RC=STATUS)
-      VERIFY_(STATUS)
-
-      NQ = NQ + 1
-
-      field = ESMF_FieldCreate(GRID, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, RC=STATUS )
-      VERIFY_(STATUS)
-      call ESMF_AttributeSet(field,name='VLOCATION',value=MAPL_VLocationCenter,rc=status)
-      VERIFY_(STATUS)
-      call ESMF_AttributeSet(field,name='DIMS',value=MAPL_DimsHorzVert,rc=status)
-      VERIFY_(STATUS)
-      call MAPL_FieldBundleAdd ( bundle, field, rc=STATUS )
-      VERIFY_(STATUS)
-
-      if (NQ == 1) then
-         ALLOCATE(STATE%VARS%tracer(nq), STAT=STATUS)
-         VERIFY_(STATUS)
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, rc=status)
-         VERIFY_(STATUS)
+      if (nq == 1) then
+         allocate(state%VARS%tracer(nq), _STAT)
+         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          state%vars%tracer(nq)%content => ptr
-         state%vars%tracer(nq  )%is_r4 = .false.
+         state%vars%tracer(nq)%is_r4 = .false.
       else
          allocate(t(nq))
          t(1:nq-1) = state%vars%tracer
          deallocate(state%vars%tracer)
          state%vars%tracer => t
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, rc=status)
-         VERIFY_(STATUS)
+         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          state%vars%tracer(nq)%content => ptr
          state%vars%tracer(nq  )%is_r4 = .false.
       endif
 
-      STATE%GRID%NQ = NQ
+      state%grid%nq = nq
 
-      return
+      _RETURN(_SUCCESS)
    end subroutine addTracer_r8
 
    subroutine addTracer_r4(state, bundle, var, grid, fieldname)
-      type (DynState), pointer         :: STATE
-      type (ESMF_FieldBundle)          :: BUNDLE
-      real(r4), pointer                :: var(:,:,:)
-      type (ESMF_Grid)                 :: GRID
-      type (ESMF_DistGrid)             :: DistGRID
-      character(len=ESMF_MAXSTR)       :: FIELDNAME
+      type(DynState), pointer :: state
+      type(ESMF_FieldBundle) :: bundle
+      real(r4), pointer :: var(:, :, :)
+      type(ESMF_Grid) :: grid
+      type(ESMF_DistGrid) :: dist_grid
+      character(len=ESMF_MAXSTR) :: fieldname
 
       integer :: nq,rc,status
-      type(DynTracers), pointer        :: t(:)
+      type(DynTracers), pointer :: t(:)
+      type(ESMF_Field) :: field
+      real(r4), pointer :: ptr(:, :, :)
 
-      character(len=ESMF_MAXSTR)       :: IAm='FV:addTracer_r4'
+      call ESMF_GridGet(grid, distGrid=dist_grid, _RC)
+      call ESMF_FieldBundleGet(bundle, fieldCount=NQ, _RC)
 
-      type (ESMF_Field)                :: field
-      real(r4),              pointer   :: ptr(:,:,:)
+      nq = nq + 1
 
-      call ESMF_GridGet (GRID,  distGrid=distgrid,       RC=STATUS)
-      VERIFY_(STATUS)
-
-      call ESMF_FieldBundleGet(BUNDLE, fieldCount=NQ, RC=STATUS)
-      VERIFY_(STATUS)
-
-      NQ = NQ + 1
-
-      field = ESMF_FieldCreate(GRID, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, RC=STATUS )
-      VERIFY_(STATUS)
-      call ESMF_AttributeSet(field,name='VLOCATION',value=MAPL_VLocationCenter,rc=status)
-      VERIFY_(STATUS)
-      call ESMF_AttributeSet(field,name='DIMS',value=MAPL_DimsHorzVert,rc=status)
-      VERIFY_(STATUS)
-      call MAPL_FieldBundleAdd ( bundle, field, rc=STATUS )
-      VERIFY_(STATUS)
+      field = ESMF_FieldCreate(grid, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, _RC)
+      ! pchakrab - TODO: Need to replace MAPL_VLocationCenter with VERTICAL_STAGGER_CENTER
+      ! pchakrab - TODO: need a replacement for MAPL_DimsHorzVert
+      ! call ESMF_AttributeSet(field, name='VLOCATION', value=MAPL_VLocationCenter, _RC)
+      ! call ESMF_AttributeSet(field, name='DIMS', value=MAPL_DimsHorzVert, _RC)
+      call MAPL_FieldBundleAdd(bundle, field, _RC)
 
       if (NQ == 1) then
-         ALLOCATE(STATE%VARS%tracer(nq), STAT=STATUS)
-         VERIFY_(STATUS)
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, rc=status)
-         VERIFY_(STATUS)
+         allocate(state%VARS%tracer(nq), _STAT)
+         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          state%vars%tracer(nq)%content_r4 => ptr
-         state%vars%tracer(nq  )%is_r4 = .true.
+         state%vars%tracer(nq)%is_r4 = .true.
       else
          allocate(t(nq))
          t(1:nq-1) = state%vars%tracer
          deallocate(state%vars%tracer)
          state%vars%tracer => t
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, rc=status)
-         VERIFY_(STATUS)
+         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          state%vars%tracer(nq)%content_r4 => ptr
          state%vars%tracer(nq  )%is_r4 = .true.
       endif
 
-      STATE%GRID%NQ = NQ
+      state%grid%nq = nq
 
-      return
+      _RETURN(_SUCCESS)
    end subroutine addTracer_r4
 
    subroutine freeTracers(state)
@@ -6462,3 +6449,11 @@ contains
    end function R4_TO_R8
 
 end module FVdycoreCubed_GridComp
+
+subroutine SetServices(gc, rc)
+   use ESMF
+   use FVdycoreCubed_GridComp, only : mySetservices=>SetServices
+   type(ESMF_GridComp) :: gc
+   integer, intent(out) :: rc
+   call mySetServices(gc, rc=rc)
+end subroutine SetServices

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -25,7 +25,7 @@ module FVdycoreCubed_GridComp
 
    use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
 
-   use MAPL_GenericMod, only: MAPL_TimerAdd
+   ! use MAPL_GenericMod, only: MAPL_TimerAdd
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
    use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_RemapBounds
@@ -392,20 +392,20 @@ contains
       !     6 ints: YYYY MM DD H M S
       !     5 ints: I,J,K, KS (num true pressure levels), NQ (num tracers) headers
 
-      ! Set the Profiling timers
-      call MAPL_TimerAdd(gc, name="INITIALIZE", _RC)
-      call MAPL_TimerAdd(gc, name="RUN", _RC)
-      call MAPL_TimerAdd(gc, name="RUN2", _RC)
-      call MAPL_TimerAdd(gc, name="-DYN_INIT", _RC)
-      call MAPL_TimerAdd(gc, name="--FMS_INIT", _RC)
-      call MAPL_TimerAdd(gc, name="--FV_INIT", _RC)
-      call MAPL_TimerAdd(gc, name="-DYN_ANA", _RC)
-      call MAPL_TimerAdd(gc, name="-DYN_PROLOGUE", _RC)
-      call MAPL_TimerAdd(gc, name="-DYN_CORE", _RC)
-      call MAPL_TimerAdd(gc, name="-DYN_EPILOGUE", _RC)
-      call MAPL_TimerAdd(gc, name="--FV_DYNAMICS", _RC)
-      call MAPL_TimerAdd(gc, name="--MASS_FIX", _RC)
-      call MAPL_TimerAdd(gc, name="FINALIZE", _RC)
+      ! ! Set the Profiling timers
+      ! call MAPL_TimerAdd(gc, name="INITIALIZE", _RC)
+      ! call MAPL_TimerAdd(gc, name="RUN", _RC)
+      ! call MAPL_TimerAdd(gc, name="RUN2", _RC)
+      ! call MAPL_TimerAdd(gc, name="-DYN_INIT", _RC)
+      ! call MAPL_TimerAdd(gc, name="--FMS_INIT", _RC)
+      ! call MAPL_TimerAdd(gc, name="--FV_INIT", _RC)
+      ! call MAPL_TimerAdd(gc, name="-DYN_ANA", _RC)
+      ! call MAPL_TimerAdd(gc, name="-DYN_PROLOGUE", _RC)
+      ! call MAPL_TimerAdd(gc, name="-DYN_CORE", _RC)
+      ! call MAPL_TimerAdd(gc, name="-DYN_EPILOGUE", _RC)
+      ! call MAPL_TimerAdd(gc, name="--FV_DYNAMICS", _RC)
+      ! call MAPL_TimerAdd(gc, name="--MASS_FIX", _RC)
+      ! call MAPL_TimerAdd(gc, name="FINALIZE", _RC)
 
       ! Register services for this component
       call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Initialize,  Initialize, _RC)
@@ -507,25 +507,25 @@ contains
       ! call MAPL_TimerOff(MAPL, "-DYN_INIT")
 
       ! Create PLE and PREF EXPORT Coupling (Needs to be done only once per run)
-      call MAPL_GetPointer(export, ak4, "AK", _RC)
-      call MAPL_GetPointer(export, bk4, "BK", _RC)
-      call MAPL_GetPointer(internal, ak, "AK", _RC)
-      call MAPL_GetPointer(internal, bk, "BK", _RC)
-      call MAPL_GetPointer(export, pref, "PREF", ALLOC=.true., _RC)
+      call MAPL_StateGetPointer(export, ak4, "AK", _RC)
+      call MAPL_StateGetPointer(export, bk4, "BK", _RC)
+      call MAPL_StateGetPointer(internal, ak, "AK", _RC)
+      call MAPL_StateGetPointer(internal, bk, "BK", _RC)
+      call MAPL_GetPointer(export, pref, "PREF", alloc=.true., _RC)
       ak4 = ak
       bk4 = bk
       pref = ak + bk * P00
 
-      call MAPL_GetPointer(internal, ud, "U", _RC)
-      call MAPL_GetPointer(internal, vd, "V", _RC)
-      call MAPL_GetPointer(internal, pe, "PE", _RC)
-      call MAPL_GetPointer(internal, pt, "PT", _RC)
-      call MAPL_GetPointer(internal, pk, "PKZ", _RC)
+      call MAPL_StateGetPointer(internal, ud, "U", _RC)
+      call MAPL_StateGetPointer(internal, vd, "V", _RC)
+      call MAPL_StateGetPointer(internal, pe, "PE", _RC)
+      call MAPL_StateGetPointer(internal, pt, "PT", _RC)
+      call MAPL_StateGetPointer(internal, pk, "PKZ", _RC)
 
-      call MAPL_GetPointer(export, ple, "PLE", ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, u, "U", ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, v, "V", ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, t, "T", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, ple, "PLE", alloc=.true., _RC)
+      call MAPL_GetPointer(export, u, "U", alloc=.true., _RC)
+      call MAPL_GetPointer(export, v, "V", alloc=.true., _RC)
+      call MAPL_GetPointer(export, t, "T", alloc=.true., _RC)
 
       ! Create A-Grid Winds
       ifirst = self%grid%is
@@ -544,13 +544,13 @@ contains
       deallocate(ur, vr)
 
       ! Fill Grid-Cell Area Delta-X/Y
-      call MAPL_GetPointer(export, temp2d, "DXC", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, temp2d, "DXC", alloc=.true., _RC)
       temp2d = self%grid%dxc
 
-      call MAPL_GetPointer(export, temp2d, "DYC", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, temp2d, "DYC", alloc=.true., _RC)
       temp2d = self%grid%dyc
 
-      call MAPL_GetPointer(export, temp2d, "AREA", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, temp2d, "AREA", alloc=.true., _RC)
       temp2d = self%grid%area
 
       ! ======================================================================
@@ -561,6 +561,7 @@ contains
       !     would be to move the computation to phase 2 of Initialize and
       !     eliminate this section alltogether
       ! ======================================================================
+      ! pchakrab: TODO - do we need to port the following to MAPL3
       call ESMF_StateGet(export, "PREF", field, _RC)
       call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
@@ -831,9 +832,9 @@ contains
       ! call MAPL_TimerOn(MAPL, "RUN")
 
       call MAPL_GridGet(esmfgrid, longitudes=lons, latitudes=lats, _RC)
-      call MAPL_GetPointer(export, temp2d, "LONS", _RC)
+      call MAPL_StateGetPointer(export, temp2d, "LONS", _RC)
       if( associated(temp2D) ) temp2d = lons
-      call MAPL_GetPointer(export, temp2d, "LATS", _RC)
+      call MAPL_StateGetPointer(export, temp2d, "LATS", _RC)
       if( associated(temp2D) ) temp2d = lats
 
       ! Retrieve the pointer to the internal state
@@ -883,17 +884,17 @@ contains
       allocate(  dmdt(ifirstxy:ilastxy,jfirstxy:jlastxy     ))
 
       doEnergetics=.false.
-      call MAPL_GetPointer(export, temp2D, "KEANA", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "KEANA", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, "PEANA", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "PEANA", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, "TEANA", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "TEANA", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, "KEDYN", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "KEDYN", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, "PEDYN", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "PEDYN", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, "TEDYN", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "TEDYN", _RC)
       if(associated(temp2D)) doEnergetics=.true.
       if (doEnergetics) then
          allocate( kedyn(ifirstxy:ilastxy,jfirstxy:jlastxy))
@@ -1050,7 +1051,7 @@ contains
       endif
 
       ! Surface Geopotential from import state
-      call MAPL_GetPointer(import, PHIS, "PHIS", _RC)
+      call MAPL_StateGetPointer(import, PHIS, "PHIS", _RC)
 
       phisxy = real(phis,kind=r8)
 
@@ -1226,13 +1227,13 @@ contains
          allocate(  qsold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
          allocate(  qgold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
 
-         call MAPL_GetPointer(import, dqvana, "DQVANA", _RC)   ! Get QV Increment from Analysis
-         call MAPL_GetPointer(import, dqlana, "DQLANA", _RC)   ! Get QL Increment from Analysis
-         call MAPL_GetPointer(import, dqiana, "DQIANA", _RC)   ! Get QI Increment from Analysis
-         call MAPL_GetPointer(import, dqrana, "DQRANA", _RC)   ! Get QR Increment from Analysis
-         call MAPL_GetPointer(import, dqsana, "DQSANA", _RC)   ! Get QS Increment from Analysis
-         call MAPL_GetPointer(import, dqgana, "DQGANA", _RC)   ! Get QG Increment from Analysis
-         call MAPL_GetPointer(import, doxana, "DOXANA", _RC)   ! Get OX Increment from Analysis
+         call MAPL_StateGetPointer(import, dqvana, "DQVANA", _RC)   ! Get QV Increment from Analysis
+         call MAPL_StateGetPointer(import, dqlana, "DQLANA", _RC)   ! Get QL Increment from Analysis
+         call MAPL_StateGetPointer(import, dqiana, "DQIANA", _RC)   ! Get QI Increment from Analysis
+         call MAPL_StateGetPointer(import, dqrana, "DQRANA", _RC)   ! Get QR Increment from Analysis
+         call MAPL_StateGetPointer(import, dqsana, "DQSANA", _RC)   ! Get QS Increment from Analysis
+         call MAPL_StateGetPointer(import, dqgana, "DQGANA", _RC)   ! Get QG Increment from Analysis
+         call MAPL_StateGetPointer(import, doxana, "DOXANA", _RC)   ! Get OX Increment from Analysis
 
          QL = 0.0
          QI = 0.0
@@ -1295,23 +1296,23 @@ contains
          end if
 
          ! DUDTANA
-         call MAPL_GetPointer(export, dudtana, "DUDTANA", _RC)
+         call MAPL_StateGetPointer(export, dudtana, "DUDTANA", _RC)
          if( associated(dudtana) ) dudtana = ur
 
          ! DVDTANA
-         call MAPL_GetPointer(export, dvdtana, "DVDTANA", _RC)
+         call MAPL_StateGetPointer(export, dvdtana, "DVDTANA", _RC)
          if( associated(dvdtana) ) dvdtana = vr
 
          ! DTDTANA
-         call MAPL_GetPointer(export, dtdtana, "DTDTANA", _RC)
+         call MAPL_StateGetPointer(export, dtdtana, "DTDTANA", _RC)
          if( associated(dtdtana) ) dtdtana = vars%pt * vars%pkz
 
          ! DDELPDTANA
-         call MAPL_GetPointer(export, ddpdtana, "DDELPDTANA", _RC)
+         call MAPL_StateGetPointer(export, ddpdtana, "DDELPDTANA", _RC)
          if( associated(ddpdtana) ) ddpdtana = delp
 
          ! DTHVDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DTHVDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DTHVDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = vars%pt*(1+eps*(qv-dqvana))   ! Set tempxy = TH*QVold (Before Analysis Update)
             ALLOCATE( dthdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1323,7 +1324,7 @@ contains
          endif
 
          ! DQVDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DQVDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DQVDTANAINT", _RC)
          if( associated(temp2D) ) then
             ALLOCATE( dqvdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             ALLOCATE( dqvdtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1335,7 +1336,7 @@ contains
          endif
 
          ! DQLDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DQLDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DQLDTANAINT", _RC)
          if( associated(temp2D) ) then
             ALLOCATE( dqldtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             ALLOCATE( dqldtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1357,7 +1358,7 @@ contains
          endif
 
          ! DQIDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DQIDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DQIDTANAINT", _RC)
          if( associated(temp2D) ) then
             ALLOCATE( dqidtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             ALLOCATE( dqidtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1379,7 +1380,7 @@ contains
          endif
 
          ! DOXDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DOXDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DOXDTANAINT", _RC)
          if( associated(temp2D) ) then
             allocate( doxdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             allocate( doxdtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1398,7 +1399,7 @@ contains
             QDOLD = 1.0 - (QVOLD+QLOLD+QIOLD)
             QDNEW = 1.0 - (QV   +QL   +QI   )
          endif
-         call MAPL_GetPointer(export, area, "AREA", _RC)
+         call MAPL_StateGetPointer(export, area, "AREA", _RC)
 
          allocate( trsum1(nq) )
          allocate( trsum2(nq) )
@@ -1557,7 +1558,7 @@ contains
          enddo
 
          ! Diagnostics After Analysis Increments are Added
-         call MAPL_GetPointer(export, temp2D, "DMDTANA", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DMDTANA", _RC)
          if( associated(temp2D) ) temp2D = ( (vars%pe(:,:,km+1)-vars%pe(:,:,1)) - dmdt )/(grav*dt)
 
          call getAllWinds(vars%u, vars%v, UC=uc0, VC=vc0, UR=ur, VR=vr)
@@ -1565,32 +1566,32 @@ contains
          dmdt = vars%pe(:,:,km+1)-vars%pe(:,:,1)     ! Psurf-Ptop
 
          ! DUDTANA
-         call MAPL_GetPointer(export, dudtana, "DUDTANA", _RC)
+         call MAPL_StateGetPointer(export, dudtana, "DUDTANA", _RC)
          if( associated(dudtana) ) then
             dudtana = (ur-dudtana)/dt
          endif
 
          ! DVDTANA
-         call MAPL_GetPointer(export, dvdtana, "DVDTANA", _RC)
+         call MAPL_StateGetPointer(export, dvdtana, "DVDTANA", _RC)
          if( associated(dvdtana) ) then
             dvdtana = (vr-dvdtana)/dt
          endif
 
          ! DTDTANA
-         call MAPL_GetPointer(export, dtdtana, "DTDTANA", _RC)
+         call MAPL_StateGetPointer(export, dtdtana, "DTDTANA", _RC)
          if( associated(dtdtana) ) then
             dtdtana = ((vars%pt*vars%pkz)-dtdtana)/dt
          endif
 
          ! DDELPDTANA
-         call MAPL_GetPointer(export, ddpdtana, "DDELPDTANA", _RC)
+         call MAPL_StateGetPointer(export, ddpdtana, "DDELPDTANA", _RC)
          if( associated(ddpdtana) ) then
             ddpdtana = (delp-ddpdtana)/dt
          endif
 
          ! DTHVDTANAINT
          ! ------------
-         call MAPL_GetPointer(export, temp2D, "DTHVDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DTHVDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = vars%pt*(1+eps*qv)   ! Set tempxy = TH*QVnew (After Analysis Update)
             dthdtanaint2 = 0.0
@@ -1603,7 +1604,7 @@ contains
          endif
 
          ! DQVDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DQVDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DQVDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = qv         ! Set tempxy = QNEW (After Analysis Update)
             dqvdtanaint2 = 0.0
@@ -1616,7 +1617,7 @@ contains
          endif
 
          ! DQLDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DQLDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DQLDTANAINT", _RC)
          if( associated(temp2D) ) then
             dqldtanaint2 = 0.0
             do N = 1,size(names)
@@ -1637,7 +1638,7 @@ contains
          endif
 
          ! DQIDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DQIDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DQIDTANAINT", _RC)
          if( associated(temp2D) ) then
             dqidtanaint2 = 0.0
             do N = 1,size(names)
@@ -1658,7 +1659,7 @@ contains
          endif
 
          ! DOXDTANAINT
-         call MAPL_GetPointer(export, temp2D, "DOXDTANAINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DOXDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = ox         ! Set tempxy = OXnew (After Analysis Update)
             doxdtanaint2 = 0.0
@@ -1748,9 +1749,9 @@ contains
       call FILLOUT3(export, "PLE_DYN_IN", vars%pe, _RC)
 
       ! Initialize 3-D Tracer Dynamics Tendencies
-      call MAPL_GetPointer(export, dqldt, "DQLDTDYN", _RC)
-      call MAPL_GetPointer(export, dqidt, "DQIDTDYN", _RC)
-      call MAPL_GetPointer(export, doxdt, "DOXDTDYN", _RC)
+      call MAPL_StateGetPointer(export, dqldt, "DQLDTDYN", _RC)
+      call MAPL_StateGetPointer(export, dqidt, "DQIDTDYN", _RC)
+      call MAPL_StateGetPointer(export, doxdt, "DOXDTDYN", _RC)
 
       if (allocated(names)) then
 
@@ -1806,7 +1807,7 @@ contains
       endif
 
       ! Initialize 2-D Vertically Integrated Tracer Dynamics Tendencies
-      call MAPL_GetPointer(export, temp2D, "DQVDTDYNINT", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "DQVDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do k=1,km
@@ -1814,7 +1815,7 @@ contains
          enddo
       endif
 
-      call MAPL_GetPointer(export, temp2D, "DQLDTDYNINT", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "DQLDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do N = 1,size(names)
@@ -1833,7 +1834,7 @@ contains
          enddo
       endif
 
-      call MAPL_GetPointer(export, temp2D, "DQIDTDYNINT", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "DQIDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do N = 1,size(names)
@@ -1852,7 +1853,7 @@ contains
          enddo
       endif
 
-      call MAPL_GetPointer(export, temp2D, "DOXDTDYNINT", _RC)
+      call MAPL_StateGetPointer(export, temp2D, "DOXDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do N = 1,size(names)
@@ -1909,9 +1910,9 @@ contains
 
       ! call MAPL_TimerOn(MAPL, "-DYN_EPILOGUE")
       ! Computational diagnostics
-      call MAPL_GetPointer(export, temp2d, "TIME_IN_DYN", _RC)
+      call MAPL_StateGetPointer(export, temp2d, "TIME_IN_DYN", _RC)
       if(associated(temp2d)) temp2d = dyn_run_timer
-      call MAPL_GetPointer(export, temp2d, "PID", _RC)
+      call MAPL_StateGetPointer(export, temp2d, "PID", _RC)
       if(associated(temp2d)) temp2d = 0 !WMP need to get from MAPL gid
 
       !#define DEBUG_WINDS
@@ -1926,10 +1927,10 @@ contains
 
       if (SW_DYNAMICS) then
 
-         call MAPL_GetPointer(export, temp2d, "PHIS", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "PHIS", _RC)
          if(associated(temp2d)) temp2d = phisxy
 
-         call MAPL_GetPointer(export, temp2d, "PS", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "PS", _RC)
          if(associated(temp2d)) temp2d =  vars%pe(:,:,km+1)/GRAV
 
          call getAllWinds(vars%u, vars%v, UA=ua, VA=va, UC=uc, VC=vc, UR=ur, VR=vr)
@@ -1961,7 +1962,7 @@ contains
          delp  = ( vars%pe(:,:,2:) - vars%pe(:,:,:km) )
          dthdt = ( vars%pt*(1.0+eps*qv)*delp-dthdt )/dt
 
-         call MAPL_GetPointer(export, temp2d, "DTHVDTDYNINT", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "DTHVDTDYNINT", _RC)
          if(associated(temp2d)) then
             qsum1 = 0.0
             do k=1,km
@@ -1984,22 +1985,22 @@ contains
 
          ! Compute absolute vorticity on the D grid
          call getEPV(vars%pt, vort, ua, va, epvxyz)
-         call MAPL_GetPointer(export, temp3D, "EPV", _RC)
+         call MAPL_StateGetPointer(export, temp3D, "EPV", _RC)
          if(associated(temp3d)) temp3d = epvxyz*(p00**kappa)
 
          ! Compute Tropopause Pressure, Temperature, and Moisture
          doTropvars=.false.
-         call MAPL_GetPointer(export, temp2D, "TROPP_THERMAL", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TROPP_THERMAL", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, "TROPP_EPV", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TROPP_EPV", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, "TROPP_BLENDED", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TROPP_BLENDED", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, "TROPK_BLENDED", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TROPK_BLENDED", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, "TROPT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TROPT", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, "TROPQ", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TROPQ", _RC)
          if(associated(temp2D)) doTropvars=.true.
 
          if (doTropvars) then
@@ -2018,7 +2019,7 @@ contains
                  tropp1,tropp2,tropp3,tropt,tropq          )
 
             ! get blended index
-            call MAPL_GetPointer(export, temp2D, 'TROPK_BLENDED', _RC)
+            call MAPL_StateGetPointer(export, temp2D, 'TROPK_BLENDED', _RC)
             if( associated(temp2D) ) then
                kend = km
                do j=jfirstxy,jlastxy
@@ -2039,19 +2040,19 @@ contains
                enddo
             endif
 
-            call MAPL_GetPointer(export, temp2D, 'TROPP_THERMAL', _RC)
+            call MAPL_StateGetPointer(export, temp2D, 'TROPP_THERMAL', _RC)
             if(associated(temp2D)) temp2D = tropp1
 
-            call MAPL_GetPointer(export, temp2D, 'TROPP_EPV', _RC)
+            call MAPL_StateGetPointer(export, temp2D, 'TROPP_EPV', _RC)
             if(associated(temp2D)) temp2D = tropp2
 
-            call MAPL_GetPointer(export, temp2D, 'TROPP_BLENDED', _RC)
+            call MAPL_StateGetPointer(export, temp2D, 'TROPP_BLENDED', _RC)
             if(associated(temp2D)) temp2D = tropp3
 
-            call MAPL_GetPointer(export, temp2D, 'TROPT', _RC)
+            call MAPL_StateGetPointer(export, temp2D, 'TROPT', _RC)
             if(associated(temp2D)) temp2D = tropt
 
-            call MAPL_GetPointer(export, temp2D, 'TROPQ', _RC)
+            call MAPL_StateGetPointer(export, temp2D, 'TROPQ', _RC)
             if(associated(temp2D)) temp2D = tropq
 
             deallocate( tropp1 )
@@ -2146,7 +2147,7 @@ contains
 #ifdef SKIP_TRACERS
          do itracer = 1, ntracers
             write(myTracer, "('Q',i5.5)") itracer-1
-            call MAPL_GetPointer(export, temp3D, TRIM(myTracer), _RC)
+            call MAPL_StateGetPointer(export, temp3D, TRIM(myTracer), _RC)
             if((associated(temp3d)) .and. (NQ>=itracer)) then
                if (self%vars%tracer(itracer)%is_r4) then
                   temp3d = self%vars%tracer(itracer)%content_r4
@@ -2157,23 +2158,23 @@ contains
          enddo
 #endif
 
-         call MAPL_GetPointer(export, temp3D, 'PV', _RC)
+         call MAPL_StateGetPointer(export, temp3D, 'PV', _RC)
          if(associated(temp3d)) temp3d = epvxyz/vars%pt
 
-         call MAPL_GetPointer(export, temp3D, 'S', _RC)
+         call MAPL_StateGetPointer(export, temp3D, 'S', _RC)
          if(associated(temp3d)) temp3d = tempxy*cp
 
-         call MAPL_GetPointer(export, temp3d, 'TH', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'TH', _RC)
          !   if(associated(temp3d)) temp3d = vars%pt*(p00**kappa)
          if(associated(temp3d)) then
             temp3d = (tempxy)*(p00/(0.5*(vars%pe(:,:,1:km)+vars%pe(:,:,2:km+1))))**kappa
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'DMDTDYN', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'DMDTDYN', _RC)
          if(associated(temp2d)) temp2d = dmdt
 
          ! Compute 3-D Tracer Dynamics Tendencies
-         call MAPL_GetPointer(export, qctmp, 'QC', _RC)
+         call MAPL_StateGetPointer(export, qctmp, 'QC', _RC)
 
          if( associated(qctmp) ) then
             qctmp = 0.0
@@ -2238,7 +2239,7 @@ contains
          endif
 
          ! Compute 2-D Vertically Integrated Tracer Dynamics Tendencies
-         call MAPL_GetPointer(export, temp2D, 'DQVDTDYNINT', _RC)
+         call MAPL_StateGetPointer(export, temp2D, 'DQVDTDYNINT', _RC)
          if( associated(temp2D) ) then
             do k=1,km
                temp2d = temp2d + qv(:,:,k)*delp(:,:,k)
@@ -2246,7 +2247,7 @@ contains
             temp2d = temp2d/(grav*dt)
          endif
 
-         call MAPL_GetPointer(export, temp2D, 'DQLDTDYNINT', _RC)
+         call MAPL_StateGetPointer(export, temp2D, 'DQLDTDYNINT', _RC)
          if( associated(temp2D) ) then
             do N = 1,size(names)
                if( trim(names(N)).eq.'QLCN' .or. &
@@ -2265,7 +2266,7 @@ contains
             temp2d = temp2d/(grav*dt)
          endif
 
-         call MAPL_GetPointer(export, temp2D, 'DQIDTDYNINT', _RC)
+         call MAPL_StateGetPointer(export, temp2D, 'DQIDTDYNINT', _RC)
          if( associated(temp2D) ) then
             do N = 1,size(names)
                if( trim(names(N)).eq.'QICN' .or. &
@@ -2284,7 +2285,7 @@ contains
             temp2d = temp2d/(grav*dt)
          endif
 
-         call MAPL_GetPointer(export, temp2D, 'DOXDTDYNINT', _RC)
+         call MAPL_StateGetPointer(export, temp2D, 'DOXDTDYNINT', _RC)
          if( associated(temp2D) ) then
             do N = 1,size(names)
                pos = index(names(N),'::')
@@ -2308,12 +2309,12 @@ contains
          ! Virtual temperature
          tempxy =  tempxy*(1.0+eps*qv)
 
-         call MAPL_GetPointer(export, temp3D, 'TV', _RC)
+         call MAPL_StateGetPointer(export, temp3D, 'TV', _RC)
          if(associated(temp3D)) temp3D = tempxy
 
          ! Fluxes: UCPT & VCPT
          !--------------------
-         call MAPL_GetPointer(export, temp2d, 'UCPT', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'UCPT', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -2322,7 +2323,7 @@ contains
             temp2d = temp2d*(cp/grav)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VCPT', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VCPT', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -2334,7 +2335,7 @@ contains
          ! Compute Energetics After Dycore
          tempxy = vars%pt*(1.0+eps*qv)  ! Convert TH to THV
 
-         call MAPL_GetPointer(export, temp3d, 'THV', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'THV', _RC)
          if(associated(temp3d)) temp3d = tempxy
 
          if (doEnergetics) then
@@ -2342,11 +2343,11 @@ contains
             kedyn   = (kenrg -kenrg0)/DT
             pedyn   = (penrg -penrg0)/DT
             tedyn   = (tenrg -tenrg0)/DT
-            call MAPL_GetPointer(export, temp2d, 'KEDYN', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'KEDYN', _RC)
             if(associated(temp2d)) temp2d = kedyn
-            call MAPL_GetPointer(export, temp2d, 'PEDYN', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'PEDYN', _RC)
             if(associated(temp2d)) temp2d = pedyn
-            call MAPL_GetPointer(export, temp2d, 'TEDYN', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'TEDYN', _RC)
             if(associated(temp2d)) temp2d = tedyn
          endif
 
@@ -2354,8 +2355,8 @@ contains
          call getOmega(omaxyz)
 
          ! Fluxes: UKE & VKE
-         call MAPL_GetPointer(export, tempu, 'UKE', _RC)
-         call MAPL_GetPointer(export, tempv, 'VKE', _RC)
+         call MAPL_StateGetPointer(export, tempu, 'UKE', _RC)
+         call MAPL_StateGetPointer(export, tempv, 'VKE', _RC)
 
          if(associated(tempu) .or. associated(tempv)) then
             tmp3d = 0.5*(ur**2 + vr**2)
@@ -2378,7 +2379,7 @@ contains
          end if
 
          ! Fluxes: UQV & VQV
-         call MAPL_GetPointer(export, temp2d, 'UQV', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'UQV', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -2387,7 +2388,7 @@ contains
             temp2d = temp2d / grav
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VQV', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VQV', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -2397,7 +2398,7 @@ contains
          end if
 
          ! Fluxes: UQL & VQL
-         call MAPL_GetPointer(export, temp2d, 'UQL', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'UQL', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do N = 1,size(names)
@@ -2415,7 +2416,7 @@ contains
             temp2d = temp2d / grav
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VQL', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VQL', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do N = 1,size(names)
@@ -2434,7 +2435,7 @@ contains
          end if
 
          ! Fluxes: UQI & VQI
-         call MAPL_GetPointer(export, temp2d, 'UQI', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'UQI', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do N = 1,size(names)
@@ -2452,7 +2453,7 @@ contains
             temp2d = temp2d / grav
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VQI', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VQI', _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do N = 1,size(names)
@@ -2477,18 +2478,18 @@ contains
          enddo
          zle = zle/grav
 
-         call MAPL_GetPointer(export, temp3d, 'ZLE', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'ZLE', _RC)
          if(associated(temp3d)) temp3d = zle
 
-         call MAPL_GetPointer(export, temp3d, 'ZL', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'ZL', _RC)
          if(associated(temp3d)) temp3d = 0.5*( zle(:,:,:km)+zle(:,:,2:) )
 
-         call MAPL_GetPointer(export, temp3d, 'S', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'S', _RC)
          if(associated(temp3d)) temp3d = temp3d + grav*(0.5*( zle(:,:,:km)+zle(:,:,2:) ))
 
          ! Fluxes: UPHI & VPHI
-         call MAPL_GetPointer(export, tempu, 'UPHI', _RC)
-         call MAPL_GetPointer(export, tempv, 'VPHI', _RC)
+         call MAPL_StateGetPointer(export, tempu, 'UPHI', _RC)
+         call MAPL_StateGetPointer(export, tempv, 'VPHI', _RC)
 
          if( associated(tempu).or.associated(tempv) ) zl = 0.5*( zle(:,:,:km)+zle(:,:,2:) )
 
@@ -2512,7 +2513,7 @@ contains
          call MAPL_GridCompGetResource(gc, "HGT_SURFACE", HGT_SURFACE, default=HGT_SURFACE, _RC)
          if ( HGT_SURFACE .gt. 0.0 ) then
             ! Near surface height for surface
-            call MAPL_GetPointer(export, temp2d, 'DZ', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'DZ', _RC)
             if(associated(temp2d)) temp2d = HGT_SURFACE
 
             ! Get the height above the surface
@@ -2520,69 +2521,69 @@ contains
                zle(:,:,k) = zle(:,:,k) - zle(:,:,km+1)
             enddo
 
-            call MAPL_GetPointer(export, temp2d, 'PS', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'PS', _RC)
             if(associated(temp2d)) temp2d =  vars%pe(:,:,km+1)
 
-            call MAPL_GetPointer(export, temp2d, 'US', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'US', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, ur, -zle, -HGT_SURFACE, _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'VS', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'VS', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, vr, -zle, -HGT_SURFACE, _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'TA', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'TA', _RC)
             if(associated(temp2d)) then
                tempxy  = vars%pt * vars%pkz
                call VertInterp(temp2d, tempxy, -zle, -HGT_SURFACE, _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'QA', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'QA', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, qv, -zle, -HGT_SURFACE, positive_definite=.true., _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'SPEED', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'SPEED', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, sqrt(ur**2 + vr**2), -zle, -HGT_SURFACE, _RC)
             end if
          else
             ! Fill Surface with Lowest Model Level Variables
-            call MAPL_GetPointer(export, temp2d, 'DZ', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'DZ', _RC)
             if(associated(temp2d)) temp2d = 0.5*( zle(:,:,km)-zle(:,:,km+1) )
 
-            call MAPL_GetPointer(export, temp2d, 'PS', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'PS', _RC)
             if(associated(temp2d)) temp2d = vars%pe(:,:,km+1)
 
-            call MAPL_GetPointer(export, temp2d, 'US', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'US', _RC)
             if(associated(temp2d)) temp2d = ur(:,:,km)
 
-            call MAPL_GetPointer(export, temp2d, 'VS', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'VS', _RC)
             if(associated(temp2d)) temp2d = vr(:,:,km)
 
-            call MAPL_GetPointer(export, temp2d, 'TA', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'TA', _RC)
             if(associated(temp2d)) then
                tempxy = vars%pt * vars%pkz
                temp2d = tempxy(:,:,km)
             endif
 
-            call MAPL_GetPointer(export, temp2d, 'QA', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'QA', _RC)
             if(associated(temp2d)) temp2d = qv(:,:,km)
 
-            call MAPL_GetPointer(export, temp2d, 'SPEED', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'SPEED', _RC)
             if(associated(temp2d)) temp2d = sqrt( ur(:,:,km)**2 + vr(:,:,km)**2 )
          endif
 
 
-         call MAPL_GetPointer(export, temp2d, 'WSPD_10M', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'WSPD_10M', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, sqrt(ur**2 + vr**2), -zle, -10.0, _RC)
          end if
 
          if (.not. HYDROSTATIC) then
-            call MAPL_GetPointer(export, temp2d, 'VVEL_UP_100_1000', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'VVEL_UP_100_1000', _RC)
             if(associated(temp2d)) then
                temp2d = vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,km)
                do k=km-1,1,-1
@@ -2596,7 +2597,7 @@ contains
                   enddo
                enddo
             end if
-            call MAPL_GetPointer(export, temp2d, 'VVEL_DN_100_1000', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'VVEL_DN_100_1000', _RC)
             if(associated(temp2d)) then
                temp2d = vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,km)
                do k=km-1,1,-1
@@ -2613,11 +2614,11 @@ contains
          end if
 
          ! Updraft Helicty Exports
-         call MAPL_GetPointer(export,  uh25, 'UH25', ALLOC=.TRUE., _RC)
-         call MAPL_GetPointer(export,  uh03, 'UH03', ALLOC=.TRUE., _RC)
-         call MAPL_GetPointer(export, srh01,'SRH01', ALLOC=.TRUE., _RC)
-         call MAPL_GetPointer(export, srh03,'SRH03', ALLOC=.TRUE., _RC)
-         call MAPL_GetPointer(export, srh25,'SRH25', ALLOC=.TRUE., _RC)
+         call MAPL_GetPointer(export,  uh25, 'UH25', alloc=.true., _RC)
+         call MAPL_GetPointer(export,  uh03, 'UH03', alloc=.true., _RC)
+         call MAPL_GetPointer(export, srh01,'SRH01', alloc=.true., _RC)
+         call MAPL_GetPointer(export, srh03,'SRH03', alloc=.true., _RC)
+         call MAPL_GetPointer(export, srh25,'SRH25', alloc=.true., _RC)
          ! Per WMP, this calculation is not useful if running hydrostatic
          if (.not. HYDROSTATIC) then
             if( associated( uh25) .or. associated( uh03) .or. &
@@ -2629,49 +2630,49 @@ contains
          ! Divergence Exports
          logpe = log(vars%pe)
 
-         call MAPL_GetPointer(export, temp3d, 'DIVG', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'DIVG', _RC)
          if(associated(temp3d)) temp3d = divg
 
-         call MAPL_GetPointer(export, temp2d, 'DIVG200', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'DIVG200', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(divg), logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'DIVG500', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'DIVG500', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(divg), logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'DIVG700', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'DIVG700', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(divg), logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'DIVG850', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'DIVG850', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(divg), logpe, log(85000.), _RC)
          end if
 
          ! Vorticity Exports
-         call MAPL_GetPointer(export, temp3d, 'VORT', _RC)
+         call MAPL_StateGetPointer(export, temp3d, 'VORT', _RC)
          if(associated(temp3d)) temp3d = vort
 
-         call MAPL_GetPointer(export, temp2d, 'VORT200', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VORT200', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(vort), logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VORT500', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VORT500', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(vort), logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VORT700', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VORT700', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(vort), logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'VORT850', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'VORT850', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, dble(vort), logpe, log(85000.), _RC)
          end if
@@ -2679,27 +2680,27 @@ contains
          ! Vertical Velocity Exports
          call FILLOUT3(export, 'OMEGA', omaxyz, _RC)
 
-         call MAPL_GetPointer(export, temp2d, 'OMEGA850', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'OMEGA850', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, omaxyz, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'OMEGA700', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'OMEGA700', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, omaxyz, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'OMEGA500', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'OMEGA500', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, omaxyz, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'OMEGA200', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'OMEGA200', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, omaxyz, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'OMEGA10', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'OMEGA10', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, omaxyz, logpe, log(1000.), _RC)
          end if
@@ -2709,22 +2710,22 @@ contains
             call FILLOUT3(export, 'DELZ', vars%dz(ifirstxy:ilastxy,jfirstxy:jlastxy,:), _RC)
             call FILLOUT3(export, 'W', vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,:), _RC)
 
-            call MAPL_GetPointer(export, temp2d, 'W850', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'W850', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,:), logpe, log(85000.), _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'W500', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'W500', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,:), logpe, log(50000.), _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'W200', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'W200', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,:), logpe, log(20000.), _RC)
             end if
 
-            call MAPL_GetPointer(export, temp2d, 'W10', _RC)
+            call MAPL_StateGetPointer(export, temp2d, 'W10', _RC)
             if(associated(temp2d)) then
                call VertInterp(temp2d, vars%w(ifirstxy:ilastxy,jfirstxy:jlastxy,:), logpe, log(1000.), _RC)
             end if
@@ -3759,13 +3760,13 @@ contains
          allocate( dthdtphyint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
 
          doEnergetics=.false.
-         call MAPL_GetPointer(export, temp2D, "KE", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "KE", _RC)
          if(associated(temp2D)) doEnergetics=.true.
-         call MAPL_GetPointer(export, temp2D, "KEPHY", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "KEPHY", _RC)
          if(associated(temp2D)) doEnergetics=.true.
-         call MAPL_GetPointer(export, temp2D, "PEPHY", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "PEPHY", _RC)
          if(associated(temp2D)) doEnergetics=.true.
-         call MAPL_GetPointer(export, temp2D, "TEPHY", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "TEPHY", _RC)
          if(associated(temp2D)) doEnergetics=.true.
          if (doEnergetics) then
             allocate(  kenrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -3798,7 +3799,7 @@ contains
          allocate(  logpe(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
          allocate(    zle(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
 
-         call MAPL_GetPointer(import, PHIS, "PHIS", _RC)
+         call MAPL_StateGetPointer(import, PHIS, "PHIS", _RC)
 
          phisxy = real(phis,kind=r8)
 
@@ -3806,7 +3807,7 @@ contains
          dp = ( vars%pe(:,:,2:) - vars%pe (:,:,:km) )
 
          ! Load Specific Humidity
-         call MAPL_GetPointer(export, QOLD, 'Q', _RC)
+         call MAPL_StateGetPointer(export, QOLD, 'Q', _RC)
 
          call PULL_Q(self, import, qqq, iNXQ, _RC)
          if ((.not. ADIABATIC) .and. (self%grid%NQ > 0)) then
@@ -3833,7 +3834,7 @@ contains
          endif
 
          ! DTHVDTPHYINT
-         call MAPL_GetPointer(export, temp2D, "DTHVDTPHYINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DTHVDTPHYINT", _RC)
          if( associated(temp2D) ) then
             dthdtphyint1 = 0.0
             do k=1,km
@@ -3874,7 +3875,7 @@ contains
 
          if (doEnergetics) then
             call Energetics(ur,vr,thv,vars%pe,dp,vars%pkz,phisxy,kenrg,penrg,tenrg)
-            call MAPL_GetPointer(export, temp2d, "KE", _RC)
+            call MAPL_StateGetPointer(export, temp2d, "KE", _RC)
             if(associated(temp2d)) temp2d = kenrg
             kenrg = (kenrg-kenrg0)/DT
             penrg = (penrg-penrg0)/DT
@@ -3885,7 +3886,7 @@ contains
          endif
 
          ! DTHVDTPHYINT
-         call MAPL_GetPointer(export, temp2D, "DTHVDTPHYINT", _RC)
+         call MAPL_StateGetPointer(export, temp2D, "DTHVDTPHYINT", _RC)
          if( associated(temp2D) ) then
             dthdtphyint2 = 0.0
             do k=1,km
@@ -3925,13 +3926,13 @@ contains
          call FILLOUT3(export, "PT", vars%pt, _RC)
          call FILLOUT3(export, "PE", vars%pe, _RC)
 
-         call MAPL_GetPointer(export, temp3d, "TH", _RC)
+         call MAPL_StateGetPointer(export, temp3d, "TH", _RC)
          if(associated(temp3d)) temp3d = (tempxy)*(p00/(0.5*(vars%pe(:,:,1:km)+vars%pe(:,:,2:km+1))))**kappa
 
 #ifdef SKIP_TRACERS
          do itracer=1,ntracers
             write(myTracer, "('Q',i5.5)") itracer-1
-            call MAPL_GetPointer(export, temp3D, TRIM(myTracer), _RC)
+            call MAPL_StateGetPointer(export, temp3D, TRIM(myTracer), _RC)
             if((associated(temp3d)) .and. (self%grid%NQ>=itracer)) then
                if (self%vars%tracer(itracer)%is_r4) then
                   temp3d = self%vars%tracer(itracer)%content_r4
@@ -3952,230 +3953,230 @@ contains
          call FILLOUT3(export, "ZLE", zle, _RC)
 
          ! Compute Mid-Layer Heights
-         call MAPL_GetPointer(export, temp3d, "ZL", _RC)
+         call MAPL_StateGetPointer(export, temp3d, "ZL", _RC)
          if(associated(temp3d)) temp3d = 0.5*( zle(:,:,2:) + zle(:,:,:km) )
 
          ! Fill Single Level Variables
-         call MAPL_GetPointer(export, temp2d, "Z700", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Z700", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle*grav, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'Z500', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'Z500', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle*grav, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, 'Z300', _RC)
+         call MAPL_StateGetPointer(export, temp2d, 'Z300', _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle*grav, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H100", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H100", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H200", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H200", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H250", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H250", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H300", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H300", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H500", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H500", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H700", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H700", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H850", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H850", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle,logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "H1000", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "H1000", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, zle, logpe, log(100000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U50M", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U50M", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, -zle, -50., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V50M", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V50M", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, -zle, -50., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U100", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U100", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U200", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U200", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U250", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U250", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U300", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U300", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U500", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U500", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U700", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U700", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "U850", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "U850", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, ur, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V100", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V100", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V200", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V200", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V250", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V250", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V300", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V300", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V500", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V500", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V700", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V700", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "V850", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "V850", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, vr, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T100", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T100", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T200", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T200", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T250", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T250", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T300", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T300", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T500", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T500", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T700", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T700", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "T850", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "T850", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, tempxy, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q100", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q100", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(10000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q200", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q200", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(20000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q250", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q250", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(25000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q300", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q300", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(30000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q500", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q500", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(50000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q700", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q700", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(70000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export, temp2d, "Q850", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "Q850", _RC)
          if(associated(temp2d)) then
             call VertInterp(temp2d, qv, logpe, log(85000.), positive_definite=.true., _RC)
          end if
 
          ! Fill Model Top Level Variables
-         call MAPL_GetPointer(export, temp2d, "UTOP", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "UTOP", _RC)
          if(associated(temp2d)) temp2d = ur(:,:,1)
 
-         call MAPL_GetPointer(export, temp2d, "VTOP", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "VTOP", _RC)
          if(associated(temp2d)) temp2d = vr(:,:,1)
 
-         call MAPL_GetPointer(export, temp2d, "TTOP", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "TTOP", _RC)
          if(associated(temp2d)) temp2d = tempxy(:,:,1)
 
-         call MAPL_GetPointer(export, temp2d, "DELPTOP", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "DELPTOP", _RC)
          if(associated(temp2d)) temp2d = dp(:,:,1)
 
          ! Compute Surface Pressure
-         call MAPL_GetPointer(export, temp2d, "PS", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "PS", _RC)
          if(associated(temp2d)) temp2d=vars%pe(:,:,km+1)
 
          ! Get the height above the surface
@@ -4183,14 +4184,14 @@ contains
             zle(:,:,k) = zle(:,:,k) - zle(:,:,km+1)
          enddo
 
-         call MAPL_GetPointer(export, temp3d, "ZLE0", _RC)
+         call MAPL_StateGetPointer(export, temp3d, "ZLE0", _RC)
          if(associated(temp3d)) temp3d = zle
 
-         call MAPL_GetPointer(export, temp3d, "ZL0", _RC)
+         call MAPL_StateGetPointer(export, temp3d, "ZL0", _RC)
          if(associated(temp3d)) temp3d = 0.5*( zle(:,:,:km)+zle(:,:,2:) )
 
          ! Compute Vertically Averaged T,U
-         call MAPL_GetPointer(export, temp2d, "TAVE", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "TAVE", _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -4199,7 +4200,7 @@ contains
             temp2d = temp2d / (vars%pe(:,:,km+1)-vars%pe(:,:,1))
          endif
 
-         call MAPL_GetPointer(export, temp2d, "UAVE", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "UAVE", _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -4211,14 +4212,14 @@ contains
          ! Convert T to Tv
          tempxy = tempxy*(1.0+eps*qv)
 
-         call MAPL_GetPointer(export,temp3d, "TV", _RC)
+         call MAPL_StateGetPointer(export,temp3d, "TV", _RC)
          if(associated(temp3d)) temp3d=tempxy
 
          ! Compute Sea-Level Pressure
-         call MAPL_GetPointer(export, temp2d, "SLP", _RC)
-         call MAPL_GetPointer(export, Ztemp1, "H1000", _RC)
-         call MAPL_GetPointer(export, Ztemp2, "H850", _RC)
-         call MAPL_GetPointer(export, Ztemp3, "H500", _RC)
+         call MAPL_StateGetPointer(export, temp2d, "SLP", _RC)
+         call MAPL_StateGetPointer(export, Ztemp1, "H1000", _RC)
+         call MAPL_StateGetPointer(export, Ztemp2, "H850", _RC)
+         call MAPL_StateGetPointer(export, Ztemp3, "H500", _RC)
 
          if(associated(temp2d) .or. associated(ztemp1) &
               .or. associated(ztemp2) &
@@ -4500,10 +4501,10 @@ contains
          allocate( tend_un(is:ie  ,js:je+1,km) )
          allocate( tend_vn(is:ie+1,js:je  ,km) )
 
-         call MAPL_GetPointer(import, TEND, "DUDT", _RC)
+         call MAPL_StateGetPointer(import, TEND, "DUDT", _RC)
          tend_ua(is:ie,js:je,1:km) = tend
 
-         call MAPL_GetPointer(import, TEND, "DVDT", _RC)
+         call MAPL_StateGetPointer(import, TEND, "DVDT", _RC)
          tend_va(is:ie,js:je,1:km) = tend
 
          !if (.not. HYDROSTATIC ) then
@@ -4541,7 +4542,7 @@ contains
          ! ****                     Update Edge Pressures                    ****
          ! **********************************************************************
 
-         call MAPL_GetPointer(import, TEND, "DPEDT", _RC)
+         call MAPL_StateGetPointer(import, TEND, "DPEDT", _RC)
          self%vars%PE = self%vars%PE + DT*TEND
 
          ! **********************************************************************
@@ -4566,7 +4567,7 @@ contains
          ! ****                           b) D/Dt (T*DELP), IS_WEIGHTED=.T. ****
          ! *********************************************************************
 
-         call MAPL_GetPointer(import, TEND, "DTDT", _RC)
+         call MAPL_StateGetPointer(import, TEND, "DTDT", _RC)
 
          !if (DYN_DEBUG) then
          !   call prt_maxmin('AI PT1', self%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
@@ -4677,7 +4678,7 @@ contains
       real(r8), pointer :: cpl(:,:,:)
       integer :: status
 
-      call MAPL_GetPointer(export, cpl, name, _RC)
+      call MAPL_StateGetPointer(export, cpl, name, _RC)
       if(associated(cpl)) cpl = v
 
       _RETURN(_SUCCESS)
@@ -4692,7 +4693,7 @@ contains
       real(r4), pointer :: cpl(:,:,:)
       integer :: status
 
-      call MAPL_GetPointer(export, cpl, name, _RC)
+      call MAPL_StateGetPointer(export, cpl, name, _RC)
       if(associated(cpl)) cpl = v
 
       _RETURN(_SUCCESS)
@@ -4707,7 +4708,7 @@ contains
      real(r4), pointer :: cpl(:,:)
      integer :: status
 
-     call MAPL_GetPointer(export, cpl, name, _RC)
+     call MAPL_StateGetPointer(export, cpl, name, _RC)
      if(associated(cpl)) cpl = v
 
       _RETURN(_SUCCESS)
@@ -5019,21 +5020,21 @@ contains
          lats(:,:) = 15.0*PI/180.0
       endif
 
-      call MAPL_GetPointer(internal, U, "U", _RC) ! A-Grid U Wind
+      call MAPL_StateGetPointer(internal, U, "U", _RC) ! A-Grid U Wind
       is = lbound(U,1); ie = ubound(U,1)
       js = lbound(U,2); je = ubound(U,2)
       ks = lbound(U,3); ke = ubound(U,3)
       km = ke-ks+1
-      call MAPL_GetPointer(internal, V, "V", _RC) ! A-Grid V Wind
-      call MAPL_GetPointer(internal, PT, "PT", _RC) ! potential temperature
-      call MAPL_GetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
+      call MAPL_StateGetPointer(internal, V, "V", _RC) ! A-Grid V Wind
+      call MAPL_StateGetPointer(internal, PT, "PT", _RC) ! potential temperature
+      call MAPL_StateGetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
       PE(is:ie, js:je, 0:km) => PE1(is:ie, js:je, 1:km+1)
-      call MAPL_GetPointer(internal, PKZ , "PKZ", _RC) ! presssure ^ kappa at mid-layers
-      call MAPL_GetPointer(internal, ak1, "AK" , _RC) ! AK for vertical coordinate - 1 based
+      call MAPL_StateGetPointer(internal, PKZ , "PKZ", _RC) ! presssure ^ kappa at mid-layers
+      call MAPL_StateGetPointer(internal, ak1, "AK" , _RC) ! AK for vertical coordinate - 1 based
       ak(0:km) => ak1(1:km+1)
-      call MAPL_GetPointer(internal, bk1, "BK" , _RC) ! BK for vertical coordinate - 1 based
+      call MAPL_StateGetPointer(internal, bk1, "BK" , _RC) ! BK for vertical coordinate - 1 based
       bk(0:km) => bk1(1:km+1)
-      call MAPL_GetPointer(import, phis, "PHIS", _RC) ! surface geopotential
+      call MAPL_StateGetPointer(import, phis, "PHIS", _RC) ! surface geopotential
 
       U = 0.0
 

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -21,14 +21,14 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
    use MAPL_Constants, only: MAPL_VectorField, MAPL_BundleItem
    use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
+   use MAPL_Constants, only: MAPL_UNDEFINED_REAL
 
    use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
 
    use MAPL_GenericMod, only: MAPL_TimerAdd
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
-   use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_FieldBundleAdd
-   use MAPL_BaseMod, only: MAPL_UNDEF, MAPL_RemapBounds
+   use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_RemapBounds
    use MAPL_GridManagerMod, only: grid_manager
    use MAPL_RegridderManagerMod, only: regridder_manager
    use MAPL_RegridMethods, only: REGRID_METHOD_BILINEAR
@@ -47,6 +47,8 @@ module FVdycoreCubed_GridComp
    use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
    use mapl3g_Geom_API, only: MAPL_GridGet
    use mapl3g_State_API, only: MAPL_StateGetPointer
+   use mapl3g_Field_API, only: MAPL_FieldCreate
+   use mapl3g_FieldBundle_API, only: MAPL_FieldBundleAdd
    use pflogger, only: logger_t => logger
 
    use m_set_eta, only: set_eta
@@ -581,7 +583,7 @@ contains
          call ESMF_FieldBundleGet(tradv, fieldCount=numTracers, _RC)
          do i=1,numTracers
             call ESMF_FieldBundleGet(tradv, fieldIndex=i, field=field, _RC)
-            call MAPL_FieldBundleAdd(tradvex, field, _RC)
+            call MAPL_FieldBundleAdd(tradvex, [field], _RC)
          enddo
       end if
 
@@ -995,8 +997,10 @@ contains
                     (trim(fieldname) /= "QRAIN"   ) .and. &
                     (trim(fieldname) /= "QSNOW"   ) .and. &
                     (trim(fieldname) /= "QGRAUPEL") ) then
-                  write(STRING,"(A,A)") "FV3+ADV is excluding ", trim(fieldname)
-                  call WRITE_PARALLEL(trim(STRING))
+                  ! write(STRING,"(A,A)") "FV3+ADV is excluding ", trim(fieldname)
+                  ! call WRITE_PARALLEL(trim(STRING))
+                  call logger%info("Run:: FV3+ADV is excluding %s", trim(fieldname))
+
                   n = n + 1
                   if (n > size(xlist)) then
                      allocate(biggerlist(2*n), _STAT)
@@ -1014,7 +1018,7 @@ contains
                   end if
                end do
                if (.not. exclude) then
-                  call MAPL_FieldBundleAdd(BundleAdv, field, _RC)
+                  call MAPL_FieldBundleAdd(BundleAdv, [field], _RC)
                end if
             end do
 
@@ -1434,7 +1438,7 @@ contains
                where( qsum1.ne.0.0_r8 )
                   qsum2 = qsum1
                elsewhere
-                  qsum2 = MAPL_UNDEF
+                  qsum2 = MAPL_UNDEFINED_REAL
                end where
                call MAPL_AreaMean(TRSUM1(n), qsum2, area, esmfgrid, _RC)
             enddo
@@ -1482,7 +1486,7 @@ contains
                where( qsum1.ne.0.0_r8 )
                   qsum2 = qsum1
                elsewhere
-                  qsum2 = MAPL_UNDEF
+                  qsum2 = MAPL_UNDEFINED_REAL
                end where
                call MAPL_AreaMean(TRSUM2(n), qsum2, area, esmfgrid, _RC)
             enddo
@@ -1502,8 +1506,8 @@ contains
                     (trim(names(n)).ne."QSNOW") .and. &
                     (trim(names(n)).ne."QGRAUPEL")       ) then
 
-                  if( real(trsum1(n),kind=4).ne.MAPL_UNDEF .and. &
-                       real(trsum2(n),kind=4).ne.MAPL_UNDEF       ) then
+                  if(  real(trsum1(n),kind=4) .ne. MAPL_UNDEFINED_REAL .and. &
+                       real(trsum2(n),kind=4) .ne. MAPL_UNDEFINED_REAL) then
                      trsum2(n) = real( trsum1(n)/trsum2(n),kind=4)
                   else
                      trsum2(n) = 1.0d0
@@ -2019,7 +2023,7 @@ contains
                kend = km
                do j=jfirstxy,jlastxy
                   do i=ifirstxy,ilastxy
-                     if (tropp3(i,j) .NE. MAPL_UNDEF) then
+                     if (tropp3(i,j) .ne. MAPL_UNDEFINED_REAL) then
                         kend = 1
                         do while (vars%pe(i,j,kend).LE.tropp3(i,j))
                            kend = kend+1
@@ -2898,6 +2902,8 @@ contains
          integer, parameter :: iapproach=2 ! handle pressure more carefully
          logical :: do_remap, remap_all_tracers
 
+         call logger%info("Run::dump_n_splash_:: Starting...")
+
          do_remap = (cremap=="yes" .or. cremap=="YES")
          remap_all_tracers = (tremap=="yes" .or. tremap=="YES")
          nq3d=2 ! this routine only updates QV and OX
@@ -2931,9 +2937,7 @@ contains
             ana_u = vars%u(grid%is:grid%ie,grid%js:grid%je,1:km)
             ana_v = vars%v(grid%is:grid%ie,grid%js:grid%je,1:km)
          else if(iwind==1) then
-            status=1
-            call WRITE_PARALLEL('cannot handle single wind component')
-            _VERIFY(STATUS)
+            _FAIL("cannot handle single wind component")
          else if (iwind==2) then
 #ifdef INC_WINDS
             if (iapproach==1) then
@@ -2941,11 +2945,11 @@ contains
                allocate(cubeTEMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
                allocate(cubeVTMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
 #ifdef SCALAR_WINDS
-               call WRITE_PARALLEL('Replaying winds as scalars')
+               call logger%info("Run::dump_n_splash_:: Replaying winds as scalars")
                call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
                call l2c%regrid(YTMP3d, cubeVTMP3D, _RC)
 #else
-               call WRITE_PARALLEL('Replaying winds')
+               call logger%info("Run::dump_n_splash_:: Replaying winds")
                call l2c%regrid(XTMP3d, YTMP3d, cubeTEMP3d, cubeVTMP3d, rc=status)
 #endif /* SCALAR_WINDS */
                allocate( UAtmp(grid%is:grid%ie  ,grid%js:grid%je  ,km) )
@@ -2978,7 +2982,7 @@ contains
                UAtmpR4 = XTMP3d-UAtmpR4
                UAtmpR4 = VTMP3d-VAtmpR4
                ! convert the lat-lon A-grid wind increment back to the cubed
-               call WRITE_PARALLEL('Replaying winds')
+               call logger%info("Run::dump_n_splash_:: Replaying winds")
                call l2c%regrid(UAtmpR4, VAtmpR4, cubeTEMP3d, cubeVTMP3d, _RC)
                ! convert cubed wind increment to D-grid
                allocate( UDtmp(grid%is:grid%ie  ,grid%js:grid%je+1,km) )
@@ -3009,7 +3013,7 @@ contains
          ! PE or PS
          if( trim(dpname).ne.'NULL' ) then
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(dpname), XTMP3d, _RC)
-            call WRITE_PARALLEL('Replaying '//trim(dpname))
+            call logger%info("Run::dump_n_splash_:: Replaying "//trim(dpname))
             if ( iapproach == 1 ) then ! convert lat-lon delp to cubed and proceed
                allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
                call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
@@ -3047,7 +3051,7 @@ contains
          else
             if( trim(psname).ne.'NULL' ) then
                call ESMFL_BundleGetPointerToData(ana_bundle, trim(psname), XTMP2D, _RC)
-               call WRITE_PARALLEL('Replaying '//trim(psname))
+               call logger%info("Run::dump_n_splash_:: Replaying "//trim(psname))
                allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),1))
                allocate(     aux3D(size(XTMP2d ,1),size(XTMP2d ,2),1))
                if ( iapproach == 1 ) then ! convert lat-lon delp to cubed and proceed
@@ -3128,7 +3132,7 @@ contains
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(qname), XTMP3d, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
-            call WRITE_PARALLEL('Replaying '//trim(qname))
+            call logger%info("Run::dump_n_splash_:: Replaying "//trim(qname))
             if( qqq%is_r4 ) then
                qqq%content_r4 = max(0.,cubeTEMP3D)
             else
@@ -3147,7 +3151,7 @@ contains
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(tname), XTMP3d, _RC)
             allocate(cubeTEMP3D(size(ana_thv,1),size(ana_thv,2),km))
             call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
-            call WRITE_PARALLEL('Replaying '//trim(tname)// '; treated as '//trim(tvar))
+            call logger%info("Run::dump_n_splash_:: Replaying "//trim(tname)// '; treated as '//trim(tvar))
             if( trim(tvar).eq.'THETAV' ) ana_thv = cubeTEMP3D
             if( trim(tvar).eq.'TV'     ) ana_thv = cubeTEMP3D/ana_pkz
             if( trim(tvar).eq.'THETA' .or. &
@@ -3180,7 +3184,8 @@ contains
          deallocate( ana_pkxy    )
          deallocate( ana_thv     )
 
-         call WRITE_PARALLEL('Dump_n_Splash Replay Done')
+         call logger%info("Run::dump_n_splash_:: ...complete")
+
       end subroutine dump_n_splash_
 
       subroutine incremental_
@@ -3223,11 +3228,9 @@ contains
               trim(o3name).ne.'NULL'.and. &
               trim(tname ).ne.'NULL'.and.trim(qname ).ne.'NULL'
          if(.not.allhere) then
-            call WRITE_PARALLEL('Not all varibles needed for replay are available')
-            status = 999
-            _VERIFY(status)
+            _FAIL("Not all varibles needed for replay are available")
          endif
-         call WRITE_PARALLEL('Starting incremental replay')
+         call logger%info("Run::incremental_:: Starting...")
 
          ! U
          iwind=0
@@ -4240,9 +4243,9 @@ contains
 #endif
 
             if(associated(temp2d)) temp2d = slp
-            if(associated(ztemp1)) where( ztemp1.eq.MAPL_UNDEF ) ztemp1 = H1000
-            if(associated(ztemp2)) where( ztemp2.eq.MAPL_UNDEF ) ztemp2 = H850
-            if(associated(ztemp3)) where( ztemp3.eq.MAPL_UNDEF ) ztemp3 = H500
+            if(associated(ztemp1)) where( ztemp1.eq.MAPL_UNDEFINED_REAL ) ztemp1 = H1000
+            if(associated(ztemp2)) where( ztemp2.eq.MAPL_UNDEFINED_REAL ) ztemp2 = H850
+            if(associated(ztemp3)) where( ztemp3.eq.MAPL_UNDEFINED_REAL ) ztemp3 = H500
             deallocate(slp,H1000,H850,H500)
          end if
 
@@ -4890,7 +4893,7 @@ contains
 
       _ASSERT(edge .or. size(v3,3)==km,'needs informative message')
 
-      v2   = MAPL_UNDEF
+      v2 = MAPL_UNDEFINED_REAL
 
       if(EDGE) then
          pb   = ple(:,:,km+1)
@@ -4970,9 +4973,9 @@ contains
       real(REAL4), pointer :: lons(:,:), lats(:,:)
 
       integer :: i, j, k, n, L
-      ! integer :: IS, IE, JS, JE, KS, KE, IM, JM, KM, LS
       integer :: is, ie, js, je, ks, ke, im, jm, km, ls
       integer :: case_id, case_rotation, case_tracers
+      integer :: num_levels
 
       real :: T0
       real(REAL8) :: dummy_1, dummy_2, dummy_3, dummy_4, dummy_5, dummy_6
@@ -4995,10 +4998,10 @@ contains
       real(REAL4), pointer :: tracer(:,:,:)
       real(REAL8), allocatable :: Q5(:,:,:)
       real(REAL8), allocatable :: Q6(:,:,:)
+      type(ESMF_Geom) :: geom
       type(ESMF_Grid) :: esmfgrid
       type(ESMF_FieldBundle) :: tradv_bundle
-      character(len=ESMF_MAXSTR) :: fieldname
-      character(len=ESMF_MAXSTR) :: string
+      character(len=ESMF_MAXSTR) :: fieldname, string
       real(REAL8), parameter :: r0_6=0.6
       real(REAL8), parameter :: r1_0=1.0
 
@@ -5007,9 +5010,9 @@ contains
 
       call MAPL_GridCompGetResource(gc, "T0", T0, default=273., _RC)
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
+
       call MAPL_GridCompGet(gc, grid=esmfgrid, _RC)
       call MAPL_GridGet(esmfgrid, latitudes=lats, longitudes=lons, _RC)
-
       if (FV_Atm(1)%flagstruct%grid_type == 4) then
          ! Doubly-Period setup based on first LAT/LON coordinate
          lons(:,:) =  0.0
@@ -5346,19 +5349,19 @@ contains
          ! Parse Tracers
          if (FV3_STANDALONE /= 0) then
             call ESMF_StateGet(import, "TRADV", tradv_bundle, _RC)
-            call MAPL_GridCompGet(gc, grid=esmfgrid, _RC)
+            call MAPL_GridCompGet(gc, geom=geom, num_levels=num_levels, _RC)
 
             allocate(tracer(is:ie, js:je, 1:KM), _STAT)
             tracer(:,:,:)  = 0.0
             fieldname = 'Q'
-            call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+            call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
 
             if (case_tracers /= 1234) then
 
                do n=1,case_tracers
                   tracer(:,:,:) = 0.0
                   write(fieldname, "('Q',i3.3)") n
-                  call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+                  call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
                enddo
 
             else
@@ -5379,7 +5382,7 @@ contains
                   enddo
                enddo
                fieldname = 'Q1'
-               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, geom, num_Levels, fieldname)
 
                !-------------------
                !     tracer q2
@@ -5396,7 +5399,7 @@ contains
                   enddo
                enddo
                fieldname = 'Q2'
-               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
 
                !-------------------
                !     tracer q3
@@ -5413,14 +5416,14 @@ contains
                   enddo
                enddo
                fieldname = 'Q3'
-               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
 
                !-------------------
                !     tracer q4
                !-------------------
                tracer(:,:,:)  = 1.0_r4
                fieldname = 'Q4'
-               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
 
                !-------------------
                !     tracer q5
@@ -5428,7 +5431,7 @@ contains
                if (allocated(Q5)) then
                   tracer(:,:,:)  = Q5(:,:,:)
                   fieldname = 'Q5'
-                  call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+                  call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
                   deallocate(Q5, _STAT)
                endif
 
@@ -5438,7 +5441,7 @@ contains
                if (allocated(Q6)) then
                   tracer(:,:,:)  = Q6(:,:,:)
                   fieldname = 'Q6'
-                  call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
+                  call addTracer(self, tradv_bundle, tracer, geom, num_levels, fieldname, _RC)
                   deallocate(Q6, _STAT)
                endif
 
@@ -5747,34 +5750,37 @@ contains
    end subroutine set_eta
 #endif
 
-   subroutine addTracer_r8(self, bundle, var, grid, fieldname)
+   subroutine addTracer_r8(self, bundle, var, geom, num_levels, fieldname, rc)
       type(DynState), pointer :: self
       type(ESMF_FieldBundle) :: bundle
-      real(r8), pointer :: var(:, :, :)
-      type(ESMF_Grid) :: grid
-      type(ESMF_DistGrid) :: dist_grid
-      character(len=ESMF_MAXSTR) :: fieldname
+      real(r8), pointer :: var(:,:,:)
+      type(ESMF_Geom), intent(in) :: geom
+      integer, intent(in) :: num_levels
+      character(len=*), intent(in) :: fieldname
+      integer, optional, intent(out) :: rc
 
-      integer :: nq,rc,status
+      integer :: nq, status
       type(DynTracers), pointer :: t(:)
       type(ESMF_Field) :: field
-      real(r8), pointer :: ptr(:, :, :)
+      real(r8), pointer :: ptr(:,:,:)
 
-      call ESMF_GridGet(grid, distGrid=dist_grid, _RC)
       call ESMF_FieldBundleGet(bundle, fieldCount=nq, _RC)
-
       nq = nq + 1
 
-      field = ESMF_FieldCreate(grid, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, _RC)
-      ! pchakrab - TODO: Need to replace MAPL_VLocationCenter with VERTICAL_STAGGER_CENTER
-      ! pchakrab - TODO: need a replacement for MAPL_DimsHorzVert
-      ! call ESMF_AttributeSet(field, name='VLOCATION', value=MAPL_VLocationCenter, _RC)
-      ! call ESMF_AttributeSet(field, name='DIMS', value=MAPL_DimsHorzVert, rc=status)
-      call MAPL_FieldBundleAdd(bundle, field, _RC)
+      field = MAPL_FieldCreate( &
+           geom, typekind=ESMF_TYPEKIND_R8, &
+           name=fieldname, &
+           num_levels=num_levels, &
+           vert_staggerloc=VERTICAL_STAGGER_CENTER, &
+           units="unknown_units", &
+           standard_name="unknown_standard_name", &
+           long_name="unknown_long_name", _RC)
+      call ESMF_FieldGet(field, localDE=0, farrayPtr=ptr, _RC)
+      ptr = var
+      call MAPL_FieldBundleAdd(bundle, [field], _RC)
 
       if (nq == 1) then
          allocate(self%vars%tracer(nq), _STAT)
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          self%vars%tracer(nq)%content => ptr
          self%vars%tracer(nq)%is_r4 = .false.
       else
@@ -5782,9 +5788,8 @@ contains
          t(1:nq-1) = self%vars%tracer
          deallocate(self%vars%tracer)
          self%vars%tracer => t
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          self%vars%tracer(nq)%content => ptr
-         self%vars%tracer(nq  )%is_r4 = .false.
+         self%vars%tracer(nq)%is_r4 = .false.
       endif
 
       self%grid%nq = nq
@@ -5792,34 +5797,37 @@ contains
       _RETURN(_SUCCESS)
    end subroutine addTracer_r8
 
-   subroutine addTracer_r4(self, bundle, var, grid, fieldname)
+   subroutine addTracer_r4(self, bundle, var, geom, num_levels, fieldname, rc)
       type(DynState), pointer :: self
       type(ESMF_FieldBundle) :: bundle
-      real(r4), pointer :: var(:, :, :)
-      type(ESMF_Grid) :: grid
-      type(ESMF_DistGrid) :: dist_grid
-      character(len=ESMF_MAXSTR) :: fieldname
+      real(r4), pointer :: var(:,:,:)
+      type(ESMF_Geom), intent(in) :: geom
+      integer, intent(in) :: num_levels
+      character(len=*), intent(in) :: fieldname
+      integer, optional, intent(out) :: rc
 
-      integer :: nq,rc,status
+      integer :: nq, status
       type(DynTracers), pointer :: t(:)
       type(ESMF_Field) :: field
       real(r4), pointer :: ptr(:, :, :)
 
-      call ESMF_GridGet(grid, distGrid=dist_grid, _RC)
-      call ESMF_FieldBundleGet(bundle, fieldCount=NQ, _RC)
-
+      call ESMF_FieldBundleGet(bundle, fieldCount=nq, _RC)
       nq = nq + 1
 
-      field = ESMF_FieldCreate(grid, var, datacopyflag=ESMF_DATACOPY_VALUE, name=fieldname, _RC)
-      ! pchakrab - TODO: Need to replace MAPL_VLocationCenter with VERTICAL_STAGGER_CENTER
-      ! pchakrab - TODO: need a replacement for MAPL_DimsHorzVert
-      ! call ESMF_AttributeSet(field, name='VLOCATION', value=MAPL_VLocationCenter, _RC)
-      ! call ESMF_AttributeSet(field, name='DIMS', value=MAPL_DimsHorzVert, _RC)
-      call MAPL_FieldBundleAdd(bundle, field, _RC)
+      field = MAPL_FieldCreate( &
+           geom, typekind=ESMF_TYPEKIND_R4, &
+           name=fieldname, &
+           num_levels=num_levels, &
+           vert_staggerloc=VERTICAL_STAGGER_CENTER, &
+           units="unknown_units", &
+           standard_name="unknown_standard_name", &
+           long_name="unknown_long_name", _RC)
+      call ESMF_FieldGet(field, localDE=0, farrayPtr=ptr, _RC)
+      ptr = var
+      call MAPL_FieldBundleAdd(bundle, [field], _RC)
 
-      if (NQ == 1) then
+      if (nq == 1) then
          allocate(self%vars%tracer(nq), _STAT)
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          self%vars%tracer(nq)%content_r4 => ptr
          self%vars%tracer(nq)%is_r4 = .true.
       else
@@ -5827,9 +5835,8 @@ contains
          t(1:nq-1) = self%vars%tracer
          deallocate(self%vars%tracer)
          self%vars%tracer => t
-         call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          self%vars%tracer(nq)%content_r4 => ptr
-         self%vars%tracer(nq  )%is_r4 = .true.
+         self%vars%tracer(nq)%is_r4 = .true.
       endif
 
       self%grid%nq = nq

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -998,9 +998,7 @@ contains
                     (trim(fieldname) /= "QRAIN"   ) .and. &
                     (trim(fieldname) /= "QSNOW"   ) .and. &
                     (trim(fieldname) /= "QGRAUPEL") ) then
-                  ! write(STRING,"(A,A)") "FV3+ADV is excluding ", trim(fieldname)
-                  ! call WRITE_PARALLEL(trim(STRING))
-                  call logger%info("Run:: FV3+ADV is excluding %s", trim(fieldname))
+                  call logger%info("Run:: FV3+ADV is excluding "//trim(fieldname))
 
                   n = n + 1
                   if (n > size(xlist)) then
@@ -3254,11 +3252,11 @@ contains
             allocate(cubeTEMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
             allocate(cubeVTMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
 #ifdef SCALAR_WINDS
-            call WRITE_PARALLEL('Replaying increment of winds as scalars')
+            call logger%info("Replaying increment of winds as scalars")
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
             call l2c%regrid(VTMP3D, cubeVTMP3D, _RC)
 #else
-            call WRITE_PARALLEL('Replaying increment of winds')
+            call logger%info("Replaying increment of winds")
             call l2c%regrid(TEMP3d, VTMP3d, cubeTEMP3d, cubeVTMP3d, _RC)
 #endif /* SCALAR_WINDS */
             allocate( UAtmp(grid%is:grid%ie  ,grid%js:grid%je  ,km) )
@@ -3274,7 +3272,7 @@ contains
          ! DELP
          if( trim(psname)=='NULL' .and. trim(dpname).ne.'NULL' ) then
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(dpname), TEMP3D, _RC)
-            call WRITE_PARALLEL('Replaying increment of '//trim(dpname))
+            call logger%info("Replaying increment of "//trim(dpname))
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
             dpe(:,:,1) = 0.0
@@ -3299,7 +3297,7 @@ contains
          ! PS
          if( trim(psname)/='NULL' .and. trim(dpname)=='NULL' ) then
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(psname), TEMP2D, _RC)
-            call WRITE_PARALLEL('Replaying increment of '//trim(psname))
+            call logger%info("Replaying increment of %s", trim(psname))
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),1))
             allocate(     aux3D(size( TEMP2D,1),size( TEMP2D,2),1))
             aux3d(:,:,1) = TEMP2D ! same trick of putting in rank-3 array for transforms
@@ -3356,27 +3354,29 @@ contains
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(qname), TEMP3D, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
-            call WRITE_PARALLEL('Replaying increment of '//trim(qname))
+            call logger%info("Replaying increment of "//trim(qname))
             dqqv = cubeTEMP3D
             deallocate(cubeTEMP3D)
          endif
 
          ! PT
          if( trim(tname).ne.'NULL' ) then
-            if(trim(tvar).ne.'TV') then
-               call WRITE_PARALLEL('Error: Cannot Replay TVAR '//trim(tvar))
-               STATUS=99
-               _VERIFY(STATUS)
-            endif
-            if(trim(tname).ne.'tv') then
-               call WRITE_PARALLEL('Error: Cannot Replay TNAME '//trim(tname))
-               STATUS=99
-               _VERIFY(STATUS)
-            endif
+            _ASSERT(trim(tvar) .ne. "TV", "Cannot Replay TVAR " // trim(tvar))
+            ! if(trim(tvar).ne.'TV') then
+            !    call logger%info("Error: Cannot Replay TVAR "//trim(tvar))
+            !    STATUS=99
+            !    _VERIFY(STATUS)
+            ! endif
+            _ASSERT(trim(tname) .ne. "tv", "Cannot Replay TNAME " // trim(tname))
+            ! if(trim(tname).ne.'tv') then
+            !    call logger%info("Error: Cannot Replay TNAME "//trim(tname))
+            !    STATUS=99
+            !    _VERIFY(STATUS)
+            ! endif
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(tname), TEMP3D, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
-            call WRITE_PARALLEL('Replaying increment of '//trim(tname))
+            call logger%info("Replaying increment of "//trim(tname))
             ! have an incremental change to virtual temperature;
             ! want an incremental change to dry potential temperature
             ! calculate first incremental change to t-dry (save in dth for now)
@@ -3418,7 +3418,7 @@ contains
          deallocate( dpkz    )
          deallocate( dpkxy   )
 
-         call WRITE_PARALLEL('Incremental replay complete')
+         call logger%info("Incremental replay complete")
       end subroutine incremental_
 
       subroutine state_remap_
@@ -3454,13 +3454,14 @@ contains
                if (rank==3) nq3d=nq3d+1
             enddo
             write(STRING,'(A,I5,A)') "Found  ", nq3d, " 3d-tracers to remap"
-            call WRITE_PARALLEL( trim(STRING)   )
+            call logger%info(trim(STRING))
          endif
-         if (nq3d<2) then
-            call WRITE_PARALLEL('state_remap: invalid number of tracers')
-            status=999
-            _VERIFY(STATUS)
-         endif
+         _ASSERT(nq3d>=2, "state_remap: invalid number of tracers")
+         ! if (nq3d<2) then
+         !    call WRITE_PARALLEL('state_remap: invalid number of tracers')
+         !    status=999
+         !    _VERIFY(STATUS)
+         ! endif
 
          iib = lbound(vars%pe,1)
          iie = ubound(vars%pe,1)
@@ -3477,7 +3478,7 @@ contains
             ana_thv = vars%pt*(1.0+eps*qqq%content   (:,:,:))
          endif
 
-         call WRITE_PARALLEL('Replay start remapping')
+         call logger%info("Replay start remapping")
          !
          call ESMFL_BundleGetPointerToData(ana_bundle, 'phis', XTMP2D, _RC)
          allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),1))
@@ -3496,20 +3497,22 @@ contains
                if (rank==2) cycle
                if (rank==3) then
                   icnt=icnt+1
-                  if (icnt>nq3d) then
-                     call WRITE_PARALLEL('state_remap: number of tracers exceeds known value')
-                     status=999
-                     _VERIFY(STATUS)
-                  endif
+                  _ASSERT(icnt<=nq3d, "state_remap: number of tracers exceeds known value")
+                  ! if (icnt>nq3d) then
+                  !    call WRITE_PARALLEL('state_remap: number of tracers exceeds known value')
+                  !    status=999
+                  !    _VERIFY(STATUS)
+                  ! endif
                   call ESMFL_BundleGetPointerToData(BUNDLE, NAME, ptr3dr4, _RC)
                   ana_qq(:,:,:,icnt) = ptr3dr4
                endif
             enddo
-            if (icnt/=nq3d) then
-               call WRITE_PARALLEL('state_remap: inconsitent number of tracers')
-               status=999
-               _VERIFY(STATUS)
-            endif
+            _ASSERT(icnt==nq3d, "state_remap: inconsitent number of tracers")
+            ! if (icnt/=nq3d) then
+            !    call WRITE_PARALLEL('state_remap: inconsitent number of tracers')
+            !    status=999
+            !    _VERIFY(STATUS)
+            ! endif
          else
             if( qqq%is_r4 ) then
                ana_qq(:,:,:,1) = qqq%content_r4(:,:,:)
@@ -3577,7 +3580,7 @@ contains
                  / ( kappa*( log(vars%pe(:,:,k+1))-log(vars%pe(:,:,k)) ) )
          enddo
 
-         call WRITE_PARALLEL('Replay done remapping')
+         call logger%info("Replay done remapping")
 
          deallocate(ana_qq)
          deallocate(ana_thv)
@@ -5006,9 +5009,12 @@ contains
       real(REAL8), parameter :: r0_6=0.6
       real(REAL8), parameter :: r1_0=1.0
 
+      class(logger_t), pointer :: logger
+
       _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
       grid  => self%grid ! direct handle to grid
 
+      call MAPL_GridCompGet(gc, logger=logger, _RC)
       call MAPL_GridCompGetResource(gc, "T0", T0, default=273., _RC)
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
@@ -5111,7 +5117,7 @@ contains
          DYN_CASE = case_id
 
          write(string,'(A,I5,A)') "Initializing CASE_ID ", case_id, " in FVcubed:"
-         call WRITE_PARALLEL( trim(string) )
+         call logger%info(trim(string))
 
          ! Parse case_rotation
          if (case_rotation == -1) rot_ang =  0

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -49,6 +49,8 @@ module FVdycoreCubed_GridComp
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompAddSpec, MAPL_STATEITEM_FIELDBUNDLE
    use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
+   use mapl3g_Geom_API, only: MAPL_GridGet
+   use mapl3g_State_API, only: MAPL_StateGetPointer
    use pflogger, only: logger_t => logger
 
    use m_set_eta, only: set_eta
@@ -452,7 +454,6 @@ contains
    end subroutine SetServices
 
    subroutine Initialize(gc, import, export, clock, rc)
-
       !ARGUMENTS:
       type(ESMF_GridComp):: gc   ! composite gridded component
       type(ESMF_State) :: import ! import state
@@ -470,16 +471,15 @@ contains
       type(ESMF_Alarm) :: alarm
       type(ESMF_FieldBundle) :: tradv, tradvex
 
-      type(MAPL_MetaComp), pointer :: MAPL
-
       character(len=:), allocatable :: layout_file, ReplayMode
 
-      real(r4), pointer :: pref(:), ak4(:), bk4(:)
+      real(r4), pointer :: pref(:)
       real(r4), pointer :: ple(:,:,:)
       real(r4), pointer :: u(:,:,:), v(:,:,:), t(:,:,:)
       real(r4), pointer :: temp2d(:,:)
 
       real(r8), pointer ::  ak(:), bk(:)
+      real(r4), pointer ::  ak4(:), bk4(:)
       real(r8), pointer ::  ud(:,:,:), vd(:,:,:)
       real(r8), pointer ::  pe(:,:,:), pt(:,:,:), pk(:,:,:)
       real(r8), allocatable ::  ur(:,:,:), vr(:,:,:)
@@ -494,12 +494,9 @@ contains
       call MAPL_GridCompGet(gc, logger=logger, _RC)
       call logger%info("Initialize:: starting...")
 
-      ! Retrieve the pointer to the state
-      call MAPL_GetObjectFromGC(gc, MAPL, _RC)
-
-      ! Start the timers
-      call MAPL_TimerOn(MAPL, "TOTAL")
-      call MAPL_TimerOn(MAPL, "INITIALIZE")
+      ! ! Start the timers
+      ! call MAPL_TimerOn(MAPL, "TOTAL")
+      ! call MAPL_TimerOn(MAPL, "INITIALIZE")
 
       ! Get the private state
       call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
@@ -508,26 +505,27 @@ contains
       DycoreGrid  => state%grid ! direct handle to grid
 
       call MAPL_GridCompGetResource(gc, "LAYOUT", layout_file, default="fvcore_layout.rc", _RC)
-      call MAPL_GridCompGetResource(gc, 'DO_ADD_INCS:', DO_ADD_INCS, default=DO_ADD_INCS, _RC)
+      call MAPL_GridCompGetResource(gc, "DO_ADD_INCS", DO_ADD_INCS, default=DO_ADD_INCS, _RC)
 
       ! Check for ColdStart from the configuration
       call MAPL_GridCompGetResource(gc, "COLDSTART", ColdRestart, default=0, _RC)
       if (ColdRestart /= 0 ) then
          call Coldstart(gc, import, export, clock, _RC)
+         _HERE
       endif
 
       ! Set Private Internal State from Restart File
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
-      call MAPL_TimerOn(MAPL, "-DYN_INIT")
+      ! call MAPL_TimerOn(MAPL, "-DYN_INIT")
       call DynInit(state, clock, internal, import, gc, _RC)
-      call MAPL_TimerOff(MAPL, "-DYN_INIT")
+      ! call MAPL_TimerOff(MAPL, "-DYN_INIT")
 
       ! Create PLE and PREF EXPORT Coupling (Needs to be done only once per run)
+      call MAPL_GetPointer(export, ak4, "AK", _RC)
+      call MAPL_GetPointer(export, bk4, "BK", _RC)
       call MAPL_GetPointer(internal, ak, "AK", _RC)
       call MAPL_GetPointer(internal, bk, "BK", _RC)
-      call MAPL_GetPointer(export, ak4, "AK", ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, bk4, "BK", ALLOC=.true., _RC)
       call MAPL_GetPointer(export, pref, "PREF", ALLOC=.true., _RC)
       ak4 = ak
       bk4 = bk
@@ -625,11 +623,10 @@ contains
 
       !========End intermittent replay========================
 
-      call MAPL_TimerOff(MAPL,"INITIALIZE")
-      call MAPL_TimerOff(MAPL,"TOTAL")
+      ! call MAPL_TimerOff(MAPL,"INITIALIZE")
+      ! call MAPL_TimerOff(MAPL,"TOTAL")
 
       _RETURN(_SUCCESS)
-
    end subroutine Initialize
 
    !BOP
@@ -719,7 +716,7 @@ contains
       real(r8), allocatable ::delpold(:,:,:) ! temporary array
       real(r8), allocatable ::     ox(:,:,:) ! temporary array
       real(r8), allocatable ::     zl(:,:,:) ! temporary array
-      real(r8), allocatable ::    zle(:,:,:) ! temporary array 
+      real(r8), allocatable ::    zle(:,:,:) ! temporary array
       real(r8), allocatable ::  logpe(:,:,:) ! temporary array
       real(r8), allocatable ::   delp(:,:,:) ! temporary array
       real(r8), allocatable ::   dudt(:,:,:) ! temporary array
@@ -4009,7 +4006,7 @@ contains
          !  call Write_Profile(grid, tempxy, 'T')
          !#endif
 
-         if (DEBUG_DYN) then  
+         if (DEBUG_DYN) then
             call MAPL_MaxMin('DYN: Q_AF_INC ', qv)
             call MAPL_MaxMin('DYN: T_AF_INC ', tempxy, pmax=TMAX, pmin=TMIN)
             call MAPL_MaxMin('DYN: U_AF_INC ', ua)
@@ -4157,10 +4154,10 @@ contains
             VERIFY_(STATUS)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U100',  rc=status)         
-         VERIFY_(STATUS) 
-         if(associated(temp2d)) then                                    
-            call VertInterp(temp2d,ur,logpe,log(10000.)  ,  rc=status)     
+         call MAPL_GetPointer(export,temp2d,'U100',  rc=status)
+         VERIFY_(STATUS)
+         if(associated(temp2d)) then
+            call VertInterp(temp2d,ur,logpe,log(10000.)  ,  rc=status)
             VERIFY_(STATUS)
          end if
 
@@ -4178,10 +4175,10 @@ contains
             VERIFY_(STATUS)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U300',  rc=status)         
-         VERIFY_(STATUS) 
-         if(associated(temp2d)) then                                    
-            call VertInterp(temp2d,ur,logpe,log(30000.)  ,  rc=status)     
+         call MAPL_GetPointer(export,temp2d,'U300',  rc=status)
+         VERIFY_(STATUS)
+         if(associated(temp2d)) then
+            call VertInterp(temp2d,ur,logpe,log(30000.)  ,  rc=status)
             VERIFY_(STATUS)
          end if
 
@@ -4305,14 +4302,14 @@ contains
          end if
 
          call MAPL_GetPointer(export,temp2d,'Q100',  rc=status)
-         VERIFY_(STATUS) 
+         VERIFY_(STATUS)
          if(associated(temp2d)) then
             call VertInterp(temp2d,qv,logpe,log(10000.)  ,  positive_definite=.true., rc=status)
             VERIFY_(STATUS)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q200',  rc=status)         
-         VERIFY_(STATUS) 
+         call MAPL_GetPointer(export,temp2d,'Q200',  rc=status)
+         VERIFY_(STATUS)
          if(associated(temp2d)) then
             call VertInterp(temp2d,qv,logpe,log(20000.)  ,  positive_definite=.true., rc=status)
             VERIFY_(STATUS)
@@ -4325,10 +4322,10 @@ contains
             VERIFY_(STATUS)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q300',  rc=status)         
-         VERIFY_(STATUS) 
+         call MAPL_GetPointer(export,temp2d,'Q300',  rc=status)
+         VERIFY_(STATUS)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(30000.)  ,  positive_definite=.true., rc=status)     
+            call VertInterp(temp2d,qv,logpe,log(30000.)  ,  positive_definite=.true., rc=status)
             VERIFY_(STATUS)
          end if
 
@@ -4339,10 +4336,10 @@ contains
             VERIFY_(STATUS)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q700',  rc=status)         
-         VERIFY_(STATUS) 
+         call MAPL_GetPointer(export,temp2d,'Q700',  rc=status)
+         VERIFY_(STATUS)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(70000.)  ,  positive_definite=.true., rc=status)     
+            call VertInterp(temp2d,qv,logpe,log(70000.)  ,  positive_definite=.true., rc=status)
             VERIFY_(STATUS)
          end if
 
@@ -4838,10 +4835,10 @@ contains
                   do I=is,ie
                      if ( (STATE%VARS%PT(I,J,L) > 333.0) .OR. (STATE%VARS%PT(I,J,L)/=STATE%VARS%PT(I,J,L)) .OR. &
                           (Q(I,J,L,sphum  ) < 0.0) .OR. (Q(I,J,L,sphum  )/=Q(I,J,L,sphum  )) .OR. &
-                          (Q(I,J,L,liq_wat) < 0.0) .OR. (Q(I,J,L,liq_wat)/=Q(I,J,L,liq_wat)) .OR. & 
-                          (Q(I,J,L,ice_wat) < 0.0) .OR. (Q(I,J,L,ice_wat)/=Q(I,J,L,ice_wat)) .OR. & 
-                          (Q(I,J,L,rainwat) < 0.0) .OR. (Q(I,J,L,rainwat)/=Q(I,J,L,rainwat)) .OR. & 
-                          (Q(I,J,L,snowwat) < 0.0) .OR. (Q(I,J,L,snowwat)/=Q(I,J,L,snowwat)) .OR. & 
+                          (Q(I,J,L,liq_wat) < 0.0) .OR. (Q(I,J,L,liq_wat)/=Q(I,J,L,liq_wat)) .OR. &
+                          (Q(I,J,L,ice_wat) < 0.0) .OR. (Q(I,J,L,ice_wat)/=Q(I,J,L,ice_wat)) .OR. &
+                          (Q(I,J,L,rainwat) < 0.0) .OR. (Q(I,J,L,rainwat)/=Q(I,J,L,rainwat)) .OR. &
+                          (Q(I,J,L,snowwat) < 0.0) .OR. (Q(I,J,L,snowwat)/=Q(I,J,L,snowwat)) .OR. &
                           (Q(I,J,L,graupel) < 0.0) .OR. (Q(I,J,L,graupel)/=Q(I,J,L,graupel)) ) then
                         print *, "T or Q  spike detected : ", STATE%VARS%PT(I,J,L)
                         print *, "  Temp  ANA|PHY  Increment : ", (DT*TEND(I,J,L)*(MAPL_CP/CVM(I,J,L)))/DPNEW(I,J,L)
@@ -5212,144 +5209,102 @@ contains
 
       !ARGUMENTS:
       type(ESMF_GridComp), intent(inout) :: gc
-      type(ESMF_State),    intent(inout) :: import
-      type(ESMF_State),    intent(inout) :: export
-      type (ESMF_Clock),   intent(inout) :: clock
-      integer, intent(out), optional     :: rc
+      type(ESMF_State), intent(inout) :: import
+      type(ESMF_State), intent(inout) :: export
+      type (ESMF_Clock), intent(inout) :: clock
+      integer, intent(out), optional :: rc
       !EOP
 
-      character(len=ESMF_MAXSTR)        :: IAm="Coldstart"
-      character(len=ESMF_MAXSTR)        :: comp_name
       integer                           :: status
 
-      type (MAPL_MetaComp),     pointer :: MAPL
-      type (ESMF_State)                 :: INTERNAL
+      type(ESMF_State) :: internal
 
-      real(REAL8), pointer                 :: AK(:), BK(:)
-      real(REAL8), pointer                 :: U      (:,:,:)
-      real(REAL8), pointer                 :: V      (:,:,:)
-      real(REAL8), pointer                 :: PT     (:,:,:)
-      real(REAL8), pointer                 :: PE     (:,:,:)
-      real(REAL8), pointer                 :: PKZ    (:,:,:)
-      real(kind=4), pointer             :: phis   (:,:)
-      real(REAL4), pointer                     :: LONS   (:,:)
-      real(REAL4), pointer                     :: LATS   (:,:)
-      real                              :: T0
-      integer                           :: L
-      type(ESMF_Config)                 :: CF
-      integer                           :: i,j,k,n
-      integer                           :: IS,IE, JS,JE, KS,KE, IM,JM,KM, LS
+      real(REAL8), pointer :: AK1(:), BK1(:), AK(:), BK(:)
+      real(REAL8), pointer :: U(:,:,:), V(:,:,:), PT(:,:,:)
+      real(REAL8), pointer :: PE1(:,:,:), PE(:,:,:), PKZ(:,:,:)
+      real(REAL4), pointer :: phis(:,:)
+      real(REAL4), pointer :: lons(:,:), lats(:,:)
 
-      integer                     :: case_id
-      integer                     :: case_rotation
-      integer                     :: case_tracers
+      integer :: i, j, k, n, L
+      integer :: IS, IE, JS, JE, KS, KE, IM, JM, KM, LS
+      integer :: case_id, case_rotation, case_tracers
 
+      real :: T0
       real(REAL8) :: dummy_1, dummy_2, dummy_3, dummy_4, dummy_5, dummy_6
       real(REAL8) :: dz, ztop, height, pressure
       real(REAL8) :: LONc,LATc
       real(REAL8) :: eta, eta_top, rot_ang
       real(REAL8) :: ptop, pint
       real(REAL8), allocatable :: PS(:,:)
+
+      type(DYN_wrap) :: wrap
+      type(DynState), pointer :: state
+      type(DynGrid),  pointer :: grid
+
       logical :: perturb
       logical :: ak_is_missing = .false.
       logical :: bk_is_missing = .false.
       integer :: FV3_STANDALONE
-
-      type (DYN_wrap) :: wrap
-      type (DynState), pointer :: STATE
-      type (DynGrid),  pointer :: GRID
-
       logical :: isPresent
 
       ! Tracer Stuff
-      real(r4), pointer                :: TRACER(:,:,:)
-      real(REAL8), allocatable            :: Q5(:,:,:)
-      real(REAL8), allocatable            :: Q6(:,:,:)
-      type (ESMF_Grid)                 :: esmfGRID
-      type (ESMF_FieldBundle)          :: TRADV_BUNDLE
-      character(len=ESMF_MAXSTR)       :: FIELDNAME
-      character(len=ESMF_MAXSTR)       :: STRING
-      real(REAL8), parameter    :: r0_6=0.6
-      real(REAL8), parameter    :: r1_0=1.0
+      real(REAL4), pointer :: tracer(:,:,:)
+      real(REAL8), allocatable :: Q5(:,:,:)
+      real(REAL8), allocatable :: Q6(:,:,:)
+      type(ESMF_Grid) :: esmfgrid
+      type(ESMF_FieldBundle) :: tradv_bundle
+      character(len=ESMF_MAXSTR) :: fieldname
+      character(len=ESMF_MAXSTR) :: string
+      real(REAL8), parameter :: r0_6=0.6
+      real(REAL8), parameter :: r1_0=1.0
 
-      call ESMF_GridCompGet( gc, name=comp_name, CONFIG=CF, RC=STATUS )
-      VERIFY_(STATUS)
-      Iam = trim(comp_name) // trim(Iam)
-
-      ! Retrieve the pointer to the state
-      call MAPL_GetObjectFromGC (gc, MAPL,  RC=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, status)
-      VERIFY_(STATUS)
+      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
       state => wrap%dyn_state
-      grid  => state%grid   ! direct handle to grid
+      grid  => state%grid ! direct handle to grid
 
-      !BOR
-      ! !RESOURCE_ITEM: K :: Value of isothermal temperature on coldstart
-      call MAPL_GetResource ( MAPL, T0, 'T0:', default=273., RC=STATUS )
-      VERIFY_(STATUS)
-      !EOR
-      call MAPL_Get ( MAPL,                &
-           INTERNAL_ESMF_STATE=INTERNAL, &
-           lats = LATS,                  &
-           lons = LONS,                  &
-           RC=STATUS )
-      VERIFY_(STATUS)
+      call MAPL_GridCompGetResource(gc, "T0", T0, default=273., _RC)
+      call MAPL_GridCompGetInternalState(gc, internal, _RC)
+      call MAPL_GridCompGet(gc, grid=esmfgrid, _RC)
+      call MAPL_GridGet(esmfgrid, latitudes=lats, longitudes=lons, _RC)
 
       if (FV_Atm(1)%flagstruct%grid_type == 4) then
          ! Doubly-Period setup based on first LAT/LON coordinate
-         LONS(:,:) =  0.0
-         LATS(:,:) = 15.0*PI/180.0
+         lons(:,:) =  0.0
+         lats(:,:) = 15.0*PI/180.0
       endif
 
-      ! A-Grid U Wind
-      call MAPL_GetPointer(Internal,U,'U'  ,rc=STATUS)
-      VERIFY_(STATUS)
-      ! A-Grid V Wind
-      call MAPL_GetPointer(Internal,V,'V'  ,rc=STATUS)
-      ! Surface Geopotential
-      call MAPL_GetPointer ( import, phis, 'PHIS', RC=STATUS )
-      VERIFY_(STATUS)
-      ! Potential-Temperature
-      call MAPL_GetPointer(Internal,PT,'PT',rc=STATUS)
-      VERIFY_(STATUS)
-      ! Edge Pressures
-      call MAPL_GetPointer(Internal,PE  ,'PE',rc=STATUS)
-      VERIFY_(STATUS)
-      ! Presssure ^ kappa at mid-layers
-      call MAPL_GetPointer(Internal,PKZ ,'PKZ',rc=STATUS)
-      VERIFY_(STATUS)
-      ! AK and BK for vertical coordinate
-      call MAPL_GetPointer(Internal,ak  ,'AK' ,rc=STATUS)
-      VERIFY_(STATUS)
-      call MAPL_GetPointer(Internal,bk  ,'BK' ,rc=STATUS)
-      VERIFY_(STATUS)
+      call MAPL_GetPointer(internal, U, "U", _RC) ! A-Grid U Wind
+      IS = lbound(U,1); IE = ubound(U,1)
+      JS = lbound(U,2); JE = ubound(U,2)
+      KS = lbound(U,3); KE = ubound(U,3)
+      KM = KE-KS+1
+      call MAPL_GetPointer(internal, V, "V", _RC) ! A-Grid V Wind
+      call MAPL_GetPointer(internal, PT, "PT", _RC) ! potential temperature
+      call MAPL_GetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
+      PE(is:ie, js:je, 0:km) => PE1(is:ie, js:je, 1:km+1)
+      call MAPL_GetPointer(internal, PKZ , "PKZ", _RC) ! presssure ^ kappa at mid-layers
+      call MAPL_GetPointer(internal, ak1, "AK" , _RC) ! AK for vertical coordinate - 1 based
+      ak(0:km) => ak1(1:km+1)
+      call MAPL_GetPointer(internal, bk1, "BK" , _RC) ! BK for vertical coordinate - 1 based
+      bk(0:km) => bk1(1:km+1)
+      call MAPL_GetPointer(import, phis, "PHIS", _RC) ! surface geopotential
 
       U = 0.0
 
-      IS = lbound(U,1)
-      IE = ubound(U,1)
-      JS = lbound(U,2)
-      JE = ubound(U,2)
-      KS = lbound(U,3)
-      KE = ubound(U,3)
-      KM = KE-KS+1
-
       ALLOCATE( PS(IS:IE,JS:JE) )
 
-      call ESMF_ConfigGetAttribute( cf, IM, label='IM:', default=0 , rc = rc )
-      call ESMF_ConfigGetAttribute( cf, JM, label='JM:', default=0 , rc = rc )
+      call MAPL_GridCompGetResource(gc, "IM", IM, default=0, _RC)
+      call MAPL_GridCompGetResource(gc, "JM", JM, default=0, _RC)
 
       if (KM<=2) then   ! Shallow Water
 
-         call ESMF_ConfigGetAttribute( cf, case_id, label='CASE_ID:', default=1 , rc = rc )
+         call MAPL_GridCompGetResource(gc, "CASE_ID", case_id, default=1, _RC)
          DYN_CASE = case_id
 
          do j=JS,JE
             do i=IS,IE
-               LONc = LONS(i,j)
-               LATc = LATS(i,j)
+               LONc = lons(i,j)
+               LATc = lats(i,j)
                U(i,j,1)  = sw_uwnd(LONc,LATc,case_id)
                V(i,j,1)  = sw_vwnd(LONc,LATc,case_id)
                PE(i,j,0) = sw_phis(LONc,LATc,case_id)
@@ -5363,55 +5318,53 @@ contains
          U(IS:IE,JS:JE,KE) = .001*abs(lats(:,:))
          V = 0.0
 
-         call ESMF_ConfigFindLabel( cf, 'AK:', isPresent=isPresent, rc = status )
-         VERIFY_(STATUS)
-         if (isPresent) then
-            do L = 0, SIZE(AK)-1
-               call ESMF_ConfigNextLine  ( CF, rc=STATUS )
-               call ESMF_ConfigGetAttribute( cf, AK(L), rc = status )
-               VERIFY_(STATUS)
-            enddo
-         else
-            ak_is_missing = .true.
-         endif
+         ! pchakrab - TODO: read ak from resource file, if present
+         ! call ESMF_ConfigFindLabel( cf, 'AK:', isPresent=isPresent, rc = status )
+         ! VERIFY_(STATUS)
+         ! if (isPresent) then
+         !    do L = 0, SIZE(AK)-1
+         !       call ESMF_ConfigNextLine  ( CF, rc=STATUS )
+         !       call ESMF_ConfigGetAttribute( cf, AK(L), rc = status )
+         !       VERIFY_(STATUS)
+         !    enddo
+         ! else
+         ak_is_missing = .true.
+         ! endif
 
-         call ESMF_ConfigFindLabel( cf, 'BK:', isPresent=isPresent, rc = status )
-         VERIFY_(STATUS)
-         if (isPresent) then
-            do L = 0, SIZE(bk)-1
-               call ESMF_ConfigNextLine  ( CF, rc=STATUS )
-               call ESMF_ConfigGetAttribute( cf, BK(L), rc = status )
-               VERIFY_(STATUS)
-            enddo
-         else
-            bk_is_missing = .true.
-         endif
+         ! pchakrab - TODO: read bk from resource file, if present
+         ! call ESMF_ConfigFindLabel( cf, 'BK:', isPresent=isPresent, rc = status )
+         ! VERIFY_(STATUS)
+         ! if (isPresent) then
+         !    do L = 0, SIZE(bk)-1
+         !       call ESMF_ConfigNextLine  ( CF, rc=STATUS )
+         !       call ESMF_ConfigGetAttribute( cf, BK(L), rc = status )
+         !       VERIFY_(STATUS)
+         !    enddo
+         ! else
+         bk_is_missing = .true.
+         ! endif
 
          if (ak_is_missing .or. bk_is_missing) call set_eta(km, ls, ptop, pint, AK, BK)
-         
-         _ASSERT(ANY(AK /= 0.0) .or. ANY(BK /= 0.0),'needs informative message')
-         do L=lbound(PE,3),ubound(PE,3)
+         _ASSERT(any(AK /= 0.0) .or. any(BK /= 0.0), "needs informative message")
+
+         do L = lbound(PE,3), ubound(PE,3)
             PE(:,:,L) = AK(L) + BK(L)*MAPL_P00
          enddo
-
-         PKZ = 0.5*(PE(:,:,lbound(PE,3)  :ubound(PE,3)-1) + &
-              PE(:,:,lbound(PE,3)+1:ubound(PE,3)  ) )
+         PKZ = 0.5*( PE(:,:,lbound(PE,3):ubound(PE,3)-1) + PE(:,:,lbound(PE,3)+1:ubound(PE,3)) )
          PKZ = PKZ**MAPL_KAPPA
-
          PT = T0/PKZ
 
          ! Check if running standalone model
-         call ESMF_ConfigGetAttribute ( CF, FV3_STANDALONE, Label="FV3_STANDALONE:", default=0, RC=STATUS)
-         VERIFY_(STATUS)
+         call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", FV3_STANDALONE, default=0, _RC)
 
          ! 3D Baroclinic Test Cases
-         call ESMF_ConfigGetAttribute( cf, case_id      , label='CASE_ID:'      , default=0 , rc = rc )
-         call ESMF_ConfigGetAttribute( cf, case_rotation, label='CASE_ROTATION:', default=0 , rc = rc )
-         call ESMF_ConfigGetAttribute( cf, case_tracers , label='CASE_TRACERS:' , default=1234, rc = rc )
+         call MAPL_GridCompGetResource(gc, "CASE_ID", case_id, default=0, _RC)
+         call MAPL_GridCompGetResource(gc, "CASE_ROTATION", case_rotation, default=0 , _RC)
+         call MAPL_GridCompGetResource(gc, "CASE_TRACERS" , case_tracers, default=1234, _RC)
          DYN_CASE = case_id
 
-         write(STRING,'(A,I5,A)') "Initializing CASE_ID ", case_id, " in FVcubed:"
-         call WRITE_PARALLEL( trim(STRING) )
+         write(string,'(A,I5,A)') "Initializing CASE_ID ", case_id, " in FVcubed:"
+         call WRITE_PARALLEL( trim(string) )
 
          ! Parse case_rotation
          if (case_rotation == -1) rot_ang =  0
@@ -5435,8 +5388,8 @@ contains
                eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
                do j=JS,JE
                   do i=IS,IE
-                     LONc = LONS(i,j)
-                     LATc = LATS(i,j)
+                     LONc = lons(i,j)
+                     LATc = lats(i,j)
                      U(i,j,k) = u_wind(LONc,LATc,eta,perturb,rot_ang)
                      V(i,j,k) = v_wind(LONc,LATc,eta,perturb,rot_ang)
                      if (k==KS) phis(i,j) = surface_geopotential(LONc,LATc,rot_ang)
@@ -5453,8 +5406,8 @@ contains
                eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
                do j=JS,JE
                   do i=IS,IE
-                     LONc = LONS(i,j)
-                     LATc = LATS(i,j)
+                     LONc = lons(i,j)
+                     LATc = lats(i,j)
                      U(i,j,k) = u_wind(LONc,LATc,eta,perturb,rot_ang)
                      V(i,j,k) = v_wind(LONc,LATc,eta,perturb,rot_ang)
                      if (k==KS) phis(i,j) = surface_geopotential(LONc,LATc,rot_ang)
@@ -5476,10 +5429,8 @@ contains
 
             !PURE_ADVECTION = .true.
 
-            allocate( Q5(IS:IE, JS:JE, 0:KM-1), STAT=STATUS)
-            VERIFY_(STATUS)
-            allocate( Q6(IS:IE, JS:JE, 0:KM-1), STAT=STATUS)
-            VERIFY_(STATUS)
+            allocate(Q5(IS:IE, JS:JE, 0:KM-1), _STAT)
+            allocate(Q6(IS:IE, JS:JE, 0:KM-1), _STAT)
 
             ztop = 12000.0
             dz   = ztop/KM
@@ -5487,8 +5438,8 @@ contains
                height = (ztop - 0.5*dz) - (k)*dz  ! Layer middle height
                do j=JS,JE
                   do i=IS,IE
-                     LONc = LONS(i,j)
-                     LATc = LATS(i,j)
+                     LONc = lons(i,j)
+                     LATc = lats(i,j)
                      call  advection('56', LONc, LATc, height, rot_ang,  &
                           dummy_1, dummy_2, dummy_3, dummy_4, &
                           PS(i,j), Q5(i,j,k), Q6(i,j,k))
@@ -5518,8 +5469,8 @@ contains
 
             do j=JS,JE
                do i=IS,IE
-                  LONc = LONS(i,j)
-                  LATc = LATS(i,j)
+                  LONc = lons(i,j)
+                  LATc = lats(i,j)
                   pressure = 500.
                   call Rossby_Haurwitz(LONc,LATc, pressure, dummy_1, dummy_2, dummy_3, dummy_4, PS(i,j))
                   U(i,j,1)  = dummy_1
@@ -5534,8 +5485,8 @@ contains
             do k=KS,KE
                do j=JS,JE
                   do i=IS,IE
-                     LONc = LONS(i,j)
-                     LATc = LATS(i,j)
+                     LONc = lons(i,j)
+                     LATc = lats(i,j)
                      pressure = 0.5*(PE(i,j,k)+PE(i,j,k+1))
                      call Rossby_Haurwitz(LONc,LATc, pressure, dummy_1, dummy_2, dummy_3, dummy_4, PS(i,j))
                      U(i,j,k)  = dummy_1
@@ -5561,8 +5512,8 @@ contains
             do k=KS,KE
                do j=JS,JE
                   do i=IS,IE
-                     LONc = LONS(i,j)
-                     LATc = LATS(i,j)
+                     LONc = lons(i,j)
+                     LATc = lats(i,j)
                      pressure = 0.5*(PE(i,j,k)+PE(i,j,k+1))
                      call mountain_Rossby(case_rotation,LONc,LATc, pressure, dummy_1, dummy_2, dummy_3, dummy_4, PS(i,j))
                      U(i,j,k)  = dummy_1
@@ -5602,8 +5553,8 @@ contains
                height = (ztop - 0.5d0*dz) - (k)*dz  ! Layer middle height
                do j=JS,JE
                   do i=IS,IE
-                     LONc = LONS(i,j)
-                     LATc = LATS(i,j)
+                     LONc = lons(i,j)
+                     LATc = lats(i,j)
                      call gravity_wave(case_rotation, LONc,LATc, height, dummy_1, dummy_2, dummy_3, dummy_4, PS(i,j))
                      U(i,j,k)  = dummy_1
                      V(i,j,k)  = dummy_2
@@ -5619,8 +5570,8 @@ contains
                   height = ztop - k*dz  ! Layer edge height
                   do j=JS,JE
                      do i=IS,IE
-                        LONc = LONS(i,j)
-                        LATc = LATS(i,j)
+                        LONc = lons(i,j)
+                        LATc = lats(i,j)
                         call gravity_wave(case_rotation, LONc,LATc, height, dummy_1, dummy_2, dummy_3, dummy_4, dummy_5, pressure=dummy_6)
                         PE(i,j,k) = dummy_6
                         eta     = PE(i,j,k)/PS(i,j)
@@ -5635,7 +5586,7 @@ contains
             do L=lbound(PE,3),ubound(PE,3)
                PE(:,:,L) = AK(L) + BK(L)*PS(:,:)
             enddo
-            
+
             do k=KS,KE
                do j=JS,JE
                   do i=IS,IE
@@ -5653,25 +5604,21 @@ contains
          ! Parse Tracers
          !--------------------
          if (FV3_STANDALONE /= 0) then
-            call ESMF_StateGet(import, 'TRADV' , TRADV_BUNDLE,   RC=STATUS)
-            VERIFY_(STATUS)
+            call ESMF_StateGet(import, "TRADV", tradv_bundle, _RC)
+            call ESMF_GridCompGet(gc, grid=esmfgrid, _RC)
 
-            call ESMF_GridCompGet(gc, grid=esmfGRID, rc=STATUS)
-            VERIFY_(STATUS)
+            allocate(tracer(IS:IE, JS:JE, 1:KM), _STAT)
 
-            allocate( TRACER(IS:IE, JS:JE, 1:KM), STAT=STATUS)
-            VERIFY_(STATUS)
-
-            TRACER(:,:,:)  = 0.0
-            FIELDNAME = 'Q'
-            call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
+            tracer(:,:,:)  = 0.0
+            fieldname = 'Q'
+            call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
 
             if (case_tracers /= 1234) then
 
                do n=1,case_tracers
-                  TRACER(:,:,:)  = 0.0
-                  write(FIELDNAME, "('Q',i3.3)") n
-                  call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
+                  tracer(:,:,:) = 0.0
+                  write(fieldname, "('Q',i3.3)") n
+                  call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
                enddo
 
             else
@@ -5679,20 +5626,20 @@ contains
                !-------------------
                !     tracer q1
                !-------------------
-               TRACER(:,:,:) = 0.0
+               tracer(:,:,:) = 0.0
                do k=KS,KE
                   eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
                   do j=JS,JE
                      do i=IS,IE
-                        LONc = LONS(i,j)
-                        LATc = LATS(i,j)
+                        LONc = lons(i,j)
+                        LATc = lats(i,j)
                         dummy_1 = tracer_q1_q2(LONc,LATc,eta,rot_ang,r0_6)
-                        TRACER(i,j,k) = dummy_1
+                        tracer(i,j,k) = dummy_1
                      enddo
                   enddo
                enddo
-               FIELDNAME = 'Q1'
-               call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
+               fieldname = 'Q1'
+               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q2
@@ -5701,15 +5648,15 @@ contains
                   eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
                   do j=JS,JE
                      do i=IS,IE
-                        LONc = LONS(i,j)
-                        LATc = LATS(i,j)
+                        LONc = lons(i,j)
+                        LATc = lats(i,j)
                         dummy_1 = tracer_q1_q2(LONc,LATc,eta,rot_ang,r1_0)
-                        TRACER(i,j,k) = dummy_1
+                        tracer(i,j,k) = dummy_1
                      enddo
                   enddo
                enddo
-               FIELDNAME = 'Q2'
-               call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
+               fieldname = 'Q2'
+               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q3
@@ -5718,63 +5665,57 @@ contains
                   eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
                   do j=JS,JE
                      do i=IS,IE
-                        LONc = LONS(i,j)
-                        LATc = LATS(i,j)
+                        LONc = lons(i,j)
+                        LATc = lats(i,j)
                         dummy_1 = tracer_q3(LONc,LATc,eta,rot_ang)
-                        TRACER(i,j,k) = dummy_1
+                        tracer(i,j,k) = dummy_1
                      enddo
                   enddo
                enddo
-               FIELDNAME = 'Q3'
-               call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
+               fieldname = 'Q3'
+               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q4
                !-------------------
-               TRACER(:,:,:)  = 1.0_r4
-               FIELDNAME = 'Q4'
-               call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
-               VERIFY_(STATUS)
+               tracer(:,:,:)  = 1.0_r4
+               fieldname = 'Q4'
+               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q5
                !-------------------
                if (allocated(Q5)) then
-                  TRACER(:,:,:)  = Q5(:,:,:)
-                  FIELDNAME = 'Q5'
-                  call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
-                  VERIFY_(STATUS)
-                  deallocate( Q5, STAT=STATUS)
-                  VERIFY_(STATUS)
+                  tracer(:,:,:)  = Q5(:,:,:)
+                  fieldname = 'Q5'
+                  call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+                  deallocate(Q5, _STAT)
                endif
 
                !-------------------
                !     tracer q6
                !-------------------
                if (allocated(Q6)) then
-                  TRACER(:,:,:)  = Q6(:,:,:)
-                  FIELDNAME = 'Q6'
-                  call addTracer(STATE, TRADV_BUNDLE, TRACER, esmfGRID, FIELDNAME)
-                  VERIFY_(STATUS)
-                  deallocate( Q6, STAT=STATUS)
-                  VERIFY_(STATUS)
+                  tracer(:,:,:)  = Q6(:,:,:)
+                  fieldname = 'Q6'
+                  call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+                  deallocate(Q6, _STAT)
                endif
 
             endif
 
-            deallocate( TRACER, STAT=STATUS)
-            VERIFY_(STATUS)
+            deallocate(tracer, _STAT)
 
          endif
       endif
 
-      DEALLOCATE( PS )
+      deallocate(PS)
 
       DYN_COLDSTART=.true.
 
       _RETURN(_SUCCESS)
 
-   end subroutine COLDSTART
+   end subroutine Coldstart
 
 #ifdef MY_SET_ETA
    subroutine set_eta(km, ptop, ak, bk)
@@ -6387,7 +6328,7 @@ contains
             print*,' '
          End IF
       endif
-      
+
       deallocate(arr_global, glbArr)
 
    End Subroutine Write_Profile_R4

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -14,9 +14,35 @@ module FVdycoreCubed_GridComp
    !MODULE: FVdycoreCubed_GridComp --- Dynamical Core Grid Component
 
    !USES:
-   use ESMF                ! ESMF base class
-   use MAPL                ! GEOS base class
-   use m_set_eta,       only: set_eta
+   use ESMF
+   ! use MAPL
+   use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
+   use MAPL_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
+   use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
+   use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
+   use MAPL_Constants, only: MAPL_VectorField, MAPL_BundleItem
+   use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
+   use MAPL_Constants, only: MAPL_VLocationCenter, MAPL_VLocationEdge, MAPL_VLocationNone
+   use MAPL_Constants, only: MAPL_DimsHorzVert, MAPL_DimsHorzOnly, MAPL_DimsVertOnly
+   use MAPL_GenericMod, only: MAPL_GridCompSetEntryPoint, MAPL_MetaComp, MAPL_TimerAdd, MAPL_TimerOn
+   use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff
+   use MAPL_GenericMod, only: MAPL_GenericSetServices, MAPL_GenericInitialize, MAPL_GenericFinalize
+   use MAPL_GenericMod, only: MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_GridCreate, MAPL_Get
+   use MAPL_GenericMod, only: MAPL_AddImportSpec, MAPL_AddExportSpec, MAPL_AddInternalSpec
+   use MAPL_AbstractRegridderMod, only: AbstractRegridder
+   use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
+   use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_FieldBundleAdd
+   use MAPL_BaseMod, only: MAPL_UNDEF, MAPL_RemapBounds
+   use MAPL_GridManagerMod, only: grid_manager
+   use MAPL_RegridderManagerMod, only: regridder_manager
+   use MAPL_RegridMethods, only: REGRID_METHOD_BILINEAR
+   use MAPL_CFIOMod, only: MAPL_CFIORead
+   use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
+   use MAPL_FieldPointerUtilities, only: MAPL_FieldDestroy
+   use MAPL_MaxMinMod, only: MAPL_MaxMin
+   use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
+   use FileIOSharedMod, only: WRITE_PARALLEL
+   use m_set_eta, only: set_eta
 
    ! FV Specific Module
    use fv_arrays_mod,  only: REAL4, REAL8, FVPRC
@@ -2914,7 +2940,7 @@ contains
       !   call RunAddIncs(gc, import, export, clock, rc)
       !endif
 
-      RETURN_(ESMF_SUCCESS)
+      _RETURN(_SUCCESS)
 
    contains
 
@@ -3026,12 +3052,12 @@ contains
          ! U
          iwind=0
          if( trim(uname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(uname), XTMP3d, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(uname), XTMP3d, _RC)
             iwind=iwind+1
          endif
          ! V
          if( trim(vname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(vname), YTMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(vname), YTMP3D, _RC)
             iwind=iwind+1
          endif
 
@@ -3117,7 +3143,7 @@ contains
 
          ! PE or PS
          if( trim(dpname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(dpname), XTMP3d, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(dpname), XTMP3d, _RC)
             call WRITE_PARALLEL('Replaying '//trim(dpname))
             if ( iapproach == 1 ) then ! convert lat-lon delp to cubed and proceed
                allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
@@ -3155,7 +3181,7 @@ contains
             enddo
          else
             if( trim(psname).ne.'NULL' ) then
-               call ESMFL_BundleGetPointertoData(ana_bundle, trim(psname), XTMP2D, _RC)
+               call ESMFL_BundleGetPointerToData(ana_bundle, trim(psname), XTMP2D, _RC)
                call WRITE_PARALLEL('Replaying '//trim(psname))
                allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),1))
                allocate(     aux3D(size(XTMP2d ,1),size(XTMP2d ,2),1))
@@ -3196,7 +3222,7 @@ contains
 
          ! O3
          if( trim(o3name).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(o3name), XTMP3d, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(o3name), XTMP3d, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
 
@@ -3233,7 +3259,7 @@ contains
 
          ! QV
          if( trim(qname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(qname), XTMP3d, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(qname), XTMP3d, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
             call WRITE_PARALLEL('Replaying '//trim(qname))
@@ -3252,7 +3278,7 @@ contains
 
          ! PT
          if( trim(tname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(tname), XTMP3d, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(tname), XTMP3d, _RC)
             allocate(cubeTEMP3D(size(ana_thv,1),size(ana_thv,2),km))
             call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
             call WRITE_PARALLEL('Replaying '//trim(tname)// '; treated as '//trim(tvar))
@@ -3340,12 +3366,12 @@ contains
          ! U
          iwind=0
          if( trim(uname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(uname), TEMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(uname), TEMP3D, _RC)
             iwind=iwind+1
          endif
          ! V
          if( trim(vname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(vname), VTMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(vname), VTMP3D, _RC)
             iwind=iwind+1
          endif
 
@@ -3377,7 +3403,7 @@ contains
 
          ! DELP
          if( trim(psname)=='NULL' .and. trim(dpname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(dpname), TEMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(dpname), TEMP3D, _RC)
             call WRITE_PARALLEL('Replaying increment of '//trim(dpname))
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
@@ -3402,7 +3428,7 @@ contains
 
          ! PS
          if( trim(psname)/='NULL' .and. trim(dpname)=='NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(psname), TEMP2D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(psname), TEMP2D, _RC)
             call WRITE_PARALLEL('Replaying increment of '//trim(psname))
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),1))
             allocate(     aux3D(size( TEMP2D,1),size( TEMP2D,2),1))
@@ -3429,7 +3455,7 @@ contains
 
          ! O3
          if( trim(o3name).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(o3name), TEMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(o3name), TEMP3D, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
 
@@ -3456,7 +3482,7 @@ contains
 
          ! QV
          if( trim(qname).ne.'NULL' ) then
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(qname), TEMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(qname), TEMP3D, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
             call WRITE_PARALLEL('Replaying increment of '//trim(qname))
@@ -3476,7 +3502,7 @@ contains
                STATUS=99
                VERIFY_(STATUS)
             endif
-            call ESMFL_BundleGetPointertoData(ana_bundle, trim(tname), TEMP3D, _RC)
+            call ESMFL_BundleGetPointerToData(ana_bundle, trim(tname), TEMP3D, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
             call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
             call WRITE_PARALLEL('Replaying increment of '//trim(tname))
@@ -3582,7 +3608,7 @@ contains
 
          call WRITE_PARALLEL('Replay start remapping')
          !
-         call ESMFL_BundleGetPointertoData(ana_bundle, 'phis', XTMP2D, _RC)
+         call ESMFL_BundleGetPointerToData(ana_bundle, 'phis', XTMP2D, _RC)
          allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),1))
          allocate(     aux3D(size(XTMP2D ,1),size(XTMP2D ,2),1))
          aux3d(:,:,1)=XTMP2D ! this is a trick since the 2d interface to the transform has not worked for me (RT)
@@ -4543,7 +4569,7 @@ contains
       call MAPL_TimerOff(GENSTATE,"RUN2")
       call MAPL_TimerOff(GENSTATE,"TOTAL")
 
-      RETURN_(ESMF_SUCCESS)
+      _RETURN(_SUCCESS)
    end subroutine RunAddIncs
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -5119,7 +5145,7 @@ contains
       call MAPL_GenericFinalize ( gc, import, export, clock,  RC=STATUS)
       VERIFY_(STATUS)
 
-      RETURN_(ESMF_SUCCESS)
+      _RETURN(_SUCCESS)
 
    contains
 
@@ -5250,7 +5276,7 @@ contains
          endif
       endif
 
-      RETURN_(ESMF_SUCCESS)
+      _RETURN(_SUCCESS)
    end subroutine VertInterp
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -5836,7 +5862,7 @@ contains
 
       DYN_COLDSTART=.true.
 
-      RETURN_(ESMF_SUCCESS)
+      _RETURN(_SUCCESS)
 
    end subroutine COLDSTART
 

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -550,14 +550,11 @@ contains
 
       allocate(ur(ifirst:ilast,jfirst:jlast,km))
       allocate(vr(ifirst:ilast,jfirst:jlast,km))
-
       call getAllWinds(ud, vd, ur=ur, vr=vr)
-
       u = ur
       v = vr
       t = pt*pk
       ple = pe
-
       deallocate(ur, vr)
 
       ! Fill Grid-Cell Area Delta-X/Y
@@ -5606,7 +5603,6 @@ contains
             call MAPL_GridCompGet(gc, grid=esmfgrid, _RC)
 
             allocate(tracer(is:ie, js:je, 1:KM), _STAT)
-
             tracer(:,:,:)  = 0.0
             fieldname = 'Q'
             call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
@@ -5704,7 +5700,8 @@ contains
 
             deallocate(tracer, _STAT)
 
-         endif
+         endif ! parse tracers
+
       endif
 
       deallocate(PS)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -622,6 +622,7 @@ contains
       ! call MAPL_TimerOff(MAPL,"INITIALIZE")
       ! call MAPL_TimerOff(MAPL,"TOTAL")
 
+      call logger%info("Initialize:: ...complete")
       _RETURN(_SUCCESS)
    end subroutine Initialize
 
@@ -654,16 +655,15 @@ contains
       integer :: status
       type(ESMF_FieldBundle) :: bundle, ana_bundle
       type(ESMF_Field) :: field, ana_field
-      type(ESMF_Config) :: cf
       type(ESMF_Alarm) :: alarm
       type(ESMF_Grid) :: esmfgrid, ana_grid
       type(ESMF_Time) :: current_time, RefTime
+      type(ESMF_HConfig) :: hconfig
+
       class(AbstractRegridder), pointer :: L2C, C2L
 
-      type(MAPL_MetaComp), pointer :: MAPL
-
       type(DYN_wrap) :: wrap
-      type(DynState), pointer :: STATE
+      type(DynState), pointer :: state
       type(DynGrid), pointer :: grid
       type(DynVars), pointer :: vars
 
@@ -740,22 +740,22 @@ contains
       real(r8), allocatable :: pedyn (:,:)
       real(r8), allocatable :: tedyn (:,:)
 
-      real(kind=4), allocatable :: dqvdtanaint1(:,:)
-      real(kind=4), allocatable :: dqvdtanaint2(:,:)
-      real(kind=4), allocatable :: dqldtanaint1(:,:)
-      real(kind=4), allocatable :: dqldtanaint2(:,:)
-      real(kind=4), allocatable :: dqidtanaint1(:,:)
-      real(kind=4), allocatable :: dqidtanaint2(:,:)
-      real(kind=4), allocatable :: doxdtanaint1(:,:)
-      real(kind=4), allocatable :: doxdtanaint2(:,:)
-      real(kind=4), allocatable :: dthdtanaint1(:,:)
-      real(kind=4), allocatable :: dthdtanaint2(:,:)
+      real(r4), allocatable :: dqvdtanaint1(:,:)
+      real(r4), allocatable :: dqvdtanaint2(:,:)
+      real(r4), allocatable :: dqldtanaint1(:,:)
+      real(r4), allocatable :: dqldtanaint2(:,:)
+      real(r4), allocatable :: dqidtanaint1(:,:)
+      real(r4), allocatable :: dqidtanaint2(:,:)
+      real(r4), allocatable :: doxdtanaint1(:,:)
+      real(r4), allocatable :: doxdtanaint2(:,:)
+      real(r4), allocatable :: dthdtanaint1(:,:)
+      real(r4), allocatable :: dthdtanaint2(:,:)
 
-      real(kind=4), allocatable :: tropp1(:,:)   ! Tropopause Pressure
-      real(kind=4), allocatable :: tropp2(:,:)   ! Tropopause Pressure
-      real(kind=4), allocatable :: tropp3(:,:)   ! Tropopause Pressure
-      real(kind=4), allocatable :: tropt (:,:)   ! Tropopause Temperature
-      real(kind=4), allocatable :: tropq (:,:)   ! Tropopause Specific Humidity
+      real(r4), allocatable :: tropp1(:,:)   ! Tropopause Pressure
+      real(r4), allocatable :: tropp2(:,:)   ! Tropopause Pressure
+      real(r4), allocatable :: tropp3(:,:)   ! Tropopause Pressure
+      real(r4), allocatable :: tropt (:,:)   ! Tropopause Temperature
+      real(r4), allocatable :: tropq (:,:)   ! Tropopause Specific Humidity
 
       real(r8), allocatable :: omaxyz(:,:,:) ! vertical pressure velocity (pa/sec)
       real(r8), allocatable :: epvxyz(:,:,:) ! ertel's potential vorticity
@@ -770,35 +770,35 @@ contains
       real(r8), allocatable :: trsum1(:)     ! Global Sum of Tracers before Add_Incs
       real(r8), allocatable :: trsum2(:)     ! Global Sum of Tracers after  Add_Incs
 
-      real(kind=4), pointer ::      dudtana(:,:,:)
-      real(kind=4), pointer ::      dvdtana(:,:,:)
-      real(kind=4), pointer ::      dtdtana(:,:,:)
-      real(kind=4), pointer ::     ddpdtana(:,:,:)
-      real(kind=4), pointer ::       qctmp (:,:,:)
-      real(kind=4), pointer ::       dqldt (:,:,:)
-      real(kind=4), pointer ::       dqidt (:,:,:)
-      real(kind=4), pointer ::       doxdt (:,:,:)
-      real(kind=4), pointer ::      dqvana (:,:,:)
-      real(kind=4), pointer ::      dqlana (:,:,:)
-      real(kind=4), pointer ::      dqiana (:,:,:)
-      real(kind=4), pointer ::      dqrana (:,:,:)
-      real(kind=4), pointer ::      dqsana (:,:,:)
-      real(kind=4), pointer ::      dqgana (:,:,:)
-      real(kind=4), pointer ::      doxana (:,:,:)
-      real(kind=4), pointer ::       temp3d(:,:,:)
-      real(kind=4), pointer ::       vtmp3d(:,:,:)
-      real(kind=4), pointer ::         area(:,:)
-      real(kind=4), pointer ::       temp2d(:,:)
-      real(kind=4), pointer ::       tempu (:,:)
-      real(kind=4), pointer ::       tempv (:,:)
-      real(kind=4), allocatable ::   cubetemp3d(:,:,:)
-      real(kind=4), allocatable ::   cubevtmp3d(:,:,:)
+      real(r4), pointer ::      dudtana(:,:,:)
+      real(r4), pointer ::      dvdtana(:,:,:)
+      real(r4), pointer ::      dtdtana(:,:,:)
+      real(r4), pointer ::     ddpdtana(:,:,:)
+      real(r4), pointer ::       qctmp (:,:,:)
+      real(r4), pointer ::       dqldt (:,:,:)
+      real(r4), pointer ::       dqidt (:,:,:)
+      real(r4), pointer ::       doxdt (:,:,:)
+      real(r4), pointer ::      dqvana (:,:,:)
+      real(r4), pointer ::      dqlana (:,:,:)
+      real(r4), pointer ::      dqiana (:,:,:)
+      real(r4), pointer ::      dqrana (:,:,:)
+      real(r4), pointer ::      dqsana (:,:,:)
+      real(r4), pointer ::      dqgana (:,:,:)
+      real(r4), pointer ::      doxana (:,:,:)
+      real(r4), pointer ::       temp3d(:,:,:)
+      real(r4), pointer ::       vtmp3d(:,:,:)
+      real(r4), pointer ::         area(:,:)
+      real(r4), pointer ::       temp2d(:,:)
+      real(r4), pointer ::       tempu (:,:)
+      real(r4), pointer ::       tempv (:,:)
+      real(r4), allocatable ::   cubetemp3d(:,:,:)
+      real(r4), allocatable ::   cubevtmp3d(:,:,:)
 
-      real(kind=4), pointer :: uh25(:,:)
-      real(kind=4), pointer :: uh03(:,:)
-      real(kind=4), pointer :: srh01(:,:)
-      real(kind=4), pointer :: srh03(:,:)
-      real(kind=4), pointer :: srh25(:,:)
+      real(r4), pointer :: uh25(:,:)
+      real(r4), pointer :: uh03(:,:)
+      real(r4), pointer :: srh01(:,:)
+      real(r4), pointer :: srh03(:,:)
+      real(r4), pointer :: srh25(:,:)
 
       real(r8),     allocatable ::   uatmp(:,:,:)
       real(r8),     allocatable ::   vatmp(:,:,:)
@@ -807,20 +807,15 @@ contains
 
       character(len=ESMF_MAXSTR), ALLOCATABLE       :: NAMES (:)
       character(len=ESMF_MAXSTR), ALLOCATABLE       :: NAMES0(:)
-      character(len=ESMF_MAXSTR) :: IAm
-      character(len=ESMF_MAXSTR) :: comp_name
       character(len=ESMF_MAXSTR) :: STRING
-      character(len=ESMF_MAXSTR) :: ReplayFile
-      character(len=ESMF_MAXSTR) :: ReplayType
-      character(len=ESMF_MAXSTR) :: ReplayMode
-      character(len=ESMF_MAXSTR) :: cremap,tremap
-      character(len=ESMF_MAXSTR) :: uname,vname,tname,qname,psname,dpname,o3name,rgrid,tvar
+      character(len=:), allocatable :: ReplayMode, ReplayFile, ReplayType
+      character(len=:), allocatable :: cremap,tremap
+      character(len=:), allocatable :: uname,vname,tname,qname,psname,dpname,o3name,rgrid,tvar
 
-      type(MAPL_SunOrbit)        :: ORBIT
-      real(kind=4), pointer      :: LATS(:,:)
-      real(kind=4), pointer      :: LONS(:,:)
-      real(kind=4), allocatable  ::  ZTH(:,:)
-      real(kind=4), allocatable  ::  SLR(:,:)
+      type(MAPL_SunOrbit) :: ORBIT
+      real(r4), pointer :: lats(:,:), lons(:,:)
+      real(r4), allocatable  ::  ZTH(:,:)
+      real(r4), allocatable  ::  SLR(:,:)
 
       real                  :: rc_blend_p_above
       real                  :: rc_blend_p_below
@@ -829,8 +824,8 @@ contains
 
       real                  :: HGT_SURFACE
 
-      character(len=ESMF_MAXSTR) :: ANA_IS_WEIGHTED
-      logical                    ::     IS_WEIGHTED
+      character(len=:), allocatable :: ANA_IS_WEIGHTED
+      logical                    ::     is_weighted
 
       type(DynTracers)            :: qqq       ! Specific Humidity
       type(DynTracers)            :: ooo       ! ox
@@ -848,10 +843,8 @@ contains
       logical                             :: exclude
       character(len=ESMF_MAXSTR)          :: tmpstring
       character(len=ESMF_MAXSTR)          :: fieldname
-      character(len=ESMF_MAXSTR)          :: adjustTracerMode
-      character(len=ESMF_MAXSTR), allocatable :: xlist(:)
+      character(len=:), allocatable :: adjustTracerMode, xlist(:)
       character(len=ESMF_MAXSTR), allocatable :: biggerlist(:)
-      integer, parameter                  :: XLIST_MAX = 60
       logical                             :: isPresent
 
       logical                             :: doEnergetics
@@ -862,139 +855,121 @@ contains
       character(len=ESMF_MAXSTR) :: myTracer
       integer :: itracer
       real(kind=r8) :: t1, t2, dyn_run_timer
+      class(logger_t), pointer :: logger
 
-      Iam = "Run"
-      call ESMF_GridCompGet(gc, name=comp_name, CONFIG=cf, grid=esmfgrid, _RC)
-      Iam = trim(comp_name) // trim(Iam)
-
+      call MAPL_GridCompGet(gc, grid=esmfgrid, hconfig=hconfig, logger=logger, _RC)
+      call logger%info("Run:: starting...")
       call ESMF_GridValidate(esmfgrid, _RC)
 
-      ! Retrieve the pointer to the generic state
-      call MAPL_GetObjectFromGC(gc, MAPL, _RC)
+      ! call MAPL_TimerOn(MAPL, "TOTAL")
+      ! call MAPL_TimerOn(MAPL, "RUN")
 
-      call MAPL_TimerOn(MAPL, "TOTAL")
-      call MAPL_TimerOn(MAPL, "RUN")
-
-      call MAPL_Get(MAPL, LONS=LONS, LATS=LATS, _RC)
-
-      call MAPL_GetPointer(export, temp2d, 'LONS', _RC)
-      if( associated(temp2D) ) temp2d = LONS
-      call MAPL_GetPointer(export, temp2d, 'LATS', _RC)
-      if( associated(temp2D) ) temp2d = LATS
+      call MAPL_GridGet(esmfgrid, longitudes=lons, latitudes=lats, _RC)
+      call MAPL_GetPointer(export, temp2d, "LONS", _RC)
+      if( associated(temp2D) ) temp2d = lons
+      call MAPL_GetPointer(export, temp2d, "LATS", _RC)
+      if( associated(temp2D) ) temp2d = lats
 
       ! Retrieve the pointer to the internal state
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, status)
-      VERIFY_(STATUS)
+      call ESMF_UserCompGetInternalState(gc, "DYNstate", wrap, _RC)
       state => wrap%dyn_state
 
-      vars  => state%vars   ! direct handle to control variables
-      grid  => state%grid   ! direct handle to grid
-      dt    =  state%dt     ! dynamics time step (large)
+      vars => state%vars ! direct handle to control variables
+      grid => state%grid ! direct handle to grid
+      dt =  state%dt ! dynamics time step (large)
 
-      ifirstxy = grid%is
-      ilastxy  = grid%ie
-      jfirstxy = grid%js
-      jlastxy  = grid%je
+      ifirstxy = grid%is; ilastxy  = grid%ie
+      jfirstxy = grid%js; jlastxy  = grid%je
+      im = grid%npx; jm = grid%npy; km = grid%npz
 
-      im       = grid%npx
-      jm       = grid%npy
-      km       = grid%npz
-
-      is_ringing = ESMF_AlarmIsRinging(STATE%ALARMS(TIME_TO_RUN), _RC)
+      is_ringing = ESMF_AlarmIsRinging(state%ALARMS(TIME_TO_RUN), _RC)
       if (.not. is_ringing) return
 
       ! Allocate Arrays
-      ! ---------------
-      ALLOCATE(   delp(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(   dudt(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(   dvdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(   dtdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(   dqdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(  dthdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(  ddpdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(  dpedt(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-      ALLOCATE( tempxy(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(    pe0(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-      ALLOCATE(    pe1(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-      ALLOCATE(     pl(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     ua(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     va(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     uc(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     vc(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(    uc0(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(    vc0(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     ur(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     vr(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     qv(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     ql(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     qi(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     qr(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     qs(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     qg(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(     ox(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-
-      ALLOCATE(  qsum1(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-      ALLOCATE(  qsum2(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-
-      ALLOCATE(   dmdt(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
+      allocate(  delp(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(  dudt(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(  dvdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(  dtdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(  dqdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( dthdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( ddpdt(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( dpedt(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
+      allocate(tempxy(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(   pe0(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
+      allocate(   pe1(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
+      allocate(    pl(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    ua(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    va(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    uc(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    vc(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(   uc0(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(   vc0(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    ur(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    vr(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    qv(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    ql(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    qi(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    qr(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    qs(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    qg(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(    ox(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( qsum1(ifirstxy:ilastxy,jfirstxy:jlastxy     ))
+      allocate( qsum2(ifirstxy:ilastxy,jfirstxy:jlastxy     ))
+      allocate(  dmdt(ifirstxy:ilastxy,jfirstxy:jlastxy     ))
 
       doEnergetics=.false.
-      call MAPL_GetPointer(export, temp2D, 'KEANA', _RC)
+      call MAPL_GetPointer(export, temp2D, "KEANA", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, 'PEANA', _RC)
+      call MAPL_GetPointer(export, temp2D, "PEANA", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, 'TEANA', _RC)
+      call MAPL_GetPointer(export, temp2D, "TEANA", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, 'KEDYN', _RC)
+      call MAPL_GetPointer(export, temp2D, "KEDYN", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, 'PEDYN', _RC)
+      call MAPL_GetPointer(export, temp2D, "PEDYN", _RC)
       if(associated(temp2D)) doEnergetics=.true.
-      call MAPL_GetPointer(export, temp2D, 'TEDYN', _RC)
+      call MAPL_GetPointer(export, temp2D, "TEDYN", _RC)
       if(associated(temp2D)) doEnergetics=.true.
       if (doEnergetics) then
-         ALLOCATE(  kedyn(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE(  pedyn(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE(  tedyn(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE(  kenrg(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE(  penrg(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE(  tenrg(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE( kenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE( penrg0(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
-         ALLOCATE( tenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy)    )
+         allocate( kedyn(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate( pedyn(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate( tedyn(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate( kenrg(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate( penrg(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate( tenrg(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate(kenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate(penrg0(ifirstxy:ilastxy,jfirstxy:jlastxy))
+         allocate(tenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy))
       endif
 
-      ALLOCATE(   vort(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-      ALLOCATE(   divg(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-
-      ALLOCATE(  tmp3d(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-
-      ALLOCATE( phisxy   (ifirstxy:ilastxy,jfirstxy:jlastxy     ) )
-      ALLOCATE(    plk   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE(   pkxy   (ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-      ALLOCATE(     zl   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE(    zle   (ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-      ALLOCATE(  logpe   (ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-      ALLOCATE( omaxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE( epvxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE(  cxxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE(  cyxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE( mfxxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE( mfyxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km  ) )
-      ALLOCATE( mfzxyz   (ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
+      allocate(  vort(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(  divg(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( tmp3d(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(phisxy(ifirstxy:ilastxy,jfirstxy:jlastxy     ))
+      allocate(   plk(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(  pkxy(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
+      allocate(    zl(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(   zle(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
+      allocate( logpe(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
+      allocate(omaxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(epvxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( cxxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate( cyxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(mfxxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(mfyxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km  ))
+      allocate(mfzxyz(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1))
 
       ! Report advected friendlies
-      call ESMF_StateGet(import, 'TRADV', bundle, _RC)
+      call ESMF_StateGet(import, "TRADV", bundle, _RC)
 
-      !-------------------------------------------------------------------
       ! ALT: this section attempts to limit the amount of advected tracers
-      !-------------------------------------------------------------------
       adjustTracers = .false.
-      call MAPL_GetResource(MAPL, adjustTracerMode, 'EXCLUDE_ADVECTION_TRACERS:', default='ALWAYS', _RC)
-      if (adjustTracerMode == 'ALWAYS') then
+      call MAPL_GridCompGetResource(gc, "EXCLUDE_ADVECTION_TRACERS", adjustTracerMode, default="ALWAYS", _RC)
+      if (adjustTracerMode == "ALWAYS") then
          adjustTracers = .true.
-      else if (adjustTracerMode == 'PREDICTOR') then
+      else if (adjustTracerMode == "PREDICTOR") then
          !get PredictorAlarm from clock
-         call ESMF_ClockGetAlarm(clock, alarmName='PredictorAlarm', alarm=PredictorAlarm, rc=status)
+         call ESMF_ClockGetAlarm(clock, alarmName="PredictorAlarm", alarm=PredictorAlarm, rc=status)
          if (status == ESMF_SUCCESS) then
             !check if ringing
             if (ESMF_AlarmIsRinging(predictorAlarm)) then
@@ -1002,60 +977,62 @@ contains
             end if
          end if
       else
-         call WRITE_PARALLEL('Invalid option, ignored')
+         call logger%info("Run:: Invalid value specified for EXCLUDE_ADVECTION_TRACERS, ignored")
          adjustTracers = .false.
       end if
       if (adjustTracers) then
          if (firstime) then
-            firstime=.false.
+            firstime = .false.
             ! get the list of excluded tracers from resource
             n = 0
-            call ESMF_ConfigFindLabel(cf, 'EXCLUDE_ADVECTION_TRACERS_LIST:', isPresent=isPresent, _RC)
-            if(isPresent .or. (AdvCore_Advection >= 1)) then
-               tend  = .false.
-               allocate(xlist(XLIST_MAX), stat=status)
-               VERIFY_(STATUS)
-               if (isPresent) then
-                  do while (.not.tend)
-                     call ESMF_ConfigGetAttribute(cf, value=tmpstring, default='', rc=status) !ALT: we don't check return status
-                     if (tmpstring /= '')  then
-                        n = n + 1
-                        if (n > size(xlist)) then
-                           allocate(biggerlist(2*n), _STAT)
-                           biggerlist(1:n-1)=xlist
-                           call move_alloc(from=biggerlist, to=xlist)
-                        end if
-                        xlist(n) = tmpstring
-                     end if
-                     call ESMF_ConfigNextLine(cf, tableEnd=tend, _RC)
-                  enddo
-               endif
-            end if
+            ! call ESMF_ConfigFindLabel(cf, "EXCLUDE_ADVECTION_TRACERS_LIST:", isPresent=isPresent, _RC)
+            ! if(isPresent .or. (AdvCore_Advection >= 1)) then
+            !    tend  = .false.
+            !    allocate(xlist(XLIST_MAX), stat=status)
+            !    VERIFY_(STATUS)
+            !    if (isPresent) then
+            !       do while (.not.tend)
+            !          call ESMF_ConfigGetAttribute(cf, value=tmpstring, default="", rc=status) !ALT: we don't check return status
+            !          if (tmpstring /= "")  then
+            !             n = n + 1
+            !             if (n > size(xlist)) then
+            !                allocate(biggerlist(2*n), _STAT)
+            !                biggerlist(1:n-1)=xlist
+            !                call move_alloc(from=biggerlist, to=xlist)
+            !             end if
+            !             xlist(n) = tmpstring
+            !          end if
+            !          call ESMF_ConfigNextLine(cf, tableEnd=tend, _RC)
+            !       enddo
+            !    endif
+            ! end if
+            xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR, _RC)
+            if (allocated(xlist)) n = size(xlist)
 
             ! Count the number of tracers
             call ESMF_FieldBundleGet(bundle, grid=bgrid, fieldCount=nqt, _RC)
-            BundleAdv = ESMF_FieldBundleCreate(name='xTRADV', _RC)
+            BundleAdv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
             call ESMF_FieldBundleSet(BundleAdv, grid=bgrid, _RC)
-            !loop over NQ in TRADV
+            ! loop over NQ in TRADV
             do i = 1, nqt
                !get field from TRADV and its name
                call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
                call ESMF_FieldGet(FIELD, name=fieldname, _RC)
                !exclude everything that is not cloud/water species
                if ( (AdvCore_Advection >= 1    ) .and. &
-                    (trim(fieldname) /= 'Q'       ) .and. &
-                    (trim(fieldname) /= 'QLCN'    ) .and. &
-                    (trim(fieldname) /= 'QLLS'    ) .and. &
-                    (trim(fieldname) /= 'QICN'    ) .and. &
-                    (trim(fieldname) /= 'QILS'    ) .and. &
-                    (trim(fieldname) /= 'CLCN'    ) .and. &
-                    (trim(fieldname) /= 'CLLS'    ) .and. &
-                    (trim(fieldname) /= 'NCPL'    ) .and. &
-                    (trim(fieldname) /= 'NCPI'    ) .and. &
-                    (trim(fieldname) /= 'QRAIN'   ) .and. &
-                    (trim(fieldname) /= 'QSNOW'   ) .and. &
-                    (trim(fieldname) /= 'QGRAUPEL') ) then
-                  write(STRING,'(A,A)') "FV3+ADV is excluding ", trim(fieldname)
+                    (trim(fieldname) /= "Q"       ) .and. &
+                    (trim(fieldname) /= "QLCN"    ) .and. &
+                    (trim(fieldname) /= "QLLS"    ) .and. &
+                    (trim(fieldname) /= "QICN"    ) .and. &
+                    (trim(fieldname) /= "QILS"    ) .and. &
+                    (trim(fieldname) /= "CLCN"    ) .and. &
+                    (trim(fieldname) /= "CLLS"    ) .and. &
+                    (trim(fieldname) /= "NCPL"    ) .and. &
+                    (trim(fieldname) /= "NCPI"    ) .and. &
+                    (trim(fieldname) /= "QRAIN"   ) .and. &
+                    (trim(fieldname) /= "QSNOW"   ) .and. &
+                    (trim(fieldname) /= "QGRAUPEL") ) then
+                  write(STRING,"(A,A)") "FV3+ADV is excluding ", trim(fieldname)
                   call WRITE_PARALLEL(trim(STRING))
                   n = n + 1
                   if (n > size(xlist)) then
@@ -1106,31 +1083,31 @@ contains
       endif
 
       ! Surface Geopotential from import state
-      call MAPL_GetPointer(import, PHIS, 'PHIS', _RC)
+      call MAPL_GetPointer(import, PHIS, "PHIS", _RC)
 
       phisxy = real(phis,kind=r8)
 
       ! Get tracers from import State (Note: Contains Updates from Analysis)
-      call PULL_Q (STATE, import, qqq, NXQ, RC=rc)
+      call PULL_Q (state, import, qqq, NXQ, _RC)
 
       !-----------------------------
       ! end of fewer_tracers-section
       !-----------------------------
 
       do k=1,size(names)
-         pos = index(names(k), '::')
+         pos = index(names(k), "::")
          if(pos > 0) then
-            if( (names(k)(pos+2:))=='OX' ) ooo = vars%tracer(k)
-         elseif(names(k)=='Q') then
+            if( (names(k)(pos+2:))=="OX" ) ooo = vars%tracer(k)
+         elseif(names(k)=="Q") then
             qqq = vars%tracer(k)
          end if
       end do
 
       ! WMP Begin REPLAY/ANA section
-      call ESMF_ConfigGetAttribute(cf, FV3_STANDALONE, label="FV3_STANDALONE:", default=0, _RC)
+      call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", FV3_STANDALONE, default=0, _RC)
       if (FV3_STANDALONE == 0) then
-         call MAPL_TimerOn(MAPL, "-DYN_ANA")
-         call ESMF_ClockGetAlarm(clock, 'ReplayShutOff', alarm, _RC)
+         ! call MAPL_TimerOn(MAPL, "-DYN_ANA")
+         call ESMF_ClockGetAlarm(clock, "ReplayShutOff", alarm, _RC)
          is_shutoff = ESMF_AlarmIsRinging(alarm, _RC)
       else
          is_shutoff = .true.
@@ -1139,12 +1116,12 @@ contains
       if (.not. is_shutoff) then
          ! If requested, do Intermittent Replay
 
-         call MAPL_GetResource(MAPL, ReplayMode, 'REPLAY_MODE:', default="NoReplay", _RC)
+         call MAPL_GridCompGetResource(gc, "REPLAY_MODE", ReplayMode, default="NoReplay", _RC)
 
          REPLAYING: if(adjustl(ReplayMode)=="Intermittent") then
 
             ! If replay alarm is ringing, we need to reset state
-            call ESMF_ClockGetAlarm(clock, 'INTERMITTENT', alarm, _RC)
+            call ESMF_ClockGetAlarm(clock, "INTERMITTENT", alarm, _RC)
             call ESMF_ClockGet(clock, CurrTime=current_time, _RC)
 
             is_ringing = ESMF_AlarmIsRinging(alarm, _RC)
@@ -1157,41 +1134,43 @@ contains
                call ESMF_AlarmRingerOff(alarm, _RC)
 
                ! Read in file name of field to replay to and all other relavant resources
-               call MAPL_GetResource(MAPL, ReplayFile, 'REPLAY_FILE:', _RC)
-               call MAPL_GetResource(MAPL, ReplayType, 'REPLAY_TYPE:', default="FULL", _RC)
-               call MAPL_GetResource(MAPL, im_replay, label="REPLAY_IM:", _RC)
-               call MAPL_GetResource(MAPL, jm_replay, label="REPLAY_JM:", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_FILE", ReplayFile, _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_TYPE", ReplayType, default="FULL", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_IM", im_replay, _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_JM", jm_replay, _RC)
 
-               call MAPL_GetResource(MAPL, psname, label="REPLAY_PSNAME:", default="NULL",  _RC)
-               call MAPL_GetResource(MAPL, dpname, label="REPLAY_DPNAME:", default="delp",  _RC)
-               call MAPL_GetResource(MAPL, uname, label="REPLAY_UNAME:", default="uwnd",   _RC)
-               call MAPL_GetResource(MAPL, vname, label="REPLAY_VNAME:", default="vwnd",   _RC)
-               call MAPL_GetResource(MAPL, tname, label="REPLAY_TNAME:", default="theta",  _RC)
-               call MAPL_GetResource(MAPL, qname, label="REPLAY_QNAME:", default="sphu",   _RC)
-               call MAPL_GetResource(MAPL, o3name, label="REPLAY_O3NAME:", default="ozone", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_PSNAME", psname, default="NULL",  _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_DPNAME", dpname, default="delp",  _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_UNAME", uname, default="uwnd",   _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_VNAME", vname, default="vwnd",   _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_TNAME", tname, default="theta",  _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_QNAME", qname, default="sphu",   _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_O3NAME", o3name, default="ozone", _RC)
 
-               call MAPL_GetResource(MAPL, rgrid, label="REPLAY_GRID:", default="D-GRID", _RC)
-               call MAPL_GetResource(MAPL, tvar, label="REPLAY_TVAR:", default="THETAV", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_GRID", rgrid, default="D-GRID", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_TVAR", tvar, default="THETAV", _RC)
 
-               call MAPL_GetResource(MAPL, CREMAP, label="REPLAY_REMAP:", default="no", _RC)
-               call MAPL_GetResource(MAPL, TREMAP, label="REPLAY_REMAP_ALL_TRACERS:", default="yes", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_REMAP", cremap, default="no", _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_REMAP_ALL_TRACERS", tremap, default="yes", _RC)
 
-               call MAPL_GetResource(MAPL, rc_blend, 'REPLAY_BLEND:', default=0, _RC)
-               call MAPL_GetResource(MAPL, rc_blend_p_above, 'REPLAY_BLEND_P_ABOVE:', default=10.0, _RC)
-               call MAPL_GetResource(MAPL, rc_blend_p_below, 'REPLAY_BLEND_P_BELOW:', default=100.0, _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_BLEND", rc_blend, default=0, _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_BLEND_P_ABOVE", rc_blend_p_above, default=10.0, _RC)
+               call MAPL_GridCompGetResource(gc, "REPLAY_BLEND_P_BELOW", rc_blend_p_below, default=100.0, _RC)
 
-               call MAPL_GetResource(MAPL, sclinc, label='SCLINC:', default=1.0, _RC)
+               call MAPL_GridCompGetResource(gc, "SCLINC", sclinc, default=1.0, _RC)
 
                ! Read the fields to be reset into a bundle
-               call ESMF_ConfigGetAttribute(cf, nx_ana, label ='NX:', _RC)
-               call ESMF_ConfigGetAttribute(cf, ny_ana, label ='NY:', _RC)
+               ! call ESMF_ConfigGetAttribute(cf, nx_ana, label ="NX:", _RC)
+               ! call ESMF_ConfigGetAttribute(cf, ny_ana, label ="NY:", _RC)
+               call MAPL_GridCompGetResource(gc, "NX", nx_ana, _RC)
+               call MAPL_GridCompGetResource(gc, "NY", ny_ana, _RC)
 
                block
                   use MAPL_LatLonGridFactoryMod
                   ana_grid = grid_manager%make_grid( &
                        & LatLonGridFactory(im_world=IM_REPLAY, jm_world=JM_REPLAY, lm=km, &
                        & nx=nx_ana, ny=ny_ana, rc=status))
-                  VERIFY_(status)
+                  _VERIFY(status)
                end block
 
                ana_bundle = ESMF_FieldBundleCreate(_RC)
@@ -1212,7 +1191,7 @@ contains
                !      are in memory or need reading from file.
                !    call incremental_
                !    call state_remap_
-               if (trim(ReplayType)=='FULL') then
+               if (trim(ReplayType)=="FULL") then
                   call dump_n_splash_
                else
                   call incremental_
@@ -1238,9 +1217,9 @@ contains
          if (.not. ADIABATIC) then
             do k=1,size(names)
 
-               pos = index(names(k),'::')
+               pos = index(names(k),"::")
                if(pos > 0) then
-                  if( (names(k)(pos+2:))=='OX' ) then
+                  if( (names(k)(pos+2:))=="OX" ) then
                      if ( (ooo%is_r4) .and. associated(ooo%content_r4) ) then
                         if (size(ox)==size(ooo%content_r4)) then
                            ox = ooo%content_r4
@@ -1253,7 +1232,7 @@ contains
                   endif
                endif
 
-               if( trim(names(k))=='Q'  ) then
+               if( trim(names(k))=="Q"  ) then
                   if ( (qqq%is_r4) .and. associated(qqq%content_r4) ) then
                      if (size(qv)==size(qqq%content_r4)) then
                         qv = qqq%content_r4
@@ -1263,30 +1242,30 @@ contains
                         qv = qqq%content
                      endif
                   endif
-                  _ASSERT(all(qv >= 0.0),'Before AnaAddIncs: negative or nan water vapor detected')
+                  _ASSERT(all(qv >= 0.0),"Before AnaAddIncs: negative or nan water vapor detected")
                endif
 
             enddo
          endif
 
          ! Diagnostics Before Analysis Increments are Added
-         ALLOCATE(delpold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qdnew(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qdold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qvold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qlold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qiold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qrold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qsold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE(  qgold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(delpold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qdnew(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qdold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qvold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qlold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qiold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qrold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qsold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate(  qgold(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
 
-         call MAPL_GetPointer(import, dqvana, 'DQVANA', _RC)   ! Get QV Increment from Analysis
-         call MAPL_GetPointer(import, dqlana, 'DQLANA', _RC)   ! Get QL Increment from Analysis
-         call MAPL_GetPointer(import, dqiana, 'DQIANA', _RC)   ! Get QI Increment from Analysis
-         call MAPL_GetPointer(import, dqrana, 'DQRANA', _RC)   ! Get QR Increment from Analysis
-         call MAPL_GetPointer(import, dqsana, 'DQSANA', _RC)   ! Get QS Increment from Analysis
-         call MAPL_GetPointer(import, dqgana, 'DQGANA', _RC)   ! Get QG Increment from Analysis
-         call MAPL_GetPointer(import, doxana, 'DOXANA', _RC)   ! Get OX Increment from Analysis
+         call MAPL_GetPointer(import, dqvana, "DQVANA", _RC)   ! Get QV Increment from Analysis
+         call MAPL_GetPointer(import, dqlana, "DQLANA", _RC)   ! Get QL Increment from Analysis
+         call MAPL_GetPointer(import, dqiana, "DQIANA", _RC)   ! Get QI Increment from Analysis
+         call MAPL_GetPointer(import, dqrana, "DQRANA", _RC)   ! Get QR Increment from Analysis
+         call MAPL_GetPointer(import, dqsana, "DQSANA", _RC)   ! Get QS Increment from Analysis
+         call MAPL_GetPointer(import, dqgana, "DQGANA", _RC)   ! Get QG Increment from Analysis
+         call MAPL_GetPointer(import, doxana, "DOXANA", _RC)   ! Get OX Increment from Analysis
 
          QL = 0.0
          QI = 0.0
@@ -1294,37 +1273,35 @@ contains
          QS = 0.0
          QG = 0.0
          do N = 1,size(names)
-            if( trim(names(N)).eq.'QLCN' .or. &
-                 trim(names(N)).eq.'QLLS' ) then
+            if( trim(names(N)).eq."QLCN" .or. trim(names(N)).eq."QLLS" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   QL = QL + state%vars%tracer(N)%content_r4
                else
                   QL = QL + state%vars%tracer(N)%content
                endif
             endif
-            if( trim(names(N)).eq.'QICN' .or. &
-                 trim(names(N)).eq.'QILS' ) then
+            if( trim(names(N)).eq."QICN" .or. trim(names(N)).eq."QILS" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   QI = QI + state%vars%tracer(N)%content_r4
                else
                   QI = QI + state%vars%tracer(N)%content
                endif
             endif
-            if( trim(names(N)).eq.'QRAIN' ) then
+            if( trim(names(N)).eq."QRAIN" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   QR = state%vars%tracer(N)%content_r4
                else
                   QR = state%vars%tracer(N)%content
                endif
             endif
-            if( trim(names(N)).eq.'QSNOW' ) then
+            if( trim(names(N)).eq."QSNOW" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   QS = state%vars%tracer(N)%content_r4
                else
                   QS = state%vars%tracer(N)%content
                endif
             endif
-            if( trim(names(N)).eq.'QGRAUPEL' ) then
+            if( trim(names(N)).eq."QGRAUPEL" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   QG = state%vars%tracer(N)%content_r4
                else
@@ -1351,23 +1328,23 @@ contains
          end if
 
          ! DUDTANA
-         call MAPL_GetPointer(export, dudtana, 'DUDTANA', _RC)
+         call MAPL_GetPointer(export, dudtana, "DUDTANA", _RC)
          if( associated(dudtana) ) dudtana = ur
 
          ! DVDTANA
-         call MAPL_GetPointer(export, dvdtana, 'DVDTANA', _RC)
+         call MAPL_GetPointer(export, dvdtana, "DVDTANA", _RC)
          if( associated(dvdtana) ) dvdtana = vr
 
          ! DTDTANA
-         call MAPL_GetPointer(export, dtdtana, 'DTDTANA', _RC)
+         call MAPL_GetPointer(export, dtdtana, "DTDTANA", _RC)
          if( associated(dtdtana) ) dtdtana = vars%pt * vars%pkz
 
          ! DDELPDTANA
-         call MAPL_GetPointer(export, ddpdtana, 'DDELPDTANA', _RC)
+         call MAPL_GetPointer(export, ddpdtana, "DDELPDTANA", _RC)
          if( associated(ddpdtana) ) ddpdtana = delp
 
          ! DTHVDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DTHVDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DTHVDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = vars%pt*(1+eps*(qv-dqvana))   ! Set tempxy = TH*QVold (Before Analysis Update)
             ALLOCATE( dthdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1379,7 +1356,7 @@ contains
          endif
 
          ! DQVDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DQVDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DQVDTANAINT", _RC)
          if( associated(temp2D) ) then
             ALLOCATE( dqvdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             ALLOCATE( dqvdtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
@@ -1391,14 +1368,13 @@ contains
          endif
 
          ! DQLDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DQLDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DQLDTANAINT", _RC)
          if( associated(temp2D) ) then
             ALLOCATE( dqldtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             ALLOCATE( dqldtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             dqldtanaint1 = 0.0
             do N = 1,size(names)
-               if( trim(names(N)).eq.'QLCN' .or. &
-                    trim(names(N)).eq.'QLLS' ) then
+               if( trim(names(N)).eq."QLCN" .or. trim(names(N)).eq."QLLS" ) then
                   do k=1,km
                      if( state%vars%tracer(N)%is_r4 ) then
                         dqldtanaint1 = dqldtanaint1 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1414,14 +1390,13 @@ contains
          endif
 
          ! DQIDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DQIDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DQIDTANAINT", _RC)
          if( associated(temp2D) ) then
             ALLOCATE( dqidtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             ALLOCATE( dqidtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             dqidtanaint1 = 0.0
             do N = 1,size(names)
-               if( trim(names(N)).eq.'QICN' .or. &
-                    trim(names(N)).eq.'QILS' ) then
+               if( trim(names(N)).eq."QICN" .or. trim(names(N)).eq."QILS" ) then
                   do k=1,km
                      if( state%vars%tracer(N)%is_r4 ) then
                         dqidtanaint1 = dqidtanaint1 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1437,10 +1412,10 @@ contains
          endif
 
          ! DOXDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DOXDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DOXDTANAINT", _RC)
          if( associated(temp2D) ) then
-            ALLOCATE( doxdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE( doxdtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate( doxdtanaint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate( doxdtanaint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
             tempxy       = OX-doxana   ! Set tempxy = OXold (Before Analysis Update)
             doxdtanaint1 = 0.0
             do k=1,km
@@ -1456,23 +1431,23 @@ contains
             QDOLD = 1.0 - (QVOLD+QLOLD+QIOLD)
             QDNEW = 1.0 - (QV   +QL   +QI   )
          endif
-         call MAPL_GetPointer(export, area, 'AREA', _RC)
+         call MAPL_GetPointer(export, area, "AREA", _RC)
 
          allocate( trsum1(nq) )
          allocate( trsum2(nq) )
 
-         call MAPL_GetResource(MAPL, ANA_IS_WEIGHTED, label="ANA_IS_WEIGHTED:", default='NO', _RC)
+         call MAPL_GridCompGetResource(gc, "ANA_IS_WEIGHTED", ANA_IS_WEIGHTED, default="NO", _RC)
          ANA_IS_WEIGHTED = ESMF_UtilStringUpperCase(ANA_IS_WEIGHTED)
-         IS_WEIGHTED =   adjustl(ANA_IS_WEIGHTED)=="YES" .or. adjustl(ANA_IS_WEIGHTED)=="NO"
-         _ASSERT(IS_WEIGHTED ,'needs informative message')
-         IS_WEIGHTED = adjustl(ANA_IS_WEIGHTED)=="YES"
+         is_weighted =   adjustl(ANA_IS_WEIGHTED)=="YES" .or. adjustl(ANA_IS_WEIGHTED)=="NO"
+         _ASSERT(is_weighted, "needs informative message")
+         is_weighted = adjustl(ANA_IS_WEIGHTED)=="YES"
 
          ! Add Analysis Tendencies
-         delpold = delp                            ! Old Pressure Thickness
+         delpold = delp ! Old Pressure Thickness
 
-         call ADD_INCS(MAPL, STATE, import, DT, IS_WEIGHTED=IS_WEIGHTED)
+         call ADD_INCS(esmfgrid, state, import, DT, is_weighted=is_weighted)
 
-         if (DYN_DEBUG) call DEBUG_FV_STATE('ANA ADD_INCS', STATE)
+         if (DYN_DEBUG) call DEBUG_FV_STATE("ANA ADD_INCS", state)
 
          delp = vars%pe(:,:,2:)-vars%pe(:,:,:km)   ! Updated Pressure Thickness
 
@@ -1480,7 +1455,7 @@ contains
          if ((.not. ADIABATIC)) then
             do n=1,NQ
                qsum1(:,:) = 0.0_r8
-               if( STATE%VARS%TRACER(N)%IS_R4 ) then
+               if( state%vars%TRACER(N)%IS_R4 ) then
                   do k=1,km
                      where( delp(:,:,k).ne.delpold(:,:,k) )
                         qsum1(:,:) = qsum1(:,:) + state%vars%tracer(n)%content_r4(:,:,k)*delpold(:,:,k)
@@ -1505,17 +1480,17 @@ contains
          ! Update Specific Mass of Aerosol Constituents Keeping Mixing_Ratio Constant WRT_Dry_Air After ANA Updates
          if ((.not. ADIABATIC)) then
             do n=1,NQ
-               if( (trim(names(n)).ne.'Q'   ) .and. &
-                    (trim(names(n)).ne.'QLLS') .and. &
-                    (trim(names(n)).ne.'QLCN') .and. &
-                    (trim(names(n)).ne.'QILS') .and. &
-                    (trim(names(n)).ne.'QICN') .and. &
-                    (trim(names(n)).ne.'CLLS') .and. &
-                    (trim(names(n)).ne.'CLCN') .and. &
-                    (trim(names(n)).ne.'QRAIN') .and. &
-                    (trim(names(n)).ne.'QSNOW') .and. &
-                    (trim(names(n)).ne.'QGRAUPEL') ) then
-                  if( STATE%VARS%TRACER(N)%IS_R4 ) then
+               if( (trim(names(n)).ne."Q"   ) .and. &
+                    (trim(names(n)).ne."QLLS") .and. &
+                    (trim(names(n)).ne."QLCN") .and. &
+                    (trim(names(n)).ne."QILS") .and. &
+                    (trim(names(n)).ne."QICN") .and. &
+                    (trim(names(n)).ne."CLLS") .and. &
+                    (trim(names(n)).ne."CLCN") .and. &
+                    (trim(names(n)).ne."QRAIN") .and. &
+                    (trim(names(n)).ne."QSNOW") .and. &
+                    (trim(names(n)).ne."QGRAUPEL") ) then
+                  if( state%vars%TRACER(N)%IS_R4 ) then
                      state%vars%tracer(n)%content_r4 = state%vars%tracer(n)%content_r4 * ( QDNEW/QDOLD )
                   else
                      state%vars%tracer(n)%content    = state%vars%tracer(n)%content    * ( QDNEW/QDOLD )
@@ -1528,7 +1503,7 @@ contains
          if ((.not. ADIABATIC)) then
             do n=1,NQ
                qsum1(:,:) = 0.0_r8
-               if( STATE%VARS%TRACER(N)%IS_R4 ) then
+               if( state%vars%TRACER(N)%IS_R4 ) then
                   do k=1,km
                      where( delp(:,:,k).ne.delpold(:,:,k) )
                         qsum1(:,:) = qsum1(:,:) + state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
@@ -1553,16 +1528,16 @@ contains
          ! Ensure Conservation of Global Mass of Aerosol Constituents After ANA Updates
          if ((.not. ADIABATIC)) then
             do n=1,NQ
-               if( (trim(names(n)).ne.'Q'   ) .and. &
-                    (trim(names(n)).ne.'QLLS') .and. &
-                    (trim(names(n)).ne.'QLCN') .and. &
-                    (trim(names(n)).ne.'QILS') .and. &
-                    (trim(names(n)).ne.'QICN') .and. &
-                    (trim(names(n)).ne.'CLLS') .and. &
-                    (trim(names(n)).ne.'CLCN') .and. &
-                    (trim(names(n)).ne.'QRAIN') .and. &
-                    (trim(names(n)).ne.'QSNOW') .and. &
-                    (trim(names(n)).ne.'QGRAUPEL')       ) then
+               if( (trim(names(n)).ne."Q"   ) .and. &
+                    (trim(names(n)).ne."QLLS") .and. &
+                    (trim(names(n)).ne."QLCN") .and. &
+                    (trim(names(n)).ne."QILS") .and. &
+                    (trim(names(n)).ne."QICN") .and. &
+                    (trim(names(n)).ne."CLLS") .and. &
+                    (trim(names(n)).ne."CLCN") .and. &
+                    (trim(names(n)).ne."QRAIN") .and. &
+                    (trim(names(n)).ne."QSNOW") .and. &
+                    (trim(names(n)).ne."QGRAUPEL")       ) then
 
                   if( real(trsum1(n),kind=4).ne.MAPL_UNDEF .and. &
                        real(trsum2(n),kind=4).ne.MAPL_UNDEF       ) then
@@ -1570,9 +1545,9 @@ contains
                   else
                      trsum2(n) = 1.0d0
                   endif
-                  ! IF (MAPL_AM_I_ROOT()) print *, trim(names(n)),' ratio is: ',trsum2(n)
+                  ! IF (MAPL_AM_I_ROOT()) print *, trim(names(n))," ratio is: ",trsum2(n)
 
-                  if( STATE%VARS%TRACER(N)%IS_R4 ) then
+                  if( state%vars%TRACER(N)%IS_R4 ) then
                      do k=1,km
                         where( delp(:,:,k).ne.delpold(:,:,k) )
                            state%vars%tracer(n)%content_r4(:,:,k) = state%vars%tracer(n)%content_r4(:,:,k) * trsum2(n)
@@ -1594,9 +1569,9 @@ contains
 
          ! Update Local Copy of QV and OX to account for Global Sum Adjustment
          do k=1,size(names)
-            pos = index(names(k),'::')
+            pos = index(names(k),"::")
             if(pos > 0) then
-               if( (names(k)(pos+2:))=='OX' ) then
+               if( (names(k)(pos+2:))=="OX" ) then
                   if ( ooo%is_r4 ) then
                      ox = ooo%content_r4
                   else
@@ -1604,18 +1579,18 @@ contains
                   endif
                endif
             endif
-            if( trim(names(k))=='Q'  ) then
+            if( trim(names(k))=="Q"  ) then
                if ( qqq%is_r4 ) then
                   qv = qqq%content_r4
                else
                   qv = qqq%content
                endif
-               _ASSERT(all(qv >= 0.0),'After AnaAddIncs: negative or nan water vapor detected')
+               _ASSERT(all(qv >= 0.0),"After AnaAddIncs: negative or nan water vapor detected")
             endif
          enddo
 
          ! Diagnostics After Analysis Increments are Added
-         call MAPL_GetPointer(export, temp2D, 'DMDTANA', _RC)
+         call MAPL_GetPointer(export, temp2D, "DMDTANA", _RC)
          if( associated(temp2D) ) temp2D = ( (vars%pe(:,:,km+1)-vars%pe(:,:,1)) - dmdt )/(grav*dt)
 
          call getAllWinds(vars%u, vars%v, UC=uc0, VC=vc0, UR=ur, VR=vr)
@@ -1623,32 +1598,32 @@ contains
          dmdt = vars%pe(:,:,km+1)-vars%pe(:,:,1)     ! Psurf-Ptop
 
          ! DUDTANA
-         call MAPL_GetPointer(export, dudtana, 'DUDTANA', _RC)
+         call MAPL_GetPointer(export, dudtana, "DUDTANA", _RC)
          if( associated(dudtana) ) then
             dudtana = (ur-dudtana)/dt
          endif
 
          ! DVDTANA
-         call MAPL_GetPointer(export, dvdtana, 'DVDTANA', _RC)
+         call MAPL_GetPointer(export, dvdtana, "DVDTANA", _RC)
          if( associated(dvdtana) ) then
             dvdtana = (vr-dvdtana)/dt
          endif
 
          ! DTDTANA
-         call MAPL_GetPointer(export, dtdtana, 'DTDTANA', _RC)
+         call MAPL_GetPointer(export, dtdtana, "DTDTANA", _RC)
          if( associated(dtdtana) ) then
             dtdtana = ((vars%pt*vars%pkz)-dtdtana)/dt
          endif
 
          ! DDELPDTANA
-         call MAPL_GetPointer(export, ddpdtana, 'DDELPDTANA', _RC)
+         call MAPL_GetPointer(export, ddpdtana, "DDELPDTANA", _RC)
          if( associated(ddpdtana) ) then
             ddpdtana = (delp-ddpdtana)/dt
          endif
 
          ! DTHVDTANAINT
          ! ------------
-         call MAPL_GetPointer(export, temp2D, 'DTHVDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DTHVDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = vars%pt*(1+eps*qv)   ! Set tempxy = TH*QVnew (After Analysis Update)
             dthdtanaint2 = 0.0
@@ -1661,7 +1636,7 @@ contains
          endif
 
          ! DQVDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DQVDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DQVDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = qv         ! Set tempxy = QNEW (After Analysis Update)
             dqvdtanaint2 = 0.0
@@ -1674,12 +1649,12 @@ contains
          endif
 
          ! DQLDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DQLDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DQLDTANAINT", _RC)
          if( associated(temp2D) ) then
             dqldtanaint2 = 0.0
             do N = 1,size(names)
-               if( trim(names(N)).eq.'QLCN' .or. &
-                    trim(names(N)).eq.'QLLS' ) then
+               if( trim(names(N)).eq."QLCN" .or. &
+                    trim(names(N)).eq."QLLS" ) then
                   do k=1,km
                      if( state%vars%tracer(N)%is_r4 ) then
                         dqldtanaint2 = dqldtanaint2 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1695,12 +1670,12 @@ contains
          endif
 
          ! DQIDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DQIDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DQIDTANAINT", _RC)
          if( associated(temp2D) ) then
             dqidtanaint2 = 0.0
             do N = 1,size(names)
-               if( trim(names(N)).eq.'QICN' .or. &
-                    trim(names(N)).eq.'QILS' ) then
+               if( trim(names(N)).eq."QICN" .or. &
+                    trim(names(N)).eq."QILS" ) then
                   do k=1,km
                      if( state%vars%tracer(N)%is_r4 ) then
                         dqidtanaint2 = dqidtanaint2 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1716,7 +1691,7 @@ contains
          endif
 
          ! DOXDTANAINT
-         call MAPL_GetPointer(export, temp2D, 'DOXDTANAINT', _RC)
+         call MAPL_GetPointer(export, temp2D, "DOXDTANAINT", _RC)
          if( associated(temp2D) ) then
             tempxy       = ox         ! Set tempxy = OXnew (After Analysis Update)
             doxdtanaint2 = 0.0
@@ -1745,9 +1720,9 @@ contains
          qv = 0.0
          if (.not. ADIABATIC) then
             do k=1,size(names)
-               pos = index(names(k),'::')
+               pos = index(names(k),"::")
                if(pos > 0) then
-                  if( (names(k)(pos+2:))=='OX' ) then
+                  if( (names(k)(pos+2:))=="OX" ) then
                      if ( (ooo%is_r4) .and. associated(ooo%content_r4) ) then
                         if (size(ox)==size(ooo%content_r4)) then
                            ox = ooo%content_r4
@@ -1759,7 +1734,7 @@ contains
                      endif
                   endif
                endif
-               if( trim(names(k))=='Q'  ) then
+               if( trim(names(k))=="Q"  ) then
                   if ( (qqq%is_r4) .and. associated(qqq%content_r4) ) then
                      if (size(qv)==size(qqq%content_r4)) then
                         qv = qqq%content_r4
@@ -1769,7 +1744,7 @@ contains
                         qv = qqq%content
                      endif
                   endif
-                  _ASSERT(all(qv >= 0.0),'DYN_ANA: negative or nan water vapor detected')
+                  _ASSERT(all(qv >= 0.0),"DYN_ANA: negative or nan water vapor detected")
                endif
             enddo
          endif
@@ -1777,16 +1752,17 @@ contains
          delp   = vars%pe(:,:,2:)  -vars%pe(:,:,:km)   ! Pressure Thickness
          dmdt   = vars%pe(:,:,km+1)-vars%pe(:,:,1)     ! Psurf-Ptop
          tempxy = vars%pt * (1.0+eps*qv)
-         if (doEnergetics) &
-              call Energetics (ur,vr,tempxy,vars%pe,delp,vars%pkz,phisxy,kenrg,penrg,tenrg)
+         if (doEnergetics) then
+            call Energetics(ur, vr,tempxy, vars%pe, delp, vars%pkz, phisxy, kenrg, penrg, tenrg)
+         end if
 
       endif
-      if (FV3_STANDALONE == 0) then
-         call MAPL_TimerOff(MAPL,"-DYN_ANA")
-      endif
+      ! if (FV3_STANDALONE == 0) then
+      !    call MAPL_TimerOff(MAPL,"-DYN_ANA")
+      ! endif
 
 
-      call MAPL_TimerOn(MAPL,"-DYN_PROLOGUE")
+      ! call MAPL_TimerOn(MAPL,"-DYN_PROLOGUE")
       ! Create FV Thermodynamic Variables
       tempxy = vars%pt * vars%pkz      ! Compute Dry Temperature
 
@@ -1799,24 +1775,24 @@ contains
       dqdt   =     qv       ! Specific Humidity  Tendency
       dthdt  = vars%pt*(1.0+eps*qv)*delp
 
-      call FILLOUT3(export, 'QV_DYN_IN',       qv, _RC)
-      call FILLOUT3(export, 'T_DYN_IN',    tempxy, _RC)
-      call FILLOUT3(export, 'U_DYN_IN',        ur, _RC)
-      call FILLOUT3(export, 'V_DYN_IN',        vr, _RC)
-      call FILLOUT3(export, 'PLE_DYN_IN', vars%pe, _RC)
+      call FILLOUT3(export, "QV_DYN_IN",       qv, _RC)
+      call FILLOUT3(export, "T_DYN_IN",    tempxy, _RC)
+      call FILLOUT3(export, "U_DYN_IN",        ur, _RC)
+      call FILLOUT3(export, "V_DYN_IN",        vr, _RC)
+      call FILLOUT3(export, "PLE_DYN_IN", vars%pe, _RC)
 
       ! Initialize 3-D Tracer Dynamics Tendencies
-      call MAPL_GetPointer( export,dqldt,'DQLDTDYN', _RC)
-      call MAPL_GetPointer( export,dqidt,'DQIDTDYN', _RC)
-      call MAPL_GetPointer( export,doxdt,'DOXDTDYN', _RC)
+      call MAPL_GetPointer( export,dqldt,"DQLDTDYN", _RC)
+      call MAPL_GetPointer( export,dqidt,"DQIDTDYN", _RC)
+      call MAPL_GetPointer( export,doxdt,"DOXDTDYN", _RC)
 
       if (allocated(names)) then
 
          if( associated(dqldt) ) then
             dqldt = 0.0
             do k = 1,size(names)
-               if( trim(names(k)).eq.'QLCN' .or. &
-                    trim(names(k)).eq.'QLLS' ) then
+               if( trim(names(k)).eq."QLCN" .or. &
+                    trim(names(k)).eq."QLLS" ) then
                   if( state%vars%tracer(k)%is_r4 ) then
                      if (size(dqldt)==size(state%vars%tracer(k)%content_r4)) &
                           dqldt = dqldt - state%vars%tracer(k)%content_r4
@@ -1831,8 +1807,8 @@ contains
          if( associated(dqidt) ) then
             dqidt = 0.0
             do k = 1,size(names)
-               if( trim(names(k)).eq.'QICN' .or. &
-                    trim(names(k)).eq.'QILS' ) then
+               if( trim(names(k)).eq."QICN" .or. &
+                    trim(names(k)).eq."QILS" ) then
                   if( state%vars%tracer(k)%is_r4 ) then
                      if (size(dqidt)==size(state%vars%tracer(k)%content_r4)) &
                           dqidt = dqidt - state%vars%tracer(k)%content_r4
@@ -1847,9 +1823,9 @@ contains
          if( associated(doxdt) ) then
             doxdt = 0.0
             do k = 1,size(names)
-               pos = index(names(k),'::')
+               pos = index(names(k),"::")
                if(pos > 0) then
-                  if( (names(k)(pos+2:))=='OX' ) then
+                  if( (names(k)(pos+2:))=="OX" ) then
                      if( state%vars%tracer(k)%is_r4 ) then
                         if (size(doxdt)==size(state%vars%tracer(k)%content_r4)) &
                              doxdt = doxdt - state%vars%tracer(k)%content_r4
@@ -1864,7 +1840,7 @@ contains
       endif
 
       ! Initialize 2-D Vertically Integrated Tracer Dynamics Tendencies
-      call MAPL_GetPointer(export, temp2D, 'DQVDTDYNINT', _RC)
+      call MAPL_GetPointer(export, temp2D, "DQVDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do k=1,km
@@ -1872,12 +1848,12 @@ contains
          enddo
       endif
 
-      call MAPL_GetPointer(export, temp2D, 'DQLDTDYNINT', _RC)
+      call MAPL_GetPointer(export, temp2D, "DQLDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do N = 1,size(names)
-            if( trim(names(N)).eq.'QLCN' .or. &
-                 trim(names(N)).eq.'QLLS' ) then
+            if( trim(names(N)).eq."QLCN" .or. &
+                 trim(names(N)).eq."QLLS" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   do k=1,km
                      temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1891,12 +1867,12 @@ contains
          enddo
       endif
 
-      call MAPL_GetPointer(export, temp2D, 'DQIDTDYNINT', _RC)
+      call MAPL_GetPointer(export, temp2D, "DQIDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do N = 1,size(names)
-            if( trim(names(N)).eq.'QICN' .or. &
-                 trim(names(N)).eq.'QILS' ) then
+            if( trim(names(N)).eq."QICN" .or. &
+                 trim(names(N)).eq."QILS" ) then
                if( state%vars%tracer(N)%is_r4 ) then
                   do k=1,km
                      temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1910,13 +1886,13 @@ contains
          enddo
       endif
 
-      call MAPL_GetPointer(export, temp2D, 'DOXDTDYNINT', _RC)
+      call MAPL_GetPointer(export, temp2D, "DOXDTDYNINT", _RC)
       if( associated(temp2D) ) then
          temp2d = 0.0
          do N = 1,size(names)
-            pos = index(names(N),'::')
+            pos = index(names(N),"::")
             if(pos > 0) then
-               if( (names(N)(pos+2:))=='OX' ) then
+               if( (names(N)(pos+2:))=="OX" ) then
                   if( state%vars%tracer(N)%is_r4 ) then
                      do k=1,km
                         temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
@@ -1939,14 +1915,14 @@ contains
          kenrg = (kenrg0-kenrg)/DT
          penrg = (penrg0-penrg)/DT
          tenrg = (tenrg0-tenrg)/DT
-         call FILLOUT2(export, 'KEANA', kenrg, _RC)
-         call FILLOUT2(export, 'PEANA', penrg, _RC)
-         call FILLOUT2(export, 'TEANA', tenrg, _RC)
+         call FILLOUT2(export, "KEANA", kenrg, _RC)
+         call FILLOUT2(export, "PEANA", penrg, _RC)
+         call FILLOUT2(export, "TEANA", tenrg, _RC)
       endif
 
       ! Call Wrapper (DynRun) for FVDycore
-      call MAPL_GetResource( MAPL, CONSV, 'CONSV:', default=1, _RC)
-      call MAPL_GetResource( MAPL,  FILL,  'FILL:', default=0, _RC)
+      call MAPL_GridCompGetResource(gc, "CONSV", CONSV, default=1, _RC)
+      call MAPL_GridCompGetResource(gc, "FILL", FILL,  default=0, _RC)
 
       LCONSV = CONSV.eq.1
       LFILL  =  FILL.eq.1
@@ -1954,28 +1930,28 @@ contains
       ! Get pressures before dynamics
       pe0=vars%pe
 
-      call MAPL_TimerOff(MAPL, "-DYN_PROLOGUE")
+      ! call MAPL_TimerOff(MAPL, "-DYN_PROLOGUE")
 
       !-------------------------------------------------------
 
-      call MAPL_TimerOn(MAPL, "-DYN_CORE")
+      ! call MAPL_TimerOn(MAPL, "-DYN_CORE")
       t1 = MPI_Wtime(status)
-      call DynRun(STATE, export, clock, gc, PLE0=pe0, _RC)
+      call DynRun(state, export, clock, gc, PLE0=pe0, _RC)
       t2 = MPI_Wtime(status)
       dyn_run_timer = t2-t1
-      call MAPL_TimerOff(MAPL, "-DYN_CORE")
+      ! call MAPL_TimerOff(MAPL, "-DYN_CORE")
 
-      call MAPL_TimerOn(MAPL, "-DYN_EPILOGUE")
+      ! call MAPL_TimerOn(MAPL, "-DYN_EPILOGUE")
       ! Computational diagnostics
-      call MAPL_GetPointer(export, temp2d, 'TIME_IN_DYN', _RC)
+      call MAPL_GetPointer(export, temp2d, "TIME_IN_DYN", _RC)
       if(associated(temp2d)) temp2d = dyn_run_timer
-      call MAPL_GetPointer(export, temp2d, 'PID', _RC)
+      call MAPL_GetPointer(export, temp2d, "PID", _RC)
       if(associated(temp2d)) temp2d = 0 !WMP need to get from MAPL gid
 
       !#define DEBUG_WINDS
 #if defined(DEBUG_WINDS)
-      call Write_Profile(grid, vars%u, 'U-after-DynRun')
-      call Write_Profile(grid, vars%v, 'V-after-DynRun')
+      call Write_Profile(grid, vars%u, "U-after-DynRun")
+      call Write_Profile(grid, vars%v, "V-after-DynRun")
 #endif
       plk  = exp( kappa * log( 0.5*(vars%pe(:,:,1:km)+vars%pe(:,:,2:km+1)) ) )
       pkxy = exp( kappa * log( vars%pe ) )
@@ -1984,33 +1960,33 @@ contains
 
       if (SW_DYNAMICS) then
 
-         call MAPL_GetPointer(export, temp2d, 'PHIS', _RC)
+         call MAPL_GetPointer(export, temp2d, "PHIS", _RC)
          if(associated(temp2d)) temp2d = phisxy
 
-         call MAPL_GetPointer(export, temp2d, 'PS', _RC)
+         call MAPL_GetPointer(export, temp2d, "PS", _RC)
          if(associated(temp2d)) temp2d =  vars%pe(:,:,km+1)/GRAV
 
          call getAllWinds(vars%u, vars%v, UA=ua, VA=va, UC=uc, VC=vc, UR=ur, VR=vr)
-         call FILLOUT3(export, 'U_DGRID', vars%u  , _RC)
-         call FILLOUT3(export, 'V_DGRID', vars%v  , _RC)
-         call FILLOUT3(export, 'U_CGRID', uc      , _RC)
-         call FILLOUT3(export, 'V_CGRID', vc      , _RC)
-         call FILLOUT3(export, 'U_AGRID', ua      , _RC)
-         call FILLOUT3(export, 'V_AGRID', va      , _RC)
+         call FILLOUT3(export, "U_DGRID", vars%u  , _RC)
+         call FILLOUT3(export, "V_DGRID", vars%v  , _RC)
+         call FILLOUT3(export, "U_CGRID", uc      , _RC)
+         call FILLOUT3(export, "V_CGRID", vc      , _RC)
+         call FILLOUT3(export, "U_AGRID", ua      , _RC)
+         call FILLOUT3(export, "V_AGRID", va      , _RC)
 
-         call FILLOUT3(export, 'U'      , ur      , _RC)
-         call FILLOUT3(export, 'V'      , vr      , _RC)
+         call FILLOUT3(export, "U"      , ur      , _RC)
+         call FILLOUT3(export, "V"      , vr      , _RC)
 
       else               ! .not. SW_DYNAMICS
 
          ! Load Local Variable with Vapor Specific Humidity
-         if ((.not. ADIABATIC) .and. (STATE%GRID%NQ > 0)) then
+         if ((.not. ADIABATIC) .and. (state%grid%NQ > 0)) then
             if ( qqq%is_r4 ) then
                if (size(qv)==size(qqq%content_r4)) qv = qqq%content_r4
             else
                if (size(qv)==size(qqq%content)   ) qv = qqq%content
             endif
-            _ASSERT(all(qv >= 0.0),'After DynRun: negative or nan water vapor detected')
+            _ASSERT(all(qv >= 0.0),"After DynRun: negative or nan water vapor detected")
          else
             qv = 0.0
          endif
@@ -2019,7 +1995,7 @@ contains
          delp  = ( vars%pe(:,:,2:) - vars%pe(:,:,:km) )
          dthdt = ( vars%pt*(1.0+eps*qv)*delp-dthdt )/dt
 
-         call MAPL_GetPointer(export, temp2d, 'DTHVDTDYNINT', _RC)
+         call MAPL_GetPointer(export, temp2d, "DTHVDTDYNINT", _RC)
          if(associated(temp2d)) then
             qsum1 = 0.0
             do k=1,km
@@ -2042,22 +2018,22 @@ contains
 
          ! Compute absolute vorticity on the D grid
          call getEPV(vars%pt, vort, ua, va, epvxyz)
-         call MAPL_GetPointer(export, temp3D, 'EPV', _RC)
+         call MAPL_GetPointer(export, temp3D, "EPV", _RC)
          if(associated(temp3d)) temp3d = epvxyz*(p00**kappa)
 
          ! Compute Tropopause Pressure, Temperature, and Moisture
          doTropvars=.false.
-         call MAPL_GetPointer(export, temp2D, 'TROPP_THERMAL', _RC)
+         call MAPL_GetPointer(export, temp2D, "TROPP_THERMAL", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, 'TROPP_EPV', _RC)
+         call MAPL_GetPointer(export, temp2D, "TROPP_EPV", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, 'TROPP_BLENDED', _RC)
+         call MAPL_GetPointer(export, temp2D, "TROPP_BLENDED", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, 'TROPK_BLENDED', _RC)
+         call MAPL_GetPointer(export, temp2D, "TROPK_BLENDED", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, 'TROPT', _RC)
+         call MAPL_GetPointer(export, temp2D, "TROPT", _RC)
          if(associated(temp2D)) doTropvars=.true.
-         call MAPL_GetPointer(export, temp2D, 'TROPQ', _RC)
+         call MAPL_GetPointer(export, temp2D, "TROPQ", _RC)
          if(associated(temp2D)) doTropvars=.true.
 
          if (doTropvars) then
@@ -2566,7 +2542,7 @@ contains
          ! Fill Surface and Near-Surface Variables
          HGT_SURFACE = 50.0
          if (km .eq. 72) HGT_SURFACE =  0.0
-         call MAPL_GetResource(MAPL, HGT_SURFACE, label="HGT_SURFACE:", default=HGT_SURFACE, _RC)
+         call MAPL_GridCompGetResource(gc, "HGT_SURFACE", HGT_SURFACE, default=HGT_SURFACE, _RC)
          if ( HGT_SURFACE .gt. 0.0 ) then
             ! Near surface height for surface
             call MAPL_GetPointer(export, temp2d, 'DZ', _RC)
@@ -2789,7 +2765,7 @@ contains
 
       end if   ! SW_DYNAMICS
 
-      call MAPL_TimerOff(MAPL, "-DYN_EPILOGUE")
+      ! call MAPL_TimerOff(MAPL, "-DYN_EPILOGUE")
 
       ! De-Allocate Arrays
 
@@ -2857,14 +2833,15 @@ contains
 
       call freeTracers(state)
 
-      call MAPL_TimerOff(MAPL, "RUN")
-      call MAPL_TimerOff(MAPL, "TOTAL")
+      ! call MAPL_TimerOff(MAPL, "RUN")
+      ! call MAPL_TimerOff(MAPL, "TOTAL")
 
       !if (ADIABATIC) then
       !  ! Fill Exports
       !   call RunAddIncs(gc, import, export, clock, rc)
       !endif
 
+      call logger%info("Run:: ...complete")
       _RETURN(_SUCCESS)
 
    contains
@@ -2872,17 +2849,17 @@ contains
       subroutine check_replay_time_(lring)
 
          logical :: lring
-
+         
          integer :: REPLAY_REF_DATE, REPLAY_REF_TIME, REPLAY_REF_TGAP
          integer :: REF_TIME(6), REF_TGAP(6)
-         type (ESMF_TimeInterval)  :: RefTGap
+         type(ESMF_TimeInterval)  :: RefTGap
 
-         call MAPL_GetResource(MAPL, ReplayType, 'REPLAY_TYPE:', default="FULL", _RC)
+         call MAPL_GridCompGetResource(gc, "REPLAY_TYPE", ReplayType, default="FULL", _RC)
          !  if (trim(ReplayType) == "FULL") return
 
-         call MAPL_GetResource(MAPL, REPLAY_REF_DATE, label = 'REPLAY_REF_DATE:', default=-1, _RC)
-         call MAPL_GetResource(MAPL, REPLAY_REF_TIME, label = 'REPLAY_REF_TIME:', default=-1, _RC)
-         call MAPL_GetResource(MAPL, REPLAY_REF_TGAP, label = 'REPLAY_REF_TGAP:', default=-1, _RC)
+         call MAPL_GridCompGetResource(gc, "REPLAY_REF_DATE", REPLAY_REF_DATE, default=-1, _RC)
+         call MAPL_GridCompGetResource(gc, "REPLAY_REF_TIME", REPLAY_REF_TIME, default=-1, _RC)
+         call MAPL_GridCompGetResource(gc, "REPLAY_REF_TGAP", REPLAY_REF_TGAP, default=-1, _RC)
 
          if(REPLAY_REF_DATE==-1.or.REPLAY_REF_TIME==-1) return
 
@@ -2933,9 +2910,9 @@ contains
 
       subroutine dump_n_splash_
 
-         real(kind=4), pointer :: XTMP2d (:,:) =>NULL()
-         real(kind=4), pointer :: XTMP3d(:,:,:)=>NULL()
-         real(kind=4), pointer :: YTMP3d(:,:,:)=>NULL()
+         real(r4), pointer :: XTMP2d (:,:) =>NULL()
+         real(r4), pointer :: XTMP3d(:,:,:)=>NULL()
+         real(r4), pointer :: YTMP3d(:,:,:)=>NULL()
          real(r8), allocatable :: ana_thv (:,:,:)
          real(r8), allocatable :: ana_phis  (:,:)
          real(r8), allocatable :: ana_pkxy  (:,:,:)
@@ -2993,7 +2970,7 @@ contains
          else if(iwind==1) then
             status=1
             call WRITE_PARALLEL('cannot handle single wind component')
-            VERIFY_(STATUS)
+            _VERIFY(STATUS)
          else if (iwind==2) then
 #ifdef INC_WINDS
             if (iapproach==1) then
@@ -3145,37 +3122,38 @@ contains
             endif
          endif
 
-         ! O3
-         if( trim(o3name).ne.'NULL' ) then
-            call ESMFL_BundleGetPointerToData(ana_bundle, trim(o3name), XTMP3d, _RC)
-            allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
-            call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
+         ! pchakrab - TODO: orbit??
+         ! ! O3
+         ! if( trim(o3name).ne.'NULL' ) then
+         !    call ESMFL_BundleGetPointerToData(ana_bundle, trim(o3name), XTMP3d, _RC)
+         !    allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
+         !    call l2c%regrid(XTMP3d, cubeTEMP3D, _RC)
 
-            ! Ozone needs to be adjusted to OX
-            call WRITE_PARALLEL('Replaying '//trim(o3name))
+         !    ! Ozone needs to be adjusted to OX
+         !    call WRITE_PARALLEL('Replaying '//trim(o3name))
 
-            call MAPL_Get(MAPL, LONS=LONS, LATS=LATS, ORBIT=ORBIT, _RC)
+         !    call MAPL_Get(MAPL, lons=lons, lats=lats, ORBIT=ORBIT, _RC)
 
-            allocate( ZTH( size(LONS,1),size(LONS,2) ) )
-            allocate( SLR( size(LONS,1),size(LONS,2) ) )
+         !    allocate( ZTH( size(lons,1),size(lons,2) ) )
+         !    allocate( SLR( size(lons,1),size(lons,2) ) )
 
-            call MAPL_SunGetInsolation(LONS, LATS, ORBIT, ZTH, SLR, clock=clock, _RC)
+         !    call MAPL_SunGetInsolation(lons, lats, ORBIT, ZTH, SLR, clock=clock, _RC)
 
-            pl = ( vars%pe(:,:,2:) + vars%pe(:,:,:km) ) * 0.5
+         !    pl = ( vars%pe(:,:,2:) + vars%pe(:,:,:km) ) * 0.5
 
-            do L=1,km
-               if( ooo%is_r4 ) then
-                  where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
-                       ooo%content_r4(:,:,L) = max(0.,cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6)
-               else
-                  where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
-                       ooo%content   (:,:,L) = max(0.,cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6)
-               endif
-            enddo
+         !    do L=1,km
+         !       if( ooo%is_r4 ) then
+         !          where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
+         !               ooo%content_r4(:,:,L) = max(0.,cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6)
+         !       else
+         !          where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
+         !               ooo%content   (:,:,L) = max(0.,cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6)
+         !       endif
+         !    enddo
 
-            deallocate( ZTH, SLR )
-            deallocate(cubeTEMP3D)
-         endif
+         !    deallocate( ZTH, SLR )
+         !    deallocate(cubeTEMP3D)
+         ! endif
          if( ooo%is_r4 ) then ! ana_qq(2) used as aux var to hold ox
             ana_qq(:,:,:,2) = ooo%content_r4
          else
@@ -3284,7 +3262,7 @@ contains
          if(.not.allhere) then
             call WRITE_PARALLEL('Not all varibles needed for replay are available')
             status = 999
-            VERIFY_(status)
+            _VERIFY(status)
          endif
          call WRITE_PARALLEL('Starting incremental replay')
 
@@ -3304,7 +3282,7 @@ contains
          if(iwind==1) then
             status=1
             print *, 'cannot handle single wind component'
-            VERIFY_(STATUS)
+            _VERIFY(STATUS)
          else if (iwind==2) then
             allocate(cubeTEMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
             allocate(cubeVTMP3D(grid%is:grid%ie,grid%js:grid%je,km) )
@@ -3378,32 +3356,33 @@ contains
             enddo
          endif
 
-         ! O3
-         if( trim(o3name).ne.'NULL' ) then
-            call ESMFL_BundleGetPointerToData(ana_bundle, trim(o3name), TEMP3D, _RC)
-            allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
-            call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
+         ! pchakrab - TODO: orbit?
+         ! ! O3
+         ! if( trim(o3name).ne.'NULL' ) then
+         !    call ESMFL_BundleGetPointerToData(ana_bundle, trim(o3name), TEMP3D, _RC)
+         !    allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
+         !    call l2c%regrid(TEMP3D, cubeTEMP3D, _RC)
 
-            ! Ozone needs to be adjusted to OX
-            call WRITE_PARALLEL('Replaying increment of '//trim(o3name))
+         !    ! Ozone needs to be adjusted to OX
+         !    call WRITE_PARALLEL('Replaying increment of '//trim(o3name))
 
-            call MAPL_Get(MAPL, LONS=LONS, LATS=LATS, ORBIT=ORBIT, _RC)
+         !    call MAPL_Get(MAPL, lons=lons, lats=lats, ORBIT=ORBIT, _RC)
 
-            allocate( ZTH( size(LONS,1),size(LONS,2) ) )
-            allocate( SLR( size(LONS,1),size(LONS,2) ) )
+         !    allocate( ZTH( size(lons,1),size(lons,2) ) )
+         !    allocate( SLR( size(lons,1),size(lons,2) ) )
 
-            call MAPL_SunGetInsolation(LONS, LATS, ORBIT, ZTH, SLR, clock=clock, _RC)
+         !    call MAPL_SunGetInsolation(lons, lats, ORBIT, ZTH, SLR, clock=clock, _RC)
 
-            pl = ( vars%pe(:,:,2:) + vars%pe(:,:,:km) ) * 0.5
+         !    pl = ( vars%pe(:,:,2:) + vars%pe(:,:,:km) ) * 0.5
 
-            do L=1,km
-               where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
-                    dqox(:,:,L) = cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6
-            enddo
+         !    do L=1,km
+         !       where(PL(:,:,L) >= 100.0 .or. ZTH <= 0.0) &
+         !            dqox(:,:,L) = cubeTEMP3D(:,:,L)*(MAPL_AIRMW/MAPL_O3MW)*1.0E-6
+         !    enddo
 
-            deallocate( ZTH, SLR )
-            deallocate(cubeTEMP3D)
-         endif
+         !    deallocate( ZTH, SLR )
+         !    deallocate(cubeTEMP3D)
+         ! endif
 
          ! QV
          if( trim(qname).ne.'NULL' ) then
@@ -3420,12 +3399,12 @@ contains
             if(trim(tvar).ne.'TV') then
                call WRITE_PARALLEL('Error: Cannot Replay TVAR '//trim(tvar))
                STATUS=99
-               VERIFY_(STATUS)
+               _VERIFY(STATUS)
             endif
             if(trim(tname).ne.'tv') then
                call WRITE_PARALLEL('Error: Cannot Replay TNAME '//trim(tname))
                STATUS=99
-               VERIFY_(STATUS)
+               _VERIFY(STATUS)
             endif
             call ESMFL_BundleGetPointerToData(ana_bundle, trim(tname), TEMP3D, _RC)
             allocate(cubeTEMP3D(size(vars%pe,1),size(vars%pe,2),km))
@@ -3477,9 +3456,9 @@ contains
 
       subroutine state_remap_
 
-         real(kind=4), pointer :: XTMP2d (:,:) =>NULL()
-         real(kind=4), pointer :: XTMP3d(:,:,:)=>NULL()
-         real(kind=4), pointer :: YTMP3d(:,:,:)=>NULL()
+         real(r4), pointer :: XTMP2d (:,:) =>NULL()
+         real(r4), pointer :: XTMP3d(:,:,:)=>NULL()
+         real(r4), pointer :: YTMP3d(:,:,:)=>NULL()
          real(r8), allocatable :: ana_thv (:,:,:)
          real(r8), allocatable :: ana_phis  (:,:)
          real(r8), allocatable :: ana_qq    (:,:,:,:)
@@ -3513,7 +3492,7 @@ contains
          if (nq3d<2) then
             call WRITE_PARALLEL('state_remap: invalid number of tracers')
             status=999
-            VERIFY_(STATUS)
+            _VERIFY(STATUS)
          endif
 
          iib = lbound(vars%pe,1)
@@ -3553,7 +3532,7 @@ contains
                   if (icnt>nq3d) then
                      call WRITE_PARALLEL('state_remap: number of tracers exceeds known value')
                      status=999
-                     VERIFY_(STATUS)
+                     _VERIFY(STATUS)
                   endif
                   call ESMFL_BundleGetPointerToData(BUNDLE, NAME, ptr3dr4, _RC)
                   ana_qq(:,:,:,icnt) = ptr3dr4
@@ -3562,7 +3541,7 @@ contains
             if (icnt/=nq3d) then
                call WRITE_PARALLEL('state_remap: inconsitent number of tracers')
                status=999
-               VERIFY_(STATUS)
+               _VERIFY(STATUS)
             endif
          else
             if( qqq%is_r4 ) then
@@ -3640,9 +3619,9 @@ contains
 
    end subroutine Run
 
-   subroutine PULL_Q(STATE, import, QQQ, iNXQ, InFieldName, RC)
+   subroutine PULL_Q(state, import, QQQ, iNXQ, InFieldName, RC)
 
-      type (DynState)        :: STATE
+      type (DynState)        :: state
       type (ESMF_State)              :: import
       type (DynTracers)               :: QQQ       ! Specific Humidity
       integer,           intent(IN)  :: iNXQ
@@ -3680,14 +3659,14 @@ contains
       VERIFY_(STATUS)
 
       NQ = NQ + iNXQ
-      STATE%GRID%NQ = NQ       ! GRID%NQ is now the "official" NQ
+      state%grid%NQ = NQ       ! grid%NQ is now the "official" NQ
 
       ! Tracer pointer array
-      IF( ASSOCIATED( STATE%VARS%tracer ) ) then
+      IF( ASSOCIATED( state%vars%tracer ) ) then
          call freeTracers(state)
       ENDIF
 
-      ALLOCATE(STATE%VARS%tracer(nq), STAT=STATUS)
+      ALLOCATE(state%vars%tracer(nq), STAT=STATUS)
       VERIFY_(STATUS)
 
       DO n = 1, NQ-iNXQ
@@ -3698,11 +3677,11 @@ contains
          call ESMF_ArrayGet(array,typekind=kind,rc=status)
          VERIFY_(STATUS)
 
-         STATE%VARS%TRACER(N)%IS_R4  = (kind == ESMF_TYPEKIND_R4)   ! Is real*4?
+         state%vars%TRACER(N)%IS_R4  = (kind == ESMF_TYPEKIND_R4)   ! Is real*4?
 
-         STATE%VARS%TRACER(N)%TNAME = fieldname
+         state%vars%TRACER(N)%TNAME = fieldname
 
-         if ( STATE%VARS%TRACER(N)%IS_R4 ) then
+         if ( state%vars%TRACER(N)%IS_R4 ) then
             call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r4, rc=status)
             VERIFY_(STATUS)
             state%vars%tracer(n)%content_r4 => MAPL_RemapBounds(PTR_R4, i1,in,j1,jn, &
@@ -3748,16 +3727,12 @@ contains
       integer, intent(out) :: rc
       !EOP
 
-      integer                                          :: status
-      character(len=ESMF_MAXSTR) :: IAm
-
-      type (MAPL_MetaComp), pointer :: genstate
-
-      type (DYN_wrap) :: wrap
-      type (DynState), pointer :: STATE
-      type (DynGrid),  pointer :: GRID
-      type (DynVars),  pointer :: VARS
-      type (DynTracers)                 :: qqq     ! Specific Humidity
+      type(DYN_wrap) :: wrap
+      type(DynState), pointer :: state
+      type(DynGrid), pointer :: grid
+      type(DynVars), pointer :: vars
+      type(DynTracers) :: qqq                ! Specific Humidity
+      type(ESMF_Grid) :: esmfgrid
 
       real(r8), allocatable :: penrg (:,:)   ! Vertically Integrated Cp*T
       real(r8), allocatable :: kenrg (:,:)   ! Vertically Integrated K
@@ -3766,8 +3741,8 @@ contains
       real(r8), allocatable :: kenrg0(:,:)   ! Vertically Integrated K
       real(r8), allocatable :: tenrg0(:,:)   ! PHIS*(Psurf-Ptop)
 
-      real(r8),     pointer :: phisxy(:,:)
-      real(r4),     pointer ::   phis(:,:)
+      real(r8), pointer     :: phisxy(:,:)
+      real(r4), pointer     ::   phis(:,:)
       real(r8), allocatable ::    slp(:,:)
       real(r8), allocatable ::  H1000(:,:)
       real(r8), allocatable ::  H850 (:,:)
@@ -3793,107 +3768,90 @@ contains
       real(r8), allocatable ::  logpe(:,:,:)
       real(r8), allocatable ::  logps(:,:)
 
-      real(FVPRC)              :: dt
-
       real(r4), pointer     :: QOLD(:,:,:)
       real(r4), pointer     :: temp3d(:,:,:)
       real(r4), pointer     :: temp2d(:,:  )
 
-      integer ifirstxy, ilastxy
-      integer jfirstxy, jlastxy
-      integer im,jm,km, iNXQ
       real(r4), pointer     :: ztemp1(:,:  )
       real(r4), pointer     :: ztemp2(:,:  )
       real(r4), pointer     :: ztemp3(:,:  )
 
-      real(kind=4), allocatable :: dthdtphyint1(:,:)
-      real(kind=4), allocatable :: dthdtphyint2(:,:)
+      real(r4), allocatable :: dthdtphyint1(:,:)
+      real(r4), allocatable :: dthdtphyint2(:,:)
 
+      real(FVPRC) :: dt
       logical :: doEnergetics
+      integer :: ifirstxy, ilastxy, jfirstxy, jlastxy
+      integer :: im, jm, km, iNXQ
+      integer :: i, j, k, status
+      class(logger_t), pointer :: logger
 
-      integer i,j,k
+      call MAPL_GridCompGet(gc, grid=esmfgrid, logger=logger, _RC)
+      call logger%info("RunAddIncs:: starting...")
 
-      character(len=ESMF_MAXSTR) :: comp_name
-
-      Iam = "RunAddIncs"
-      call ESMF_GridCompGet( gc, name=comp_name, RC=STATUS )
-      VERIFY_(STATUS)
-      Iam = trim(comp_name) // trim(Iam)
-
-      ! Retrieve the pointer to the generic state
-      call MAPL_GetObjectFromGC (gc, GENSTATE,  RC=STATUS )
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(GENSTATE,"TOTAL")
-      call MAPL_TimerOn(GENSTATE,"RUN2")
+      ! call MAPL_TimerOn(GENSTATE,"TOTAL")
+      ! call MAPL_TimerOn(GENSTATE,"RUN2")
 
       ! Retrieve the pointer to the internal state
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, status)
-      VERIFY_(STATUS)
+      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
       state => wrap%dyn_state
 
-      vars  => state%vars   ! direct handle to control variables
-      grid  => state%grid   ! direct handle to grid
-      dt    =  state%dt     ! dynamics time step (large)
+      vars => state%vars ! direct handle to control variables
+      grid => state%grid ! direct handle to grid
+      dt = state%dt      ! dynamics time step (large)
 
-      ifirstxy = grid%is
-      ilastxy  = grid%ie
-      jfirstxy = grid%js
-      jlastxy  = grid%je
+      ifirstxy = grid%is; ilastxy  = grid%ie
+      jfirstxy = grid%js; jlastxy  = grid%je
 
-      im  = grid%npx
-      jm  = grid%npy
-      km  = grid%npz
-      iNXQ = 0
+      im  = grid%npx; jm  = grid%npy
+      km  = grid%npz; iNXQ = 0
 
       if (.not. SW_DYNAMICS) then
 
-         ALLOCATE( dthdtphyint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-         ALLOCATE( dthdtphyint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+         allocate( dthdtphyint1(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+         allocate( dthdtphyint2(ifirstxy:ilastxy,jfirstxy:jlastxy) )
 
          doEnergetics=.false.
-         call MAPL_GetPointer(export,temp2D,'KE'   ,rc=status); VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2D, "KE", _RC)
          if(associated(temp2D)) doEnergetics=.true.
-         call MAPL_GetPointer(export,temp2D,'KEPHY',rc=status); VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2D, "KEPHY", _RC)
          if(associated(temp2D)) doEnergetics=.true.
-         call MAPL_GetPointer(export,temp2D,'PEPHY',rc=status); VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2D, "PEPHY", _RC)
          if(associated(temp2D)) doEnergetics=.true.
-         call MAPL_GetPointer(export,temp2D,'TEPHY',rc=status); VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2D, "TEPHY", _RC)
          if(associated(temp2D)) doEnergetics=.true.
          if (doEnergetics) then
-            ALLOCATE(  kenrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE(  penrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE(  tenrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE( kenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE( penrg0(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE( tenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(  kenrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(  penrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(  tenrg(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate( kenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate( penrg0(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate( tenrg0(ifirstxy:ilastxy,jfirstxy:jlastxy) )
          endif
 
-         ALLOCATE(  tmp3d(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
-         ALLOCATE( phisxy(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-         ALLOCATE(  logps(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+         allocate(  tmp3d(ifirstxy:ilastxy,jfirstxy:jlastxy,km) )
+         allocate( phisxy(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+         allocate(  logps(ifirstxy:ilastxy,jfirstxy:jlastxy) )
 
-         ALLOCATE(     ua(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     va(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     uc(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     vc(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     ur(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     vr(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     qv(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     pl(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(  logpl(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(     dp(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(    thv(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE( tempxy(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     ua(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     va(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     uc(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     vc(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     ur(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     vr(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     qv(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     pl(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(  logpl(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(     dp(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(    thv(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate( tempxy(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
 
-         ALLOCATE(    plk(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
-         ALLOCATE(    pke(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-         ALLOCATE(  logpe(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
-         ALLOCATE(    zle(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
+         allocate(    plk(ifirstxy:ilastxy,jfirstxy:jlastxy,km)   )
+         allocate(    pke(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
+         allocate(  logpe(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
+         allocate(    zle(ifirstxy:ilastxy,jfirstxy:jlastxy,km+1) )
 
-
-         call MAPL_GetPointer ( import, PHIS, 'PHIS', RC=STATUS )
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(import, PHIS, "PHIS", _RC)
 
          phisxy = real(phis,kind=r8)
 
@@ -3901,16 +3859,16 @@ contains
          dp = ( vars%pe(:,:,2:) - vars%pe (:,:,:km) )
 
          ! Load Specific Humidity
-         call MAPL_GetPointer(export,QOLD,'Q',  rc=status)
+         call MAPL_GetPointer(export, QOLD, 'Q', _RC)
 
-         call PULL_Q ( STATE, import, qqq, iNXQ, RC=rc )
-         if ((.not. ADIABATIC) .and. (STATE%GRID%NQ > 0)) then
+         call PULL_Q(state, import, qqq, iNXQ, _RC)
+         if ((.not. ADIABATIC) .and. (state%grid%NQ > 0)) then
             if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
                if (size(qv)==size(qqq%content_r4)) qv = qqq%content_r4
             elseif (associated(qqq%content)) then
                if (size(qv)==size(qqq%content)) qv = qqq%content
             endif
-            _ASSERT(all(qv >= 0.0),'RunAddIncs: negative or nan water vapor detected')
+            _ASSERT(all(qv >= 0.0), "RunAddIncs: negative or nan water vapor detected")
          else
             qv = 0.0
          endif
@@ -3928,8 +3886,7 @@ contains
          endif
 
          ! DTHVDTPHYINT
-         call MAPL_GetPointer ( export, temp2D, 'DTHVDTPHYINT', rc=status )
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2D, "DTHVDTPHYINT", _RC)
          if( associated(temp2D) ) then
             dthdtphyint1 = 0.0
             do k=1,km
@@ -3938,12 +3895,12 @@ contains
          endif
 
          ! Add Diabatic Forcing to State Variables
-         call MAPL_TimerOn (GENSTATE,"PHYS_ADD_INCS")
-         call ADD_INCS ( GENSTATE,STATE,import,DT )
-         call MAPL_TimerOff(GENSTATE,"PHYS_ADD_INCS")
+         ! call MAPL_TimerOn (GENSTATE,"PHYS_ADD_INCS")
+         call ADD_INCS(esmfgrid, state, import, DT)
+         ! call MAPL_TimerOff(GENSTATE,"PHYS_ADD_INCS")
 
 
-         if (DYN_DEBUG) call DEBUG_FV_STATE('PHYSICS ADD_INCS',STATE)
+         if (DYN_DEBUG) call DEBUG_FV_STATE('PHYSICS ADD_INCS',state)
 
          ! Update Mid-Layer Pressure and Pressure Thickness
          dp = ( vars%pe(:,:,2:) - vars%pe (:,:,:km) )
@@ -3955,12 +3912,12 @@ contains
 
          ! Get Cubed-Sphere Wind Exports
          call getAllWinds(vars%u, vars%v, UA=ua, VA=va, UC=uc, VC=vc, UR=ur, VR=vr)
-         call FILLOUT3 (export, 'U_DGRID', vars%u  , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'V_DGRID', vars%v  , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'U_CGRID', uc      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'V_CGRID', vc      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'U_AGRID', ua      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'V_AGRID', va      , rc=status); VERIFY_(STATUS)
+         call FILLOUT3(export, 'U_DGRID', vars%u, _RC)
+         call FILLOUT3(export, 'V_DGRID', vars%v, _RC)
+         call FILLOUT3(export, 'U_CGRID', uc, _RC)
+         call FILLOUT3(export, 'V_CGRID', vc, _RC)
+         call FILLOUT3(export, 'U_AGRID', ua, _RC)
+         call FILLOUT3(export, 'V_AGRID', va, _RC)
 
          ! Compute Energetics After Diabatic Forcing
          thv = vars%pt*(1.0+eps*qv)
@@ -3970,27 +3927,25 @@ contains
 #endif
 
          if (doEnergetics) then
-            call Energetics (ur,vr,thv,vars%pe,dp,vars%pkz,phisxy,kenrg,penrg,tenrg)
-            call MAPL_GetPointer(export,temp2d,'KE',  rc=status)
-            VERIFY_(STATUS)
+            call Energetics(ur,vr,thv,vars%pe,dp,vars%pkz,phisxy,kenrg,penrg,tenrg)
+            call MAPL_GetPointer(export, temp2d, "KE", _RC)
             if(associated(temp2d)) temp2d = kenrg
             kenrg = (kenrg-kenrg0)/DT
             penrg = (penrg-penrg0)/DT
             tenrg = (tenrg-tenrg0)/DT
-            call FILLOUT2 (export, 'KEPHY', kenrg, rc=status); VERIFY_(STATUS)
-            call FILLOUT2 (export, 'PEPHY', penrg, rc=status); VERIFY_(STATUS)
-            call FILLOUT2 (export, 'TEPHY', tenrg, rc=status); VERIFY_(STATUS)
+            call FILLOUT2(export, "KEPHY", kenrg, _RC)
+            call FILLOUT2(export, "PEPHY", penrg, _RC)
+            call FILLOUT2(export, "TEPHY", tenrg, _RC)
          endif
 
          ! DTHVDTPHYINT
-         call MAPL_GetPointer ( export, temp2D, 'DTHVDTPHYINT', rc=status )
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2D, "DTHVDTPHYINT", _RC)
          if( associated(temp2D) ) then
             dthdtphyint2 = 0.0
             do k=1,km
                dthdtphyint2 = dthdtphyint2 + thv(:,:,k)*dp(:,:,k)
             enddo
-            temp2D       = (dthdtphyint2-dthdtphyint1) * MAPL_P00**MAPL_KAPPA / (MAPL_GRAV*DT)
+            temp2D = (dthdtphyint2-dthdtphyint1) * MAPL_P00**MAPL_KAPPA / (MAPL_GRAV*DT)
          endif
 
          plk = exp( kappa * log( 0.5*(vars%pe(:,:,1:km)+vars%pe(:,:,2:km+1)) ) )
@@ -4011,29 +3966,27 @@ contains
             if (TMAX >= 333.0_r8) call Write_Profile(grid, tempxy, 'TAFINC')
          endif
 
-         call FILLOUT3 (export, 'DELP'   , dp      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'U'      , ur      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'V'      , vr      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'T'      , tempxy  , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'Q'      , qv      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'PL'     , pl      , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'PLE'    , vars%pe , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'PLK'    , plk     , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'PKE'    , pke     , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'THV'    , thv     , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'PT'     , vars%pt , rc=status); VERIFY_(STATUS)
-         call FILLOUT3 (export, 'PE'     , vars%pe , rc=status); VERIFY_(STATUS)
+         call FILLOUT3(export, "DELP", dp, _RC)
+         call FILLOUT3(export, "U", ur, _RC)
+         call FILLOUT3(export, "V", vr, _RC)
+         call FILLOUT3(export, "T", tempxy, _RC)
+         call FILLOUT3(export, "Q", qv, _RC)
+         call FILLOUT3(export, "PL", pl, _RC)
+         call FILLOUT3(export, "PLE", vars%pe, _RC)
+         call FILLOUT3(export, "PLK", plk, _RC)
+         call FILLOUT3(export, "PKE", pke, _RC)
+         call FILLOUT3(export, "THV", thv, _RC)
+         call FILLOUT3(export, "PT", vars%pt, _RC)
+         call FILLOUT3(export, "PE", vars%pe, _RC)
 
-         call MAPL_GetPointer(export,temp3d,'TH',rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp3d, "TH", _RC)
          if(associated(temp3d)) temp3d = (tempxy)*(p00/(0.5*(vars%pe(:,:,1:km)+vars%pe(:,:,2:km+1))))**kappa
 
 #ifdef SKIP_TRACERS
          do itracer=1,ntracers
             write(myTracer, "('Q',i5.5)") itracer-1
-            call MAPL_GetPointer(export, temp3D, TRIM(myTracer), rc=status)
-            VERIFY_(STATUS)
-            if((associated(temp3d)) .and. (STATE%GRID%NQ>=itracer)) then
+            call MAPL_GetPointer(export, temp3D, TRIM(myTracer), _RC)
+            if((associated(temp3d)) .and. (state%grid%NQ>=itracer)) then
                if (state%vars%tracer(itracer)%is_r4) then
                   temp3d = state%vars%tracer(itracer)%content_r4
                else
@@ -4050,322 +4003,233 @@ contains
          enddo
          zle(:,:,:) = zle(:,:,:)/grav
 
-         call FILLOUT3 (export, 'ZLE', zle, rc=status); VERIFY_(STATUS)
+         call FILLOUT3(export, "ZLE", zle, _RC)
 
          ! Compute Mid-Layer Heights
-         call MAPL_GetPointer(export,temp3d,'ZL',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp3d, "ZL", _RC)
          if(associated(temp3d)) temp3d = 0.5*( zle(:,:,2:) + zle(:,:,:km) )
 
-
          ! Fill Single Level Variables
-         call MAPL_GetPointer(export,temp2d,'Z700',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Z700", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle*grav,logpe,log(70000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle*grav, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Z500',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, 'Z500', _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle*grav,logpe,log(50000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle*grav, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Z300',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, 'Z300', _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle*grav,logpe,log(30000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle*grav, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H100',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H100", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(10000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H200',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H200", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(20000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H250',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H250", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(25000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H300',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H300", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(30000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H500',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H500", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(50000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H700',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H700", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(70000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H850',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H850", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(85000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle,logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'H1000',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "H1000", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,zle,logpe,log(100000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, zle, logpe, log(100000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U50M',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U50M", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,-zle,-50., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, -zle, -50., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V50M',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V50M", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,-zle,-50., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, -zle, -50., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U100',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U100", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(10000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U200',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U200", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(20000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U250',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U250", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(25000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U300',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U300", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(30000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U500',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U500", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(50000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U700',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U700", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(70000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'U850',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "U850", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,ur,logpe,log(85000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, ur, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V100',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V100", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(10000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V200',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V200", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(20000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V250',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V250", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(25000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V300',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V300", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(30000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V500',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V500", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(50000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V700',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V700", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(70000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'V850',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "V850", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,vr,logpe,log(85000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, vr, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T100',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T100", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(10000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T200',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T200", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(20000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T250',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T250", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(25000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T300',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T300", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(30000.)  , rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T500',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T500", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(50000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T700',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T700", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(70000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'T850',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "T850", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,tempxy,logpe,log(85000.)  ,  rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, tempxy, logpe, log(85000.), _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q100',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q100", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(10000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(10000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q200',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q200", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(20000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(20000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q250',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q250", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(25000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(25000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q300',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q300", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(30000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(30000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q500',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q500", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(50000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(50000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q700',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q700", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(70000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(70000.), positive_definite=.true., _RC)
          end if
 
-         call MAPL_GetPointer(export,temp2d,'Q850',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "Q850", _RC)
          if(associated(temp2d)) then
-            call VertInterp(temp2d,qv,logpe,log(85000.)  ,  positive_definite=.true., rc=status)
-            VERIFY_(STATUS)
+            call VertInterp(temp2d, qv, logpe, log(85000.), positive_definite=.true., _RC)
          end if
 
          ! Fill Model Top Level Variables
-         call MAPL_GetPointer(export,temp2d,'UTOP', rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "UTOP", _RC)
          if(associated(temp2d)) temp2d = ur(:,:,1)
 
-         call MAPL_GetPointer(export,temp2d,'VTOP', rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "VTOP", _RC)
          if(associated(temp2d)) temp2d = vr(:,:,1)
 
-         call MAPL_GetPointer(export,temp2d,'TTOP', rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "TTOP", _RC)
          if(associated(temp2d)) temp2d = tempxy(:,:,1)
 
-         call MAPL_GetPointer(export,temp2d,'DELPTOP', rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "DELPTOP", _RC)
          if(associated(temp2d)) temp2d = dp(:,:,1)
 
          ! Compute Surface Pressure
-         call MAPL_GetPointer(export,temp2d,'PS',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "PS", _RC)
          if(associated(temp2d)) temp2d=vars%pe(:,:,km+1)
 
          ! Get the height above the surface
@@ -4373,17 +4237,14 @@ contains
             zle(:,:,k) = zle(:,:,k) - zle(:,:,km+1)
          enddo
 
-         call MAPL_GetPointer(export,temp3d,'ZLE0',rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp3d, "ZLE0", _RC)
          if(associated(temp3d)) temp3d = zle
 
-         call MAPL_GetPointer(export,temp3d,'ZL0' ,rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp3d, "ZL0", _RC)
          if(associated(temp3d)) temp3d = 0.5*( zle(:,:,:km)+zle(:,:,2:) )
 
          ! Compute Vertically Averaged T,U
-         call MAPL_GetPointer(export,temp2d,'TAVE',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "TAVE", _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -4392,8 +4253,7 @@ contains
             temp2d = temp2d / (vars%pe(:,:,km+1)-vars%pe(:,:,1))
          endif
 
-         call MAPL_GetPointer(export,temp2d,'UAVE',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "UAVE", _RC)
          if(associated(temp2d)) then
             temp2d = 0.0
             do k=1,km
@@ -4405,27 +4265,22 @@ contains
          ! Convert T to Tv
          tempxy = tempxy*(1.0+eps*qv)
 
-         call MAPL_GetPointer(export,temp3d,'TV',  rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export,temp3d, "TV", _RC)
          if(associated(temp3d)) temp3d=tempxy
 
          ! Compute Sea-Level Pressure
-         call MAPL_GetPointer(export,temp2d,'SLP'  ,rc=status)
-         VERIFY_(STATUS)
-         call MAPL_GetPointer(export,Ztemp1,'H1000',rc=status)
-         VERIFY_(STATUS)
-         call MAPL_GetPointer(export,Ztemp2,'H850' ,rc=status)
-         VERIFY_(STATUS)
-         call MAPL_GetPointer(export,Ztemp3,'H500' ,rc=status)
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(export, temp2d, "SLP", _RC)
+         call MAPL_GetPointer(export, Ztemp1, "H1000", _RC)
+         call MAPL_GetPointer(export, Ztemp2, "H850", _RC)
+         call MAPL_GetPointer(export, Ztemp3, "H500", _RC)
 
          if(associated(temp2d) .or. associated(ztemp1) &
               .or. associated(ztemp2) &
               .or. associated(ztemp3) ) then
-            ALLOCATE(  slp(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE(H1000(ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE(H850 (ifirstxy:ilastxy,jfirstxy:jlastxy) )
-            ALLOCATE(H500 (ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(  slp(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(H1000(ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(H850 (ifirstxy:ilastxy,jfirstxy:jlastxy) )
+            allocate(H500 (ifirstxy:ilastxy,jfirstxy:jlastxy) )
             do j=jfirstxy,jlastxy
                do i=ifirstxy,ilastxy
                   call get_slp ( km,vars%pe (i,j,  km+1),phisxy(i,j),  slp(i,j), &
@@ -4445,55 +4300,56 @@ contains
             if(associated(ztemp1)) where( ztemp1.eq.MAPL_UNDEF ) ztemp1 = H1000
             if(associated(ztemp2)) where( ztemp2.eq.MAPL_UNDEF ) ztemp2 = H850
             if(associated(ztemp3)) where( ztemp3.eq.MAPL_UNDEF ) ztemp3 = H500
-            DEALLOCATE(slp,H1000,H850,H500)
+            deallocate(slp,H1000,H850,H500)
          end if
 
          ! Deallocate Memory
          if (doEnergetics) then
-            DEALLOCATE(  kenrg )
-            DEALLOCATE(  penrg )
-            DEALLOCATE(  tenrg )
-            DEALLOCATE( kenrg0 )
-            DEALLOCATE( penrg0 )
-            DEALLOCATE( tenrg0 )
+            deallocate(  kenrg )
+            deallocate(  penrg )
+            deallocate(  tenrg )
+            deallocate( kenrg0 )
+            deallocate( penrg0 )
+            deallocate( tenrg0 )
          endif
 
-         DEALLOCATE(  tmp3d )
+         deallocate(  tmp3d )
 
-         DEALLOCATE( phisxy )
+         deallocate( phisxy )
 
-         DEALLOCATE(     ua )
-         DEALLOCATE(     va )
-         DEALLOCATE(     uc )
-         DEALLOCATE(     vc )
-         DEALLOCATE(     ur )
-         DEALLOCATE(     vr )
-         DEALLOCATE(     qv )
-         DEALLOCATE(     pl )
-         DEALLOCATE(     dp )
-         DEALLOCATE( tempxy )
+         deallocate(     ua )
+         deallocate(     va )
+         deallocate(     uc )
+         deallocate(     vc )
+         deallocate(     ur )
+         deallocate(     vr )
+         deallocate(     qv )
+         deallocate(     pl )
+         deallocate(     dp )
+         deallocate( tempxy )
 
-         DEALLOCATE(    thv )
-         DEALLOCATE(    plk )
-         DEALLOCATE(    pke )
-         DEALLOCATE(  logpl )
-         DEALLOCATE(  logpe )
-         DEALLOCATE(  logps )
-         DEALLOCATE(    zle )
-         DEALLOCATE( dthdtphyint1 )
-         DEALLOCATE( dthdtphyint2 )
+         deallocate(    thv )
+         deallocate(    plk )
+         deallocate(    pke )
+         deallocate(  logpl )
+         deallocate(  logpe )
+         deallocate(  logps )
+         deallocate(    zle )
+         deallocate( dthdtphyint1 )
+         deallocate( dthdtphyint2 )
 
          call freeTracers(state)
 
       end if ! .not. SW_DYNAMICS
 
-      call MAPL_TimerOff(GENSTATE,"RUN2")
-      call MAPL_TimerOff(GENSTATE,"TOTAL")
+      ! call MAPL_TimerOff(GENSTATE,"RUN2")
+      ! call MAPL_TimerOff(GENSTATE,"TOTAL")
 
+      call logger%info("RunAddIncs:: ...complete")
       _RETURN(_SUCCESS)
    end subroutine RunAddIncs
 
-   subroutine ADD_INCS ( MAPL,STATE,import,DT,IS_WEIGHTED,RC )
+   subroutine ADD_INCS(esmfgrid, state, import, DT, is_weighted, rc)
 
       use fms_mod, only: set_domain, nullify_domain
       use fv_diagnostics_mod, only: prt_maxmin
@@ -4501,69 +4357,57 @@ contains
       use fv_update_phys_mod, only: fv_update_phys
 
       !INPUT PARAMETERS:
-      type (MAPL_MetaComp)                   :: MAPL
-      type(DynState), pointer                :: STATE
-      type(ESMF_State),       intent(INOUT)  :: import
-      real(FVPRC),            intent(IN   )  :: DT
-      integer,  optional,     intent(OUT  )  :: RC
-      logical,  optional,     intent(IN   )  :: is_weighted
+      type(ESMF_Grid), intent(in) :: esmfgrid
+      type(DynState), pointer :: state
+      type(ESMF_State), intent(inout) :: import
+      real(FVPRC), intent(in) :: DT
+      logical, optional, intent(in) :: is_weighted
+      integer, optional, intent(out) :: rc
 
       !DESCRIPTION:  This routine adds the tendencies to the state,
       !              weighted appropriately by the time step.  Temperature
       !              tendencies are pressure weighted (ie., DELP*DT/Dt).
       !              All tendencies are on the A-grid, and have an XY decomposition.
 
-      integer               :: status
       logical               :: is_weighted_
 
-      integer               :: II, JJ, I, J, L
-      integer               :: is ,ie , js ,je , km
-      integer               :: isd,ied, jsd,jed
+      integer :: II, JJ, I, J, L
+      integer :: is, ie, js, je, km
+      integer :: isd, ied, jsd, jed
       real(r4), allocatable :: fvQOLD(:,:,:), QTEND(:,:,:)
-      real(r8), allocatable :: DPNEW(:,:,:),DPOLD(:,:,:)
-
-      real(REAL8), allocatable :: tend_ua(:,:,:), tend_va(:,:,:)
-      real(REAL8), allocatable :: tend_un(:,:,:), tend_vn(:,:,:)
-
-      real(FVPRC), allocatable :: u_dt(:,:,:), v_dt(:,:,:), t_dt(:,:,:)
-
       real(r4), pointer :: tend(:,:,:)
-
-      real(r4), pointer, dimension(:,:)   :: LONS
-      real(r4), pointer, dimension(:,:)   :: LATS
-
-      type(DynTracers)      :: qqq       ! Specific Humidity
+      real(r4), pointer, dimension(:,:) :: lons, lats
+      real(r8), allocatable :: DPNEW(:,:,:), DPOLD(:,:,:)
+      real(r8), allocatable :: tend_ua(:,:,:), tend_va(:,:,:)
+      real(r8), allocatable :: tend_un(:,:,:), tend_vn(:,:,:)
+      real(FVPRC), allocatable :: u_dt(:,:,:), v_dt(:,:,:), t_dt(:,:,:)
       real(FVPRC), allocatable :: Q(:,:,:,:), CVM(:,:,:)
+
+      type(DynTracers) :: qqq       ! Specific Humidity
       integer :: n, nwat_tracers, nwat, sphum, liq_wat, ice_wat, rainwat, snowwat, graupel
       real, parameter:: c_ice = 1972.            !< heat capacity of ice at -15.C
       real, parameter:: c_liq = 4.1855e+3        !< GFS: heat capacity of water at 0C
       real, parameter:: c_vap = MAPL_CPVAP       !< 1846.
       real, parameter:: c_air = MAPL_CP
-
-      character(len=ESMF_MAXSTR)         :: IAm="ADD_INCS"
       real(FVPRC) :: fac
+      type(time_type) :: Time_Nudge
+      integer :: status
 
-      type (time_type) :: Time_Nudge
-
+      is_weighted_ = .true.
       if(present(is_weighted)) then
          is_weighted_ = is_weighted
-      else
-         is_weighted_ = .true.
-      endif
+      end if
 
-      is = state%grid%is
-      ie = state%grid%ie
-      js = state%grid%js
-      je = state%grid%je
+      is = state%grid%is; ie = state%grid%ie
+      js = state%grid%js; je = state%grid%je
       km = state%grid%npz
 
-      isd = state%grid%isd
-      ied = state%grid%ied
-      jsd = state%grid%jsd
-      jed = state%grid%jed
+      isd = state%grid%isd; ied = state%grid%ied
+      jsd = state%grid%jsd; jed = state%grid%jed
 
-      call MAPL_Get( MAPL, LONS=LONS, LATS=LATS, RC=STATUS )
-      VERIFY_(STATUS)
+      ! call MAPL_Get( MAPL, LONS=LONS, LATS=LATS, RC=STATUS )
+      ! VERIFY_(STATUS)
+      call MAPL_GridGet(esmfgrid, latitudes=lats, longitudes=lons, _RC)
 
       ! **********************************************************************
       ! ****  Use QV from FV3 init when coldstarting idealized cases      ****
@@ -4573,7 +4417,7 @@ contains
       nwat = state%vars%nwat
       nwat_tracers = 0
       if ((nwat==0) .AND. (.not. ADIABATIC)) then
-         do n=1,STATE%GRID%NQ
+         do n=1,state%grid%NQ
             if (TRIM(state%vars%tracer(n)%tname) == 'Q'       ) nwat_tracers = nwat_tracers + 1
             if (TRIM(state%vars%tracer(n)%tname) == 'QLCN'    ) nwat_tracers = nwat_tracers + 1
             if (TRIM(state%vars%tracer(n)%tname) == 'QLLS'    ) nwat_tracers = nwat_tracers + 1
@@ -4583,13 +4427,13 @@ contains
          ! We must have these first 5 at a minimum
          _ASSERT(nwat_tracers == 5, 'expecting 5 water species: Q QLCN QLLS QICN QILS')
          ! Check for QRAIN, QSNOW, QGRAUPEL
-         do n=1,STATE%GRID%NQ
+         do n=1,state%grid%NQ
             if (TRIM(state%vars%tracer(n)%tname) == 'QRAIN'   ) nwat_tracers = nwat_tracers + 1
             if (TRIM(state%vars%tracer(n)%tname) == 'QSNOW'   ) nwat_tracers = nwat_tracers + 1
             if (TRIM(state%vars%tracer(n)%tname) == 'QGRAUPEL') nwat_tracers = nwat_tracers + 1
          enddo
-         if (nwat_tracers >= 5) nwat = 3 ! STATE has QV, QLIQ, QICE
-         if (nwat_tracers == 8) nwat = 6 ! STATE has QV, QLIQ, QICE, QRAIN, QSNOW, QGRAUPEL
+         if (nwat_tracers >= 5) nwat = 3 ! state has QV, QLIQ, QICE
+         if (nwat_tracers == 8) nwat = 6 ! state has QV, QLIQ, QICE, QRAIN, QSNOW, QGRAUPEL
       endif
       if (.not. ADIABATIC) then
          _ASSERT(nwat >= 1, 'expecting water species (nwat) to match')
@@ -4620,10 +4464,10 @@ contains
       end select
 
       if (nwat >= 1) then
-         ALLOCATE(   Q(is:ie,js:je,1:km,nwat) )
-         ALLOCATE( CVM(is:ie,js:je,1:km) )
+         allocate(   Q(is:ie,js:je,1:km,nwat) )
+         allocate( CVM(is:ie,js:je,1:km) )
          Q(:,:,:,:) = 0.0
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='Q', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='Q', RC=rc )
          if (DYN_COLDSTART .and. overwrite_Q .and. (.not. ADIABATIC)) then
             ! USE Q computed by FV3
             call getQ(Q(:,:,:,sphum), 'Q')
@@ -4647,26 +4491,26 @@ contains
       endif
       if (nwat >= 3) then
          ! Grab QLIQ from imports
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QLLS', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QLLS', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content_r4)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content
          endif
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QLCN', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QLCN', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content_r4)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content
          endif
          ! Grab QICE from imports
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QILS', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QILS', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,ice_wat))==size(qqq%content_r4)) Q(:,:,:,ice_wat) = Q(:,:,:,ice_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,ice_wat))==size(qqq%content)) Q(:,:,:,ice_wat) = Q(:,:,:,ice_wat) + qqq%content
          endif
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QICN', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QICN', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,ice_wat))==size(qqq%content_r4)) Q(:,:,:,ice_wat) = Q(:,:,:,ice_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
@@ -4675,21 +4519,21 @@ contains
       endif
       if (nwat >= 6) then
          ! Grab RAIN from imports
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QRAIN', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QRAIN', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,rainwat))==size(qqq%content_r4)) Q(:,:,:,rainwat) = qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,rainwat))==size(qqq%content)) Q(:,:,:,rainwat) = qqq%content
          endif
          ! Grab SNOW from imports
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QSNOW', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QSNOW', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,snowwat))==size(qqq%content_r4)) Q(:,:,:,snowwat) = qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,snowwat))==size(qqq%content)) Q(:,:,:,snowwat) = qqq%content
          endif
          ! Grab GRAUPEL from imports
-         call PULL_Q ( STATE, import, qqq, NXQ, InFieldName='QGRAUPEL', RC=rc )
+         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QGRAUPEL', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,graupel))==size(qqq%content_r4)) Q(:,:,:,graupel) = qqq%content_r4
          elseif (associated(qqq%content)) then
@@ -4705,44 +4549,39 @@ contains
          ! ****        while import Tendencies are on the A-Grid             ****
          ! **********************************************************************
 
-         ALLOCATE( tend_ua(is:ie  ,js:je  ,km) )
-         ALLOCATE( tend_va(is:ie  ,js:je  ,km) )
-         ALLOCATE( tend_un(is:ie  ,js:je+1,km) )
-         ALLOCATE( tend_vn(is:ie+1,js:je  ,km) )
+         allocate( tend_ua(is:ie  ,js:je  ,km) )
+         allocate( tend_va(is:ie  ,js:je  ,km) )
+         allocate( tend_un(is:ie  ,js:je+1,km) )
+         allocate( tend_vn(is:ie+1,js:je  ,km) )
 
-         call ESMFL_StateGetPointerToData ( import,TEND,'DUDT',RC=STATUS )
-         VERIFY_(STATUS)
-
+         call MAPL_GetPointer(import, TEND, "DUDT", _RC)
          tend_ua(is:ie,js:je,1:km) = tend
 
-         call ESMFL_StateGetPointerToData ( import,TEND,'DVDT',RC=STATUS )
-         VERIFY_(STATUS)
-
+         call MAPL_GetPointer(import, TEND, "DVDT", _RC)
          tend_va(is:ie,js:je,1:km) = tend
 
          !if (.not. HYDROSTATIC ) then
          !  call ESMFL_StateGetPointerToData ( import,TEND,'DWDT',RC=STATUS )
          !  VERIFY_(STATUS)
-         !  STATE%VARS%W = STATE%VARS%W + DT*TEND(is:ie,js:je,1:km)
+         !  state%vars%W = state%vars%W + DT*TEND(is:ie,js:je,1:km)
          !endif
 
          ! Put the wind tendencies on the Native Dynamics grid
-         call Agrid_To_Native( tend_ua, tend_va, tend_un, tend_vn, &
-              wind_increment_limiter = 800.d0/86400.d0 )
+         call Agrid_To_Native(tend_ua, tend_va, tend_un, tend_vn, wind_increment_limiter=800.d0/86400.d0)
 
 
          ! Add the wind tendencies to the control variables
-         STATE%VARS%U = STATE%VARS%U + DT*TEND_UN(is:ie,js:je,1:km)
-         STATE%VARS%V = STATE%VARS%V + DT*TEND_VN(is:ie,js:je,1:km)
+         state%vars%U = state%vars%U + DT*TEND_UN(is:ie,js:je,1:km)
+         state%vars%V = state%vars%V + DT*TEND_VN(is:ie,js:je,1:km)
 
-         DEALLOCATE( tend_ua )
-         DEALLOCATE( tend_va )
+         deallocate( tend_ua )
+         deallocate( tend_va )
 
          ! **********************************************************************
          ! ****           Compute Old Pressure Thickness                     ****
          ! **********************************************************************
 
-         ALLOCATE( DPOLD(is:ie,js:je,km) )
+         allocate( DPOLD(is:ie,js:je,km) )
 
          if(is_weighted_) then
             do k=1,km
@@ -4756,16 +4595,14 @@ contains
          ! ****                     Update Edge Pressures                    ****
          ! **********************************************************************
 
-         call ESMFL_StateGetPointerToData ( import,TEND,'DPEDT',RC=STATUS )
-         VERIFY_(STATUS)
-
-         STATE%VARS%PE = STATE%VARS%PE + DT*TEND
+         call MAPL_GetPointer(import, TEND, "DPEDT", _RC)
+         state%vars%PE = state%vars%PE + DT*TEND
 
          ! **********************************************************************
          ! ****           Compute New Pressure Thickness                     ****
          ! **********************************************************************
 
-         ALLOCATE( DPNEW(is:ie,js:je,km) )
+         allocate( DPNEW(is:ie,js:je,km) )
 
          if(is_weighted_) then
             do k=1,km
@@ -4783,11 +4620,10 @@ contains
          ! ****                           b) D/Dt (T*DELP), IS_WEIGHTED=.T. ****
          ! *********************************************************************
 
-         call ESMFL_StateGetPointerToData ( import,TEND,'DTDT',RC=STATUS )
-         VERIFY_(STATUS)
+         call MAPL_GetPointer(import, TEND, "DTDT", _RC)
 
          !if (DYN_DEBUG) then
-         !   call prt_maxmin('AI PT1', STATE%VARS%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
+         !   call prt_maxmin('AI PT1', state%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
          !endif
 
          select case (nwat)
@@ -4807,46 +4643,46 @@ contains
          end select
 
          ! Make previous PT into just T
-         STATE%VARS%PT = STATE%VARS%PT*STATE%VARS%PKZ
+         state%vars%PT = state%vars%PT*state%vars%PKZ
 
          if (.not. HYDROSTATIC ) then
             ! remove old T from DZ
-            STATE%VARS%DZ = STATE%VARS%DZ / STATE%VARS%PT
+            state%vars%DZ = state%vars%DZ / state%vars%PT
 
             ! Update T
-            STATE%VARS%PT =  STATE%VARS%PT                         *DPOLD
-            STATE%VARS%PT = (STATE%VARS%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
+            state%vars%PT =  state%vars%PT                         *DPOLD
+            state%vars%PT = (state%vars%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
 
             ! update DZ with new T
-            STATE%VARS%DZ = STATE%VARS%DZ * STATE%VARS%PT
+            state%vars%DZ = state%vars%DZ * state%vars%PT
          else
             ! Update T
-            STATE%VARS%PT =  STATE%VARS%PT                         *DPOLD
-            STATE%VARS%PT = (STATE%VARS%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
+            state%vars%PT =  state%vars%PT                         *DPOLD
+            state%vars%PT = (state%vars%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
          endif
 
          if (DEBUG_TQ_ERRORS) then
             do L=1,KM
                do J=js,je
                   do I=is,ie
-                     if ( (STATE%VARS%PT(I,J,L) > 333.0) .OR. (STATE%VARS%PT(I,J,L)/=STATE%VARS%PT(I,J,L)) .OR. &
+                     if ( (state%vars%PT(I,J,L) > 333.0) .OR. (state%vars%PT(I,J,L)/=state%vars%PT(I,J,L)) .OR. &
                           (Q(I,J,L,sphum  ) < 0.0) .OR. (Q(I,J,L,sphum  )/=Q(I,J,L,sphum  )) .OR. &
                           (Q(I,J,L,liq_wat) < 0.0) .OR. (Q(I,J,L,liq_wat)/=Q(I,J,L,liq_wat)) .OR. &
                           (Q(I,J,L,ice_wat) < 0.0) .OR. (Q(I,J,L,ice_wat)/=Q(I,J,L,ice_wat)) .OR. &
                           (Q(I,J,L,rainwat) < 0.0) .OR. (Q(I,J,L,rainwat)/=Q(I,J,L,rainwat)) .OR. &
                           (Q(I,J,L,snowwat) < 0.0) .OR. (Q(I,J,L,snowwat)/=Q(I,J,L,snowwat)) .OR. &
                           (Q(I,J,L,graupel) < 0.0) .OR. (Q(I,J,L,graupel)/=Q(I,J,L,graupel)) ) then
-                        print *, "T or Q  spike detected : ", STATE%VARS%PT(I,J,L)
+                        print *, "T or Q  spike detected : ", state%vars%PT(I,J,L)
                         print *, "  Temp  ANA|PHY  Increment : ", (DT*TEND(I,J,L)*(MAPL_CP/CVM(I,J,L)))/DPNEW(I,J,L)
                         print *, "    IN ADD_INCS inside DYN   "
                         II=I-is+1
                         JJ=J-js+1
                         print *, "  Latitude       =", LATS(II,JJ)*180.0/MAPL_PI
                         print *, "  Longitude      =", LONS(II,JJ)*180.0/MAPL_PI
-                        print *, "  Pressure (mb)  =", 0.5*(STATE%VARS%PE(I,J,L+1)+STATE%VARS%PE(I,J,L))/100.0
+                        print *, "  Pressure (mb)  =", 0.5*(state%vars%PE(I,J,L+1)+state%vars%PE(I,J,L))/100.0
 
-                        print *, "  UWND =", STATE%VARS%U(I,J,L), " UINC =", DT*TEND_UN(I,J,L)
-                        print *, "  VWND =", STATE%VARS%V(I,J,L), " VINC =", DT*TEND_VN(I,J,L)
+                        print *, "  UWND =", state%vars%U(I,J,L), " UINC =", DT*TEND_UN(I,J,L)
+                        print *, "  VWND =", state%vars%V(I,J,L), " VINC =", DT*TEND_VN(I,J,L)
                         if (nwat >= 6) then
                            print *, "  QV=", Q(I,J,L,sphum  ), "  QL=", Q(I,J,L,liq_wat), "  QI=", Q(I,J,L,ice_wat)
                            print *, "  QR=", Q(I,J,L,rainwat), "  QS=", Q(I,J,L,snowwat), "  QG=", Q(I,J,L,graupel)
@@ -4857,30 +4693,30 @@ contains
             end do ! LM loop
          endif
 
-         DEALLOCATE( tend_un )
-         DEALLOCATE( tend_vn )
+         deallocate( tend_un )
+         deallocate( tend_vn )
 
 
          ! Update PKZ from hydrostatic pressures
          !  This isn't entirely necessary, FV3 overwrites this in fv_dynamics
          !  but we have to get back to PT here
-         !!   call getPKZ(STATE%VARS%PKZ,STATE%VARS%PT,Q,STATE%VARS%PE,STATE%VARS%DZ,HYDROSTATIC)
-         call getPKZ(STATE%VARS%PKZ,STATE%VARS%PE)
+         !!   call getPKZ(state%vars%PKZ,state%vars%PT,Q,state%vars%PE,state%vars%DZ,HYDROSTATIC)
+         call getPKZ(state%vars%PKZ,state%vars%PE)
 
          ! Make T back into PT
-         STATE%VARS%PT = STATE%VARS%PT/STATE%VARS%PKZ
+         state%vars%PT = state%vars%PT/state%vars%PKZ
 
          !if (DYN_DEBUG) then
-         !call prt_maxmin('AI PT2', STATE%VARS%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
+         !call prt_maxmin('AI PT2', state%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
          !endif
 
-         DEALLOCATE (DPNEW)
-         DEALLOCATE (DPOLD)
+         deallocate (DPNEW)
+         deallocate (DPOLD)
 
       endif ! .not. Adiabatic
 
-      if (ALLOCATED(Q  )) DEALLOCATE( Q   )
-      if (ALLOCATED(CVM)) DEALLOCATE( CVM )
+      if (allocateD(Q  )) deallocate( Q   )
+      if (allocateD(CVM)) deallocate( CVM )
 
       return
 
@@ -4922,7 +4758,7 @@ contains
      real(r8),           intent(IN   ) :: V(:,:)
      integer, optional,  intent(  out) :: rc
 
-     real(kind=4), pointer      :: CPL(:,:)
+     real(r4), pointer      :: CPL(:,:)
      integer                    :: status
      character(len=ESMF_MAXSTR) :: IAm="Fillout2"
 
@@ -5018,7 +4854,7 @@ contains
       !EOP
 
       type (DYN_wrap) :: wrap
-      type (DynState), pointer  :: STATE
+      type (DynState), pointer  :: state
 
       character(len=ESMF_MAXSTR)        :: IAm
       character(len=ESMF_MAXSTR)        :: comp_name
@@ -5045,7 +4881,7 @@ contains
 
       state => wrap%dyn_state
 
-      call DynFinalize( STATE )
+      call DynFinalize( state )
 
       ! Call Generic Finalize
       call MAPL_TimerOff(MAPL,"FINALIZE")
@@ -5288,12 +5124,12 @@ contains
 
       U = 0.0
 
-      ALLOCATE( PS(is:ie,js:je) )
+      allocate( PS(is:ie,js:je) )
 
       call MAPL_GridCompGetResource(gc, "IM", IM, default=0, _RC)
       call MAPL_GridCompGetResource(gc, "JM", JM, default=0, _RC)
 
-      if (KM<=2) then   ! Shallow Water
+      if (KM<=2) then ! Shallow Water
 
          call MAPL_GridCompGetResource(gc, "CASE_ID", case_id, default=1, _RC)
          DYN_CASE = case_id
@@ -5310,7 +5146,7 @@ contains
             enddo
          enddo
 
-      else              ! 3-D Baroclinic
+      else ! 3-D Baroclinic
 
          U(is:ie,js:je,KE) = .001*abs(lats(:,:))
          V = 0.0
@@ -6027,7 +5863,7 @@ contains
       call MAPL_FieldBundleAdd(bundle, field, _RC)
 
       if (nq == 1) then
-         allocate(state%VARS%tracer(nq), _STAT)
+         allocate(state%vars%tracer(nq), _STAT)
          call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          state%vars%tracer(nq)%content => ptr
          state%vars%tracer(nq)%is_r4 = .false.
@@ -6072,7 +5908,7 @@ contains
       call MAPL_FieldBundleAdd(bundle, field, _RC)
 
       if (NQ == 1) then
-         allocate(state%VARS%tracer(nq), _STAT)
+         allocate(state%vars%tracer(nq), _STAT)
          call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
          state%vars%tracer(nq)%content_r4 => ptr
          state%vars%tracer(nq)%is_r4 = .true.
@@ -6092,11 +5928,11 @@ contains
    end subroutine addTracer_r4
 
    subroutine freeTracers(state)
-      type (DynState) :: STATE
+      type (DynState) :: state
 
-      if (associated(STATE%VARS%tracer)) then
-         DEALLOCATE( STATE%VARS%tracer)   ! Comment out to output tracer to checkpoint file
-         NULLIFY( STATE%VARS%tracer)
+      if (associated(state%vars%tracer)) then
+         deallocate( state%vars%tracer)   ! Comment out to output tracer to checkpoint file
+         NULLIFY( state%vars%tracer)
       end if
 
       return

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -451,8 +451,6 @@ contains
 
    end subroutine SetServices
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    subroutine Initialize(gc, import, export, clock, rc)
 
       !ARGUMENTS:
@@ -633,8 +631,6 @@ contains
       _RETURN(_SUCCESS)
 
    end subroutine Initialize
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !BOP
    !IROUTINE: Run
@@ -1028,7 +1024,7 @@ contains
                VERIFY_(STATUS)
                if (isPresent) then
                   do while (.not.tend)
-                     call ESMF_ConfigGetAttribute(cf, value=tmpstring, default='', rc=status) !ALT: we don't check return status!!!
+                     call ESMF_ConfigGetAttribute(cf, value=tmpstring, default='', rc=status) !ALT: we don't check return status
                      if (tmpstring /= '')  then
                         n = n + 1
                         if (n > size(xlist)) then
@@ -3651,8 +3647,6 @@ contains
 
    end subroutine Run
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    subroutine PULL_Q(STATE, import, QQQ, iNXQ, InFieldName, RC)
 
       type (DynState)        :: STATE
@@ -3740,8 +3734,6 @@ contains
       END DO
 
    end subroutine PULL_Q
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !BOP
    !IROUTINE: RunAddIncs
@@ -4508,8 +4500,6 @@ contains
       _RETURN(_SUCCESS)
    end subroutine RunAddIncs
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    subroutine ADD_INCS ( MAPL,STATE,import,DT,IS_WEIGHTED,RC )
 
       use fms_mod, only: set_domain, nullify_domain
@@ -4903,8 +4893,6 @@ contains
 
    end subroutine ADD_INCS
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    subroutine FILLOUT3r8(export, name, V, RC)
       type (ESMF_State),  intent(inout) :: export
       character(len=*),   intent(IN   ) :: name
@@ -4920,8 +4908,6 @@ contains
       if(associated(cpl)) cpl=v
    end subroutine FILLOUT3r8
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    subroutine FILLOUT3(export, name, V, RC)
       type (ESMF_State),  intent(inout) :: export
       character(len=*),   intent(IN   ) :: name
@@ -4936,8 +4922,6 @@ contains
       VERIFY_(STATUS)
       if(associated(cpl)) cpl=v
    end subroutine FILLOUT3
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    subroutine FILLOUT2(export, name, V, rc)
      type (ESMF_State),  intent(inout) :: export
@@ -4955,8 +4939,6 @@ contains
 
      return
    end subroutine FILLOUT2
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    subroutine Energetics (ua,va,thv,ple,delp,pk,phiS,keint,peint,teint,ke,cpt,gze)
 
@@ -5025,8 +5007,6 @@ contains
       return
    end subroutine Energetics
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    !BOP
    !IROUTINE: Finalize
 
@@ -5094,8 +5074,6 @@ contains
 
    end subroutine FINALIZE
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
    subroutine get_slp ( km,ps,phis,slp,pe,pk,tv,H1000,H850,H500)
       implicit   none
 
@@ -5151,8 +5129,6 @@ contains
 
       return
    end subroutine get_slp
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    subroutine VertInterp(v2,v3,ple,pp,positive_definite,rc)
       real(r4), intent(OUT) :: v2(:,:)
@@ -5214,8 +5190,6 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine VertInterp
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !BOP
    !IROUTINE: Coldstart

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -4978,7 +4978,8 @@ contains
 
       real(REAL8), pointer :: AK1(:), BK1(:), AK(:), BK(:)
       real(REAL8), pointer :: U(:,:,:), V(:,:,:), PT(:,:,:)
-      real(REAL8), pointer :: PE1(:,:,:), PE(:,:,:), PKZ(:,:,:)
+      real(REAL8), pointer :: PE1(:,:,:), PKZ(:,:,:)
+      real(REAL8), allocatable :: PE(:,:,:)
       real(REAL4), pointer :: phis(:,:)
       real(REAL4), pointer :: lons(:,:), lats(:,:)
 
@@ -5039,8 +5040,11 @@ contains
       km = ke-ks+1
       call MAPL_StateGetPointer(internal, V, "V", _RC) ! A-Grid V Wind
       call MAPL_StateGetPointer(internal, PT, "PT", _RC) ! potential temperature
-      call MAPL_StateGetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
-      PE(is:ie, js:je, 0:km) => PE1(is:ie, js:je, 1:km+1)
+      ! call MAPL_StateGetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
+      ! pchakrab - gfortran has issues with the following rank
+      ! remapping (ifort doesn't) , so we allocate a new array
+      ! PE(is:ie, js:je, 0:km) => PE1(is:ie, js:je, 1:km+1)
+      allocate(PE(is:ie, js:je, 0:km), _STAT)
       call MAPL_StateGetPointer(internal, PKZ , "PKZ", _RC) ! presssure ^ kappa at mid-layers
       call MAPL_StateGetPointer(internal, ak1, "AK" , _RC) ! AK for vertical coordinate - 1 based
       ak(0:km) => ak1(1:km+1)
@@ -5466,8 +5470,9 @@ contains
 
       endif
 
-      deallocate(PS)
-
+      call MAPL_StateGetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
+      PE1(is:ie, js:je, 1:km+1) = PE(is:ie, js:je, 0:km)
+      deallocate(PE, PS)
       DYN_COLDSTART=.true.
 
       _RETURN(_SUCCESS)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -511,7 +511,6 @@ contains
       call MAPL_GridCompGetResource(gc, "COLDSTART", ColdRestart, default=0, _RC)
       if (ColdRestart /= 0 ) then
          call Coldstart(gc, import, export, clock, _RC)
-         _HERE
       endif
 
       ! Set Private Internal State from Restart File
@@ -5226,7 +5225,8 @@ contains
       real(REAL4), pointer :: lons(:,:), lats(:,:)
 
       integer :: i, j, k, n, L
-      integer :: IS, IE, JS, JE, KS, KE, IM, JM, KM, LS
+      ! integer :: IS, IE, JS, JE, KS, KE, IM, JM, KM, LS
+      integer :: is, ie, js, je, ks, ke, im, jm, km, ls
       integer :: case_id, case_rotation, case_tracers
 
       real :: T0
@@ -5274,10 +5274,10 @@ contains
       endif
 
       call MAPL_GetPointer(internal, U, "U", _RC) ! A-Grid U Wind
-      IS = lbound(U,1); IE = ubound(U,1)
-      JS = lbound(U,2); JE = ubound(U,2)
-      KS = lbound(U,3); KE = ubound(U,3)
-      KM = KE-KS+1
+      is = lbound(U,1); ie = ubound(U,1)
+      js = lbound(U,2); je = ubound(U,2)
+      ks = lbound(U,3); ke = ubound(U,3)
+      km = ke-ks+1
       call MAPL_GetPointer(internal, V, "V", _RC) ! A-Grid V Wind
       call MAPL_GetPointer(internal, PT, "PT", _RC) ! potential temperature
       call MAPL_GetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
@@ -5291,7 +5291,7 @@ contains
 
       U = 0.0
 
-      ALLOCATE( PS(IS:IE,JS:JE) )
+      ALLOCATE( PS(is:ie,js:je) )
 
       call MAPL_GridCompGetResource(gc, "IM", IM, default=0, _RC)
       call MAPL_GridCompGetResource(gc, "JM", JM, default=0, _RC)
@@ -5301,8 +5301,8 @@ contains
          call MAPL_GridCompGetResource(gc, "CASE_ID", case_id, default=1, _RC)
          DYN_CASE = case_id
 
-         do j=JS,JE
-            do i=IS,IE
+         do j=js,je
+            do i=is,ie
                LONc = lons(i,j)
                LATc = lats(i,j)
                U(i,j,1)  = sw_uwnd(LONc,LATc,case_id)
@@ -5315,7 +5315,7 @@ contains
 
       else              ! 3-D Baroclinic
 
-         U(IS:IE,JS:JE,KE) = .001*abs(lats(:,:))
+         U(is:ie,js:je,KE) = .001*abs(lats(:,:))
          V = 0.0
 
          ! pchakrab - TODO: read ak from resource file, if present
@@ -5384,10 +5384,10 @@ contains
          if (case_id == 1) then ! Steady State
 
             perturb = .false.
-            do k=KS,KE
+            do k=ks,ke
                eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
-               do j=JS,JE
-                  do i=IS,IE
+               do j=js,je
+                  do i=is,ie
                      LONc = lons(i,j)
                      LATc = lats(i,j)
                      U(i,j,k) = u_wind(LONc,LATc,eta,perturb,rot_ang)
@@ -5402,10 +5402,10 @@ contains
          elseif (case_id == 2) then ! Baroclinic Wave
 
             perturb = .true.
-            do k=KS,KE
+            do k=ks,ke
                eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
-               do j=JS,JE
-                  do i=IS,IE
+               do j=js,je
+                  do i=is,ie
                      LONc = lons(i,j)
                      LATc = lats(i,j)
                      U(i,j,k) = u_wind(LONc,LATc,eta,perturb,rot_ang)
@@ -5429,15 +5429,15 @@ contains
 
             !PURE_ADVECTION = .true.
 
-            allocate(Q5(IS:IE, JS:JE, 0:KM-1), _STAT)
-            allocate(Q6(IS:IE, JS:JE, 0:KM-1), _STAT)
+            allocate(Q5(is:ie, js:je, 0:KM-1), _STAT)
+            allocate(Q6(is:ie, js:je, 0:KM-1), _STAT)
 
             ztop = 12000.0
             dz   = ztop/KM
-            do k=KS,KE
+            do k=ks,ke
                height = (ztop - 0.5*dz) - (k)*dz  ! Layer middle height
-               do j=JS,JE
-                  do i=IS,IE
+               do j=js,je
+                  do i=is,ie
                      LONc = lons(i,j)
                      LATc = lats(i,j)
                      call  advection('56', LONc, LATc, height, rot_ang,  &
@@ -5454,9 +5454,9 @@ contains
                PE(:,:,L) = AK(L) + BK(L)*PS(:,:)
             enddo
 
-            do k=KS,KE
-               do j=JS,JE
-                  do i=IS,IE
+            do k=ks,ke
+               do j=js,je
+                  do i=is,ie
                      PKZ(i,j,k) = ( (PE(i,j,k+1)**kappa) - (PE(i,j,k)**kappa) ) /  &
                             ( kappa*(log(PE(i,j,k+1))-log(PE(i,j,k))) )
                   enddo
@@ -5467,8 +5467,8 @@ contains
 
          elseif (case_id == 4) then ! 3D Rossby-Haurwitz
 
-            do j=JS,JE
-               do i=IS,IE
+            do j=js,je
+               do i=is,ie
                   LONc = lons(i,j)
                   LATc = lats(i,j)
                   pressure = 500.
@@ -5482,9 +5482,9 @@ contains
             do L=lbound(PE,3),ubound(PE,3)
                PE(:,:,L) = AK(L) + BK(L)*PS(:,:)
             enddo
-            do k=KS,KE
-               do j=JS,JE
-                  do i=IS,IE
+            do k=ks,ke
+               do j=js,je
+                  do i=is,ie
                      LONc = lons(i,j)
                      LATc = lats(i,j)
                      pressure = 0.5*(PE(i,j,k)+PE(i,j,k+1))
@@ -5497,9 +5497,9 @@ contains
                enddo
             enddo
 
-            do k=KS,KE
-               do j=JS,JE
-                  do i=IS,IE
+            do k=ks,ke
+               do j=js,je
+                  do i=is,ie
                      PKZ(i,j,k) = ( (PE(i,j,k+1)**kappa) - (PE(i,j,k)**kappa) ) /  &
                           ( kappa*(log(PE(i,j,k+1))-log(PE(i,j,k))) )
                   enddo
@@ -5509,9 +5509,9 @@ contains
 
          elseif (case_id == 5) then ! Mountain-Induced Rossby Wave
 
-            do k=KS,KE
-               do j=JS,JE
-                  do i=IS,IE
+            do k=ks,ke
+               do j=js,je
+                  do i=is,ie
                      LONc = lons(i,j)
                      LATc = lats(i,j)
                      pressure = 0.5*(PE(i,j,k)+PE(i,j,k+1))
@@ -5527,9 +5527,9 @@ contains
                PE(:,:,L) = AK(L) + BK(L)*PS(:,:)
             enddo
 
-            do k=KS,KE
-               do j=JS,JE
-                  do i=IS,IE
+            do k=ks,ke
+               do j=js,je
+                  do i=is,ie
                      PKZ(i,j,k) = ( (PE(i,j,k+1)**kappa) - (PE(i,j,k)**kappa) ) /  &
                           ( kappa*(log(PE(i,j,k+1))-log(PE(i,j,k))) )
                   enddo
@@ -5549,10 +5549,10 @@ contains
             ! Get ICs
             ztop = 10000.d0
             dz   = ztop/KM
-            do k=KS,KE
+            do k=ks,ke
                height = (ztop - 0.5d0*dz) - (k)*dz  ! Layer middle height
-               do j=JS,JE
-                  do i=IS,IE
+               do j=js,je
+                  do i=is,ie
                      LONc = lons(i,j)
                      LATc = lats(i,j)
                      call gravity_wave(case_rotation, LONc,LATc, height, dummy_1, dummy_2, dummy_3, dummy_4, PS(i,j))
@@ -5568,8 +5568,8 @@ contains
                PTOP = 27381.905d0
                do k=lbound(PE,3),ubound(PE,3)
                   height = ztop - k*dz  ! Layer edge height
-                  do j=JS,JE
-                     do i=IS,IE
+                  do j=js,je
+                     do i=is,ie
                         LONc = lons(i,j)
                         LATc = lats(i,j)
                         call gravity_wave(case_rotation, LONc,LATc, height, dummy_1, dummy_2, dummy_3, dummy_4, dummy_5, pressure=dummy_6)
@@ -5587,9 +5587,9 @@ contains
                PE(:,:,L) = AK(L) + BK(L)*PS(:,:)
             enddo
 
-            do k=KS,KE
-               do j=JS,JE
-                  do i=IS,IE
+            do k=ks,ke
+               do j=js,je
+                  do i=is,ie
                      PKZ(i,j,k) = ( (PE(i,j,k+1)**kappa) - (PE(i,j,k)**kappa) ) /  &
                           ( kappa*(log(PE(i,j,k+1))-log(PE(i,j,k))) )
                   enddo
@@ -5600,14 +5600,12 @@ contains
 
          endif ! case_id
 
-         !--------------------
          ! Parse Tracers
-         !--------------------
          if (FV3_STANDALONE /= 0) then
             call ESMF_StateGet(import, "TRADV", tradv_bundle, _RC)
-            call ESMF_GridCompGet(gc, grid=esmfgrid, _RC)
+            call MAPL_GridCompGet(gc, grid=esmfgrid, _RC)
 
-            allocate(tracer(IS:IE, JS:JE, 1:KM), _STAT)
+            allocate(tracer(is:ie, js:je, 1:KM), _STAT)
 
             tracer(:,:,:)  = 0.0
             fieldname = 'Q'
@@ -5627,10 +5625,10 @@ contains
                !     tracer q1
                !-------------------
                tracer(:,:,:) = 0.0
-               do k=KS,KE
+               do k=ks,ke
                   eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
-                  do j=JS,JE
-                     do i=IS,IE
+                  do j=js,je
+                     do i=is,ie
                         LONc = lons(i,j)
                         LATc = lats(i,j)
                         dummy_1 = tracer_q1_q2(LONc,LATc,eta,rot_ang,r0_6)
@@ -5644,10 +5642,10 @@ contains
                !-------------------
                !     tracer q2
                !-------------------
-               do k=KS,KE
+               do k=ks,ke
                   eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
-                  do j=JS,JE
-                     do i=IS,IE
+                  do j=js,je
+                     do i=is,ie
                         LONc = lons(i,j)
                         LATc = lats(i,j)
                         dummy_1 = tracer_q1_q2(LONc,LATc,eta,rot_ang,r1_0)
@@ -5661,10 +5659,10 @@ contains
                !-------------------
                !     tracer q3
                !-------------------
-               do k=KS,KE
+               do k=ks,ke
                   eta = 0.5*( (ak(k-1)+ak(k))/1.e5 + bk(k-1)+bk(k) )
-                  do j=JS,JE
-                     do i=IS,IE
+                  do j=js,je
+                     do i=is,ie
                         LONc = lons(i,j)
                         LATc = lats(i,j)
                         dummy_1 = tracer_q3(LONc,LATc,eta,rot_ang)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -20,7 +20,6 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
    use MAPL_Constants, only: MAPL_VectorField, MAPL_BundleItem
-   use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL
 
    use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
@@ -28,12 +27,13 @@ module FVdycoreCubed_GridComp
    ! use MAPL_GenericMod, only: MAPL_TimerAdd
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
-   use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_RemapBounds
+   ! use MAPL_BaseMod, only: MAPL_AttributeSet
+   use MAPL_BaseMod, only: MAPL_RemapBounds
    use MAPL_GridManagerMod, only: grid_manager
    use MAPL_RegridderManagerMod, only: regridder_manager
    use MAPL_RegridMethods, only: REGRID_METHOD_BILINEAR
    use MAPL_CFIOMod, only: MAPL_CFIORead
-   use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
+   ! use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
    use MAPL_FieldPointerUtilities, only: MAPL_FieldDestroy
    use MAPL_MaxMinMod, only: MAPL_MaxMin
    use MAPL_CommsMod, only: MAPL_AM_I_ROOT, MAPL_ArrayGather => ArrayGather
@@ -49,6 +49,8 @@ module FVdycoreCubed_GridComp
    use mapl3g_State_API, only: MAPL_StateGetPointer
    use mapl3g_Field_API, only: MAPL_FieldCreate
    use mapl3g_FieldBundle_API, only: MAPL_FieldBundleAdd
+   use mapl3g_RestartModes, only: MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED
+
    use pflogger, only: logger_t => logger
 
    use m_set_eta, only: set_eta
@@ -511,6 +513,7 @@ contains
       call MAPL_StateGetPointer(export, bk4, "BK", _RC)
       call MAPL_StateGetPointer(internal, ak, "AK", _RC)
       call MAPL_StateGetPointer(internal, bk, "BK", _RC)
+      ! pchakrab: TODO - how to handle `alloc=.true.` in MAPL3??
       call MAPL_GetPointer(export, pref, "PREF", alloc=.true., _RC)
       ak4 = ak
       bk4 = bk
@@ -522,6 +525,7 @@ contains
       call MAPL_StateGetPointer(internal, pt, "PT", _RC)
       call MAPL_StateGetPointer(internal, pk, "PKZ", _RC)
 
+      ! pchakrab: TODO - how to handle `alloc=.true.` in MAPL3??
       call MAPL_GetPointer(export, ple, "PLE", alloc=.true., _RC)
       call MAPL_GetPointer(export, u, "U", alloc=.true., _RC)
       call MAPL_GetPointer(export, v, "V", alloc=.true., _RC)
@@ -544,6 +548,7 @@ contains
       deallocate(ur, vr)
 
       ! Fill Grid-Cell Area Delta-X/Y
+      ! pchakrab: TODO - how to handle `alloc=.true.` in MAPL3??
       call MAPL_GetPointer(export, temp2d, "DXC", alloc=.true., _RC)
       temp2d = self%grid%dxc
 
@@ -561,21 +566,21 @@ contains
       !     would be to move the computation to phase 2 of Initialize and
       !     eliminate this section alltogether
       ! ======================================================================
-      ! pchakrab: TODO - do we need to port the following to MAPL3
-      call ESMF_StateGet(export, "PREF", field, _RC)
-      call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
+      ! ! pchakrab: TODO - do we need to port the following to MAPL3
+      ! call ESMF_StateGet(export, "PREF", field, _RC)
+      ! call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, "PLE", field, _RC)
-      call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
+      ! call ESMF_StateGet(export, "PLE", field, _RC)
+      ! call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, "U", field, _RC)
-      call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
+      ! call ESMF_StateGet(export, "U", field, _RC)
+      ! call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, "V", field, _RC)
-      call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
+      ! call ESMF_StateGet(export, "V", field, _RC)
+      ! call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, "T", field, _RC)
-      call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
+      ! call ESMF_StateGet(export, "T", field, _RC)
+      ! call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
       call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", fv3_standalone, default=0, _RC)
       if (fv3_standalone /= 0) then
@@ -2612,6 +2617,7 @@ contains
          end if
 
          ! Updraft Helicty Exports
+         ! pchakrab: TODO - how to handle `alloc=.true.` in MAPL3??
          call MAPL_GetPointer(export,  uh25, 'UH25', alloc=.true., _RC)
          call MAPL_GetPointer(export,  uh03, 'UH03', alloc=.true., _RC)
          call MAPL_GetPointer(export, srh01,'SRH01', alloc=.true., _RC)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -15,16 +15,16 @@ module FVdycoreCubed_GridComp
 
    !USES:
    use ESMF
-   ! use MAPL
+   use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
+
    use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
-   use MAPL_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
    use MAPL_Constants, only: MAPL_VectorField, MAPL_BundleItem
    use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
    use MAPL_Constants, only: MAPL_VLocationCenter, MAPL_VLocationEdge, MAPL_VLocationNone
    use MAPL_Constants, only: MAPL_DimsHorzVert, MAPL_DimsHorzOnly, MAPL_DimsVertOnly
-   use MAPL_GenericMod, only: MAPL_GridCompSetEntryPoint, MAPL_MetaComp, MAPL_TimerAdd, MAPL_TimerOn
+   use MAPL_GenericMod, only: MAPL_MetaComp, MAPL_TimerAdd, MAPL_TimerOn
    use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff
    use MAPL_GenericMod, only: MAPL_GenericSetServices, MAPL_GenericInitialize, MAPL_GenericFinalize
    use MAPL_GenericMod, only: MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_GridCreate, MAPL_Get
@@ -42,6 +42,11 @@ module FVdycoreCubed_GridComp
    use MAPL_MaxMinMod, only: MAPL_MaxMin
    use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
    use FileIOSharedMod, only: WRITE_PARALLEL
+
+   use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource
+   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
+   use pflogger, only: logger_t => logger
+
    use m_set_eta, only: set_eta
 
    ! FV Specific Module
@@ -272,18 +277,14 @@ module FVdycoreCubed_GridComp
    integer :: I, J, K  !  Default declaration for loops.
 
    ! Tracer I/O History stuff
-   integer, parameter         :: nlevs=5
-   integer, parameter         :: ntracers=11
-   integer                    :: nlev, ntracer
-   integer                    :: plevs(nlevs)
-   character(len=ESMF_MAXSTR) :: myTracer
-   data plevs /850,700,600,500,300/
+   integer, parameter :: ntracers=11
+   integer, parameter :: plevs(5) = [850, 700, 600, 500, 300]
 
    ! Wrapper for extracting internal state
 
-   type DYN_wrap
-      type (DynState), pointer :: DYN_STATE
-   end type DYN_wrap
+   type dyn_wrap
+      type(DynState), pointer :: dyn_state
+   end type dyn_wrap
 
    interface addTracer
       module procedure addTracer_r4
@@ -296,9 +297,6 @@ module FVdycoreCubed_GridComp
       module procedure Write_Profile_2d_R4
       module procedure Write_Profile_2d_R8
    end interface Write_Profile
-
-   real(kind=8) :: t1, t2
-   real(kind=8) :: dyn_run_timer
 
    logical :: DO_ADD_INCS = .true.
 
@@ -339,48 +337,34 @@ contains
       type(ESMF_GridComp), intent(inout) :: gc     ! gridded component
       integer, intent(out), optional :: rc     ! return code
 
-      !DESCRIPTION: Set services (register) for the FVCAM Dynamical Core
-      !               Grid Component.
+      !DESCRIPTION: Set services (register) for the FVCAM Dynamical Core GridComp
       !EOP
 
-      type (DynState), pointer :: dyn_internal_state
-      type (DYN_wrap)                  :: wrap
+      type(DynState), pointer :: dyn_internal_state
+      type(DYN_wrap) :: wrap
+      character(len=:), allocatable :: layout_file
+      character(len=ESMF_MAXSTR) :: myTracer
+      class(logger_t), pointer :: logger
+      integer :: FV3_STANDALONE, ilev, itracer, status
 
-      integer :: FV3_STANDALONE
-      integer :: status
-      character(len=ESMF_MAXSTR) :: IAm
-      character(len=ESMF_MAXSTR) :: comp_name
+      call MAPL_GridCompGet(gc, logger=logger, _RC)
+      call logger%info("SetServices:: starting...")
 
-      type(ESMF_Config) :: CF
-      type(ESMF_VM) :: VM
-
-      type(MAPL_MetaComp), pointer :: MAPL
-      character(len=ESMF_MAXSTR) :: LAYOUT_FILE
-
-      ! Get the configuration from the component
-      call ESMF_GridCompGet(gc, CONFIG = CF, _RC)
-      call ESMF_GridCompGet(gc, name=comp_name, _RC)
-      Iam = trim(comp_name) // "SetServices"
-
-      call ESMF_VMGetCurrent(VM, _RC)
-
-      call MAPL_MemUtilsWrite(VM, trim(IAm)//': Begin', _RC)
-
-      ! Allocate this instance of the internal state and put it in wrapper.
+      ! Wrap gridcomp's private state and store it in gc
       allocate(dyn_internal_state, _STAT)
       wrap%dyn_state => dyn_internal_state
-
-      ! Save pointer to the wrapped internal state in the gc
       call ESMF_UserCompSetInternalState(gc, 'DYNstate', wrap, _RC)
 
 #include "DynCore_Import___.h"
+#include "DynCore_Export___.h"
+#include "DynCore_Internal___.h"
+
       call MAPL_AddImportSpec(gc, &
            SHORT_NAME='TRADV', &
            LONG_NAME='advected_quantities', &
            UNITS='unknown', &
            DATATYPE=MAPL_BundleItem, _RC)
 
-#include "DynCore_Export___.h"
       call MAPL_AddExportSpec(gc, &
            SHORT_NAME='CX', &
            LONG_NAME='eastward_accumulated_courant_number', &
@@ -412,9 +396,9 @@ contains
            VLOCATION=MAPL_VLocationCenter, _RC)
 
 #ifdef SKIP_TRACERS
-      do ntracer=1,ntracers
-         do nlev=1,nlevs
-            write(myTracer, "('Q',i5.5,'_',i3.3)") ntracer-1, plevs(nlev)
+      do itracer = 1, ntracers
+         do ilev = 1, size(plevs)
+            write(myTracer, "('Q',i5.5,'_',i3.3)") itracer-1, plevs(ilev)
             call MAPL_AddExportSpec(gc, &
                  SHORT_NAME=TRIM(myTracer), &
                  LONG_NAME =TRIM(myTracer), &
@@ -422,7 +406,7 @@ contains
                  DIMS=MAPL_DimsHorzOnly, &
                  VLOCATION=MAPL_VLocationNone, _RC)
          enddo
-         write(myTracer, "('Q',i5.5)") ntracer-1
+         write(myTracer, "('Q',i5.5)") itracer-1
          call MAPL_AddExportSpec(gc, &
               SHORT_NAME=TRIM(myTracer), &
               LONG_NAME=TRIM(myTracer), &
@@ -438,8 +422,6 @@ contains
            UNITS= '', &
            DIMS=MAPL_DimsHorzOnly, &
            VLOCATION=MAPL_VLocationNone, _RC)
-
-#include "DynCore_Internal___.h"
 
       ! pchakrab: TODO: DO WE STILL NEED THIS COMMENT?
       !ALT: technically the first 2 records of "old" style FV restart have
@@ -462,38 +444,35 @@ contains
       call MAPL_TimerAdd(gc, name="FINALIZE", _RC)
 
       ! Register services for this component
-      call MAPL_GridCompSetEntryPoint ( gc, ESMF_METHOD_INITIALIZE,  Initialize, _RC)
-      call MAPL_GridCompSetEntryPoint ( gc, ESMF_METHOD_RUN,   Run, _RC)
-      call MAPL_GridCompSetEntryPoint ( gc, ESMF_METHOD_RUN,   RunAddIncs, _RC)
-      call MAPL_GridCompSetEntryPoint ( gc, ESMF_METHOD_FINALIZE, Finalize, _RC)
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Initialize,  Initialize, _RC)
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Run, Run, phase_name="Run", _RC)
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Run, RunAddIncs, phase_name="RunAddIncs", _RC)
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Finalize, Finalize, _RC)
       !  call MAPL_GridCompSetEntryPoint(gc, ESMF_SETREADRESTART, Coldstart, _RC)
 
       ! Setup FMS/FV3
-      call MAPL_GetObjectFromGC(gc, MAPL, _RC)
-      call MAPL_GetResource(MAPL, LAYOUT_FILE, 'LAYOUT:', default='fvcore_layout.rc', _RC)
-      call DynSetup(gc, LAYOUT_FILE, _RC)
+      call MAPL_GridCompGetResource(gc, "LAYOUT", layout_file, default="fvcore_layout.rc", _RC)
+      call DynSetup(gc, layout_file, _RC)
 
       ! Register prototype of cubed sphere grid and associated regridders
       call register_grid_and_regridders()
 
-      ! At this point check if FV is standalone and init the grid
-      call ESMF_ConfigGetAttribute(CF, FV3_STANDALONE, Label="FV3_STANDALONE:", default=0, _RC)
-      if (FV3_STANDALONE /= 0) then
-         call MAPL_GridCreate(gc, _RC)
-         call MAPL_AddExportSpec(gc, &
-              SHORT_NAME='TRADVEX', &
-              LONG_NAME='advected_quantities', &
-              UNITS='unknown', &
-              DATATYPE=MAPL_BundleItem, _RC)
-      endif
+      ! ! At this point check if FV is standalone and init the grid
+      ! call ESMF_ConfigGetAttribute(CF, FV3_STANDALONE, Label="FV3_STANDALONE:", default=0, _RC)
+      ! if (FV3_STANDALONE /= 0) then
+      !    call MAPL_GridCreate(gc, _RC)
+      !    call MAPL_AddExportSpec(gc, &
+      !         SHORT_NAME='TRADVEX', &
+      !         LONG_NAME='advected_quantities', &
+      !         UNITS='unknown', &
+      !         DATATYPE=MAPL_BundleItem, _RC)
+      ! endif
 
-      call MAPL_GetResource(MAPL, DEBUG_DYN, 'DEBUG_DYN:', default=.FALSE., _RC)
-      call MAPL_GetResource(MAPL, DEBUG_ADV, 'DEBUG_ADV:', default=.FALSE., _RC)
-      call MAPL_GetResource(MAPL, DEBUG_TQ_ERRORS, 'DEBUG_TQ_ERRORS:', default=.FALSE., _RC)
+      call MAPL_GridCompGetResource(gc, "DEBUG_DYN", DEBUG_DYN, default=.false., _RC)
+      call MAPL_GridCompGetResource(gc, "DEBUG_ADV", DEBUG_ADV, default=.false., _RC)
+      call MAPL_GridCompGetResource(gc, "DEBUG_TQ_ERRORS", DEBUG_TQ_ERRORS, default=.false., _RC)
 
-      ! Generic SetServices
-      call MAPL_GenericSetServices(gc, _RC)
-
+      call logger%info("SetServices:: ...complete")
       _RETURN(_SUCCESS)
 
    end subroutine SetServices
@@ -503,11 +482,11 @@ contains
    subroutine Initialize(gc, import, export, clock, rc)
 
       !ARGUMENTS:
-      type(ESMF_GridComp), intent(inout) :: gc       ! composite gridded component
-      type(ESMF_State), intent(inout) :: import      ! import state
-      type(ESMF_State), intent(inout) :: export      ! export state
-      type(ESMF_Clock), intent(inout) :: clock       ! the clock
-      integer, intent(out), OPTIONAL     :: rc       ! Error code, 0 all is well, error otherwise
+      type(ESMF_GridComp):: gc   ! composite gridded component
+      type(ESMF_State) :: import ! import state
+      type(ESMF_State) :: export ! export state
+      type(ESMF_Clock) :: clock  ! the clock
+      integer, intent(out) :: rc ! Error code, 0 all is well, error otherwise
 
       type(ESMF_Config) :: cf
 
@@ -723,11 +702,11 @@ contains
    subroutine Run(gc, import, export, clock, rc)
 
       !ARGUMENTS:
-      type(ESMF_GridComp), intent(inout) :: gc
-      type(ESMF_State), intent(inout) :: import
-      type(ESMF_State), intent(inout) :: export
-      type(ESMF_Clock), intent(inout) :: clock
-      integer, intent(out), optional :: rc
+      type(ESMF_GridComp) :: gc
+      type(ESMF_State) :: import
+      type(ESMF_State) :: export
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
       !EOP
 
       integer :: status
@@ -937,6 +916,10 @@ contains
       logical                             :: doTropvars
 
       integer :: FV3_STANDALONE
+
+      character(len=ESMF_MAXSTR) :: myTracer
+      integer :: itracer
+      real(kind=r8) :: t1, t2, dyn_run_timer
 
       Iam = "Run"
       call ESMF_GridCompGet(gc, name=comp_name, CONFIG=cf, grid=esmfgrid, _RC)
@@ -2276,14 +2259,14 @@ contains
          call FILLOUT3(export, 'PE'     , vars%pe , _RC)
 
 #ifdef SKIP_TRACERS
-         do ntracer=1,ntracers
-            write(myTracer, "('Q',i5.5)") ntracer-1
+         do itracer = 1, ntracers
+            write(myTracer, "('Q',i5.5)") itracer-1
             call MAPL_GetPointer(export, temp3D, TRIM(myTracer), _RC)
-            if((associated(temp3d)) .and. (NQ>=ntracer)) then
-               if (state%vars%tracer(ntracer)%is_r4) then
-                  temp3d = state%vars%tracer(ntracer)%content_r4
+            if((associated(temp3d)) .and. (NQ>=itracer)) then
+               if (state%vars%tracer(itracer)%is_r4) then
+                  temp3d = state%vars%tracer(itracer)%content_r4
                else
-                  temp3d = state%vars%tracer(ntracer)%content
+                  temp3d = state%vars%tracer(itracer)%content
                endif
             endif
          enddo
@@ -3713,7 +3696,7 @@ contains
          deallocate(ana_phis)
       end subroutine state_remap_
 
-   end subroutine RUN
+   end subroutine Run
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -3820,11 +3803,11 @@ contains
    subroutine RunAddIncs(gc, import, export, clock, rc)
 
       !ARGUMENTS:
-      type(ESMF_GridComp), intent(inout) :: gc
-      type (ESMF_State),   intent(inout) :: import
-      type (ESMF_State),   intent(inout) :: export
-      type (ESMF_Clock),   intent(in)    :: clock
-      integer, intent(out), optional     :: rc
+      type(ESMF_GridComp) :: gc
+      type(ESMF_State) :: import
+      type(ESMF_State) :: export
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
       !EOP
 
       integer                                          :: status
@@ -4108,15 +4091,15 @@ contains
          if(associated(temp3d)) temp3d = (tempxy)*(p00/(0.5*(vars%pe(:,:,1:km)+vars%pe(:,:,2:km+1))))**kappa
 
 #ifdef SKIP_TRACERS
-         do ntracer=1,ntracers
-            write(myTracer, "('Q',i5.5)") ntracer-1
+         do itracer=1,ntracers
+            write(myTracer, "('Q',i5.5)") itracer-1
             call MAPL_GetPointer(export, temp3D, TRIM(myTracer), rc=status)
             VERIFY_(STATUS)
-            if((associated(temp3d)) .and. (STATE%GRID%NQ>=ntracer)) then
-               if (state%vars%tracer(ntracer)%is_r4) then
-                  temp3d = state%vars%tracer(ntracer)%content_r4
+            if((associated(temp3d)) .and. (STATE%GRID%NQ>=itracer)) then
+               if (state%vars%tracer(itracer)%is_r4) then
+                  temp3d = state%vars%tracer(itracer)%content_r4
                else
-                  temp3d = state%vars%tracer(ntracer)%content
+                  temp3d = state%vars%tracer(itracer)%content
                endif
             endif
          enddo
@@ -5101,11 +5084,11 @@ contains
    subroutine Finalize(gc, import, export, clock, rc)
 
       !ARGUMENTS:
-      type (ESMF_GridComp), intent(inout) :: gc
-      type (ESMF_State),    intent(inout) :: import
-      type (ESMF_State),    intent(inout) :: export
-      type (ESMF_Clock),    intent(inout) :: clock
-      integer, optional,    intent(  out) :: rc
+      type (ESMF_GridComp) :: gc
+      type (ESMF_State) :: import
+      type (ESMF_State) :: export
+      type (ESMF_Clock) :: clock
+      integer, intent(out) :: rc
       !EOP
 
       type (DYN_wrap) :: wrap

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -282,12 +282,6 @@ module FVdycoreCubed_GridComp
    integer, parameter :: ntracers=11
    integer, parameter :: plevs(5) = [850, 700, 600, 500, 300]
 
-   ! Wrapper for extracting internal state
-
-   type dyn_wrap
-      type(DynState), pointer :: dyn_state
-   end type dyn_wrap
-
    interface addTracer
       module procedure addTracer_r4
       module procedure addTracer_r8
@@ -652,21 +646,19 @@ contains
 
       class(AbstractRegridder), pointer :: L2C, C2L
 
-      ! type(DYN_wrap) :: wrap
-      ! type(DynState), pointer :: state
       type(DynState), pointer :: self
       type(DynGrid), pointer :: grid
       type(DynVars), pointer :: vars
 
-      integer  :: NQ
-      integer  :: IM, JM, KM
-      integer  :: NKE, NPHI
-      integer  :: NUMVARS
-      integer  :: ifirstxy, ilastxy, jfirstxy, jlastxy
-      integer  :: kend, i, j, K, L, n
-      integer  :: im_replay,jm_replay
+      integer :: NQ
+      integer :: IM, JM, KM
+      integer :: NKE, NPHI
+      integer :: NUMVARS
+      integer :: ifirstxy, ilastxy, jfirstxy, jlastxy
+      integer :: kend, i, j, K, L, n
+      integer :: im_replay,jm_replay
       logical, parameter :: convt = .false. ! Until this is run with full physics
-      logical  :: is_shutoff, is_ringing
+      logical :: is_shutoff, is_ringing
 
       real(r8),     pointer :: phisxy(:,:)
       real(kind=4), pointer ::   phis(:,:)
@@ -4822,8 +4814,7 @@ contains
       integer, intent(out) :: rc
       !EOP
 
-      type(DYN_wrap) :: wrap
-      type (DynState), pointer  :: state
+      type (DynState), pointer :: self
       integer :: status
       class(logger_t), pointer :: logger
 
@@ -4834,10 +4825,9 @@ contains
       ! call MAPL_TimerOn(MAPL,"FINALIZE")
 
       ! Retrieve the pointer to the state
-      call ESMF_UserCompGetInternalState(gc, 'DYN_STATE', wrap, _RC)
-      state => wrap%dyn_state
+      _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
 
-      call DynFinalize( state )
+      call DynFinalize(self)
 
       ! call MAPL_TimerOff(MAPL,"FINALIZE")
       ! call MAPL_TimerOff(MAPL,"TOTAL")
@@ -5013,8 +5003,7 @@ contains
       real(REAL8) :: ptop, pint
       real(REAL8), allocatable :: PS(:,:)
 
-      type(DYN_wrap) :: wrap
-      type(DynState), pointer :: state
+      type(DynState), pointer :: self
       type(DynGrid),  pointer :: grid
 
       logical :: perturb
@@ -5034,9 +5023,8 @@ contains
       real(REAL8), parameter :: r0_6=0.6
       real(REAL8), parameter :: r1_0=1.0
 
-      call ESMF_UserCompGetInternalState(gc, 'DYN_STATE', wrap, _RC)
-      state => wrap%dyn_state
-      grid  => state%grid ! direct handle to grid
+      _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
+      grid  => self%grid ! direct handle to grid
 
       call MAPL_GridCompGetResource(gc, "T0", T0, default=273., _RC)
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
@@ -5384,14 +5372,14 @@ contains
             allocate(tracer(is:ie, js:je, 1:KM), _STAT)
             tracer(:,:,:)  = 0.0
             fieldname = 'Q'
-            call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+            call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
 
             if (case_tracers /= 1234) then
 
                do n=1,case_tracers
                   tracer(:,:,:) = 0.0
                   write(fieldname, "('Q',i3.3)") n
-                  call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+                  call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
                enddo
 
             else
@@ -5412,7 +5400,7 @@ contains
                   enddo
                enddo
                fieldname = 'Q1'
-               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q2
@@ -5429,7 +5417,7 @@ contains
                   enddo
                enddo
                fieldname = 'Q2'
-               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q3
@@ -5446,14 +5434,14 @@ contains
                   enddo
                enddo
                fieldname = 'Q3'
-               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q4
                !-------------------
                tracer(:,:,:)  = 1.0_r4
                fieldname = 'Q4'
-               call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+               call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
 
                !-------------------
                !     tracer q5
@@ -5461,7 +5449,7 @@ contains
                if (allocated(Q5)) then
                   tracer(:,:,:)  = Q5(:,:,:)
                   fieldname = 'Q5'
-                  call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+                  call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
                   deallocate(Q5, _STAT)
                endif
 
@@ -5471,7 +5459,7 @@ contains
                if (allocated(Q6)) then
                   tracer(:,:,:)  = Q6(:,:,:)
                   fieldname = 'Q6'
-                  call addTracer(state, tradv_bundle, tracer, esmfgrid, fieldname)
+                  call addTracer(self, tradv_bundle, tracer, esmfgrid, fieldname)
                   deallocate(Q6, _STAT)
                endif
 
@@ -5780,8 +5768,8 @@ contains
    end subroutine set_eta
 #endif
 
-   subroutine addTracer_r8(state, bundle, var, grid, fieldname)
-      type(DynState), pointer :: state
+   subroutine addTracer_r8(self, bundle, var, grid, fieldname)
+      type(DynState), pointer :: self
       type(ESMF_FieldBundle) :: bundle
       real(r8), pointer :: var(:, :, :)
       type(ESMF_Grid) :: grid
@@ -5806,27 +5794,27 @@ contains
       call MAPL_FieldBundleAdd(bundle, field, _RC)
 
       if (nq == 1) then
-         allocate(state%vars%tracer(nq), _STAT)
+         allocate(self%vars%tracer(nq), _STAT)
          call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
-         state%vars%tracer(nq)%content => ptr
-         state%vars%tracer(nq)%is_r4 = .false.
+         self%vars%tracer(nq)%content => ptr
+         self%vars%tracer(nq)%is_r4 = .false.
       else
          allocate(t(nq))
-         t(1:nq-1) = state%vars%tracer
-         deallocate(state%vars%tracer)
-         state%vars%tracer => t
+         t(1:nq-1) = self%vars%tracer
+         deallocate(self%vars%tracer)
+         self%vars%tracer => t
          call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
-         state%vars%tracer(nq)%content => ptr
-         state%vars%tracer(nq  )%is_r4 = .false.
+         self%vars%tracer(nq)%content => ptr
+         self%vars%tracer(nq  )%is_r4 = .false.
       endif
 
-      state%grid%nq = nq
+      self%grid%nq = nq
 
       _RETURN(_SUCCESS)
    end subroutine addTracer_r8
 
-   subroutine addTracer_r4(state, bundle, var, grid, fieldname)
-      type(DynState), pointer :: state
+   subroutine addTracer_r4(self, bundle, var, grid, fieldname)
+      type(DynState), pointer :: self
       type(ESMF_FieldBundle) :: bundle
       real(r4), pointer :: var(:, :, :)
       type(ESMF_Grid) :: grid
@@ -5851,31 +5839,31 @@ contains
       call MAPL_FieldBundleAdd(bundle, field, _RC)
 
       if (NQ == 1) then
-         allocate(state%vars%tracer(nq), _STAT)
+         allocate(self%vars%tracer(nq), _STAT)
          call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
-         state%vars%tracer(nq)%content_r4 => ptr
-         state%vars%tracer(nq)%is_r4 = .true.
+         self%vars%tracer(nq)%content_r4 => ptr
+         self%vars%tracer(nq)%is_r4 = .true.
       else
          allocate(t(nq))
-         t(1:nq-1) = state%vars%tracer
-         deallocate(state%vars%tracer)
-         state%vars%tracer => t
+         t(1:nq-1) = self%vars%tracer
+         deallocate(self%vars%tracer)
+         self%vars%tracer => t
          call ESMF_FieldGet(field, localDE=0, farrayptr=ptr, _RC)
-         state%vars%tracer(nq)%content_r4 => ptr
-         state%vars%tracer(nq  )%is_r4 = .true.
+         self%vars%tracer(nq)%content_r4 => ptr
+         self%vars%tracer(nq  )%is_r4 = .true.
       endif
 
-      state%grid%nq = nq
+      self%grid%nq = nq
 
       _RETURN(_SUCCESS)
    end subroutine addTracer_r4
 
-   subroutine freeTracers(state)
-      type (DynState) :: state
+   subroutine freeTracers(self)
+      type (DynState) :: self
 
-      if (associated(state%vars%tracer)) then
-         deallocate( state%vars%tracer)   ! Comment out to output tracer to checkpoint file
-         NULLIFY( state%vars%tracer)
+      if (associated(self%vars%tracer)) then
+         deallocate( self%vars%tracer)   ! Comment out to output tracer to checkpoint file
+         NULLIFY(self%vars%tracer)
       end if
 
       return

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -24,9 +24,10 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
    use MAPL_Constants, only: MAPL_VLocationCenter, MAPL_VLocationEdge, MAPL_VLocationNone
    use MAPL_Constants, only: MAPL_DimsHorzVert, MAPL_DimsHorzOnly, MAPL_DimsVertOnly
+
    use MAPL_GenericMod, only: MAPL_MetaComp, MAPL_TimerAdd, MAPL_TimerOn
    use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff
-   use MAPL_GenericMod, only: MAPL_GenericSetServices, MAPL_GenericInitialize, MAPL_GenericFinalize
+   use MAPL_GenericMod, only: MAPL_GenericFinalize
    use MAPL_GenericMod, only: MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_GridCreate, MAPL_Get
    use MAPL_GenericMod, only: MAPL_AddImportSpec, MAPL_AddExportSpec, MAPL_AddInternalSpec
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
@@ -41,10 +42,11 @@ module FVdycoreCubed_GridComp
    use MAPL_FieldPointerUtilities, only: MAPL_FieldDestroy
    use MAPL_MaxMinMod, only: MAPL_MaxMin
    use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
+
    use FileIOSharedMod, only: WRITE_PARALLEL
 
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource
-   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
+   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
    use pflogger, only: logger_t => logger
 
    use m_set_eta, only: set_eta
@@ -365,36 +367,6 @@ contains
            UNITS='unknown', &
            DATATYPE=MAPL_BundleItem, _RC)
 
-      call MAPL_AddExportSpec(gc, &
-           SHORT_NAME='CX', &
-           LONG_NAME='eastward_accumulated_courant_number', &
-           UNITS='', &
-           PRECISION=ESMF_KIND_R8, &
-           DIMS=MAPL_DimsHorzVert, &
-           VLOCATION=MAPL_VLocationCenter, _RC)
-
-      call MAPL_AddExportSpec(gc, &
-           SHORT_NAME='CY', &
-           LONG_NAME='northward_accumulated_courant_number', &
-           UNITS='', &
-           PRECISION=ESMF_KIND_R8, &
-           DIMS=MAPL_DimsHorzVert, &
-           VLOCATION=MAPL_VLocationCenter, _RC)
-
-      call MAPL_AddExportSpec(gc, &
-           SHORT_NAME='CU', &
-           LONG_NAME='eastward_accumulated_courant_number', &
-           UNITS= '', &
-           DIMS=MAPL_DimsHorzVert, &
-           VLOCATION=MAPL_VLocationCenter, _RC)
-
-      call MAPL_AddExportSpec(gc, &
-           SHORT_NAME='CV', &
-           LONG_NAME='northward_accumulated_courant_number', &
-           UNITS='', &
-           DIMS=MAPL_DimsHorzVert, &
-           VLOCATION=MAPL_VLocationCenter, _RC)
-
 #ifdef SKIP_TRACERS
       do itracer = 1, ntracers
          do ilev = 1, size(plevs)
@@ -415,13 +387,6 @@ contains
               VLOCATION=MAPL_VLocationCenter, _RC)
       enddo
 #endif
-
-      call MAPL_AddExportSpec(gc, &
-           SHORT_NAME='PID', &
-           LONG_NAME='process_id', &
-           UNITS= '', &
-           DIMS=MAPL_DimsHorzOnly, &
-           VLOCATION=MAPL_VLocationNone, _RC)
 
       ! pchakrab: TODO: DO WE STILL NEED THIS COMMENT?
       !ALT: technically the first 2 records of "old" style FV restart have
@@ -457,16 +422,16 @@ contains
       ! Register prototype of cubed sphere grid and associated regridders
       call register_grid_and_regridders()
 
-      ! ! At this point check if FV is standalone and init the grid
-      ! call ESMF_ConfigGetAttribute(CF, FV3_STANDALONE, Label="FV3_STANDALONE:", default=0, _RC)
-      ! if (FV3_STANDALONE /= 0) then
-      !    call MAPL_GridCreate(gc, _RC)
-      !    call MAPL_AddExportSpec(gc, &
-      !         SHORT_NAME='TRADVEX', &
-      !         LONG_NAME='advected_quantities', &
-      !         UNITS='unknown', &
-      !         DATATYPE=MAPL_BundleItem, _RC)
-      ! endif
+      ! At this point check if FV is standalone and init the grid
+      call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", FV3_STANDALONE, default=0, _RC)
+      if (FV3_STANDALONE /= 0) then
+         ! call MAPL_GridCreate(gc, _RC)
+         call MAPL_AddExportSpec(gc, &
+              short_name='TRADVEX', &
+              long_name='advected_quantities', &
+              units='unknown', &
+              datatype=MAPL_BundleItem, _RC)
+      endif
 
       call MAPL_GridCompGetResource(gc, "DEBUG_DYN", DEBUG_DYN, default=.false., _RC)
       call MAPL_GridCompGetResource(gc, "DEBUG_ADV", DEBUG_ADV, default=.false., _RC)
@@ -488,53 +453,39 @@ contains
       type(ESMF_Clock) :: clock  ! the clock
       integer, intent(out) :: rc ! Error code, 0 all is well, error otherwise
 
-      type(ESMF_Config) :: cf
-
       type(DYN_wrap) :: wrap
-      type (DynState), pointer :: state
+      type(DynState), pointer :: state
+      type(DynGrid), pointer :: DycoreGrid
+
+      type(ESMF_Field) :: field
+      type(ESMF_State) :: internal
+      type(ESMF_TimeInterval) :: intv
+      type(ESMF_Alarm) :: alarm
+      type(ESMF_FieldBundle) :: tradv, tradvex
 
       type(MAPL_MetaComp), pointer :: MAPL
 
-      character(len=ESMF_MAXSTR) :: layout_file
+      character(len=:), allocatable :: layout_file, ReplayMode
 
-      type(ESMF_Field) :: field
       real(r4), pointer :: pref(:), ak4(:), bk4(:)
+      real(r4), pointer :: ple(:,:,:)
+      real(r4), pointer :: u(:,:,:), v(:,:,:), t(:,:,:)
+      real(r4), pointer :: temp2d(:,:)
 
       real(r8), pointer ::  ak(:), bk(:)
       real(r8), pointer ::  ud(:,:,:), vd(:,:,:)
       real(r8), pointer ::  pe(:,:,:), pt(:,:,:), pk(:,:,:)
-
       real(r8), allocatable ::  ur(:,:,:), vr(:,:,:)
 
-      real(r4), pointer :: ple(:,:,:)
-      real(r4), pointer :: u(:,:,:), v(:,:,:), t(:,:,:)
-
-      character(len=ESMF_MAXSTR) :: ReplayMode
       real :: DNS_INTERVAL
-      type(ESMF_TimeInterval) :: intv
-      type(ESMF_Alarm) :: alarm
       integer :: ColdRestart=0
+      integer :: ifirst, ilast, jfirst, jlast, km
+      integer :: i, numTracers, fv3_standalone, status
 
-      integer :: status
-      character(len=ESMF_MAXSTR) :: IAm
-      character(len=ESMF_MAXSTR) :: comp_name
+      class(logger_t), pointer :: logger
 
-      type(ESMF_State) :: internal
-      type (DynGrid), pointer :: DycoreGrid
-
-      real(r4), pointer :: temp2d(:,:)
-
-      integer :: ifirst, ilast, jfirst, jlast
-      integer :: km
-      type(ESMF_FieldBundle) :: tradv, tradvex
-      integer :: i, numTracers, fv3_standalone
-
-      Iam = "Initialize"
-      call ESMF_GridCompGet(gc, name=comp_name, config=cf, _RC)
-      Iam = trim(comp_name) // Iam
-
-      ! Call Generic Initialize
-      call MAPL_GenericInitialize(gc, import, export, clock, _RC)
+      call MAPL_GridCompGet(gc, logger=logger, _RC)
+      call logger%info("Initialize:: starting...")
 
       ! Retrieve the pointer to the state
       call MAPL_GetObjectFromGC(gc, MAPL, _RC)
@@ -543,55 +494,48 @@ contains
       call MAPL_TimerOn(MAPL, "TOTAL")
       call MAPL_TimerOn(MAPL, "INITIALIZE")
 
-      ! Get the private internal state
+      ! Get the private state
       call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
       state => wrap%dyn_state
 
       DycoreGrid  => state%grid ! direct handle to grid
 
-      ! Get file names from the configuration
-      !BOR
-      ! !RESOURCE_ITEM: none :: name of layout file
-      call MAPL_GetResource(MAPL, layout_file, 'LAYOUT:', default='fvcore_layout.rc', _RC)
-      !EOR
-
-      call MAPL_GetResource(MAPL, DO_ADD_INCS, 'DO_ADD_INCS:', default=DO_ADD_INCS, _RC)
+      call MAPL_GridCompGetResource(gc, "LAYOUT", layout_file, default="fvcore_layout.rc", _RC)
+      call MAPL_GridCompGetResource(gc, 'DO_ADD_INCS:', DO_ADD_INCS, default=DO_ADD_INCS, _RC)
 
       ! Check for ColdStart from the configuration
-      call MAPL_GetResource(MAPL, ColdRestart, 'COLDSTART:', default=0, _RC)
+      call MAPL_GridCompGetResource(gc, "COLDSTART", ColdRestart, default=0, _RC)
       if (ColdRestart /= 0 ) then
          call Coldstart(gc, import, export, clock, _RC)
       endif
 
       ! Set Private Internal State from Restart File
-      call MAPL_Get(MAPL, INTERNAL_ESMF_STATE=internal, _RC)
+      call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
       call MAPL_TimerOn(MAPL, "-DYN_INIT")
       call DynInit(state, clock, internal, import, gc, _RC)
       call MAPL_TimerOff(MAPL, "-DYN_INIT")
 
       ! Create PLE and PREF EXPORT Coupling (Needs to be done only once per run)
-      call MAPL_GetPointer(export, pref, 'PREF', ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, ak4, 'AK', ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, bk4, 'BK', ALLOC=.true., _RC)
-
-      call MAPL_GetPointer(internal, ak, 'AK', _RC)
-      call MAPL_GetPointer(internal, bk, 'BK', _RC)
-
+      call MAPL_GetPointer(internal, ak, "AK", _RC)
+      call MAPL_GetPointer(internal, bk, "BK", _RC)
+      call MAPL_GetPointer(export, ak4, "AK", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, bk4, "BK", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, pref, "PREF", ALLOC=.true., _RC)
       ak4 = ak
       bk4 = bk
       pref = ak + bk * P00
 
-      call MAPL_GetPointer(internal, ud, 'U', _RC)
-      call MAPL_GetPointer(internal, vd, 'V', _RC)
-      call MAPL_GetPointer(internal, pe, 'PE', _RC)
-      call MAPL_GetPointer(internal, pt, 'PT', _RC)
-      call MAPL_GetPointer(internal, pk, 'PKZ', _RC)
+      call MAPL_GetPointer(internal, ud, "U", _RC)
+      call MAPL_GetPointer(internal, vd, "V", _RC)
+      call MAPL_GetPointer(internal, pe, "PE", _RC)
+      call MAPL_GetPointer(internal, pt, "PT", _RC)
+      call MAPL_GetPointer(internal, pk, "PKZ", _RC)
 
-      call MAPL_GetPointer(export, ple, 'PLE', ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, u, 'U', ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, v, 'V', ALLOC=.true., _RC)
-      call MAPL_GetPointer(export, t, 'T', ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, ple, "PLE", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, u, "U", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, v, "V", ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, t, "T", ALLOC=.true., _RC)
 
       ! Create A-Grid Winds
       ifirst = state%grid%is
@@ -613,13 +557,13 @@ contains
       deallocate(ur, vr)
 
       ! Fill Grid-Cell Area Delta-X/Y
-      call MAPL_GetPointer(export, temp2d, 'DXC', ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, temp2d, "DXC", ALLOC=.true., _RC)
       temp2d = DycoreGrid%dxc
 
-      call MAPL_GetPointer(export, temp2d, 'DYC', ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, temp2d, "DYC", ALLOC=.true., _RC)
       temp2d = DycoreGrid%dyc
 
-      call MAPL_GetPointer(export, temp2d, 'AREA', ALLOC=.true., _RC)
+      call MAPL_GetPointer(export, temp2d, "AREA", ALLOC=.true., _RC)
       temp2d = DycoreGrid%area
 
       ! ======================================================================
@@ -630,25 +574,25 @@ contains
       !     would be to move the computation to phase 2 of Initialize and
       !     eliminate this section alltogether
       ! ======================================================================
-      call ESMF_StateGet(export, 'PREF', FIELD, _RC)
+      call ESMF_StateGet(export, "PREF", field, _RC)
       call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, 'PLE', FIELD, _RC)
+      call ESMF_StateGet(export, "PLE", field, _RC)
       call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, 'U', FIELD, _RC)
+      call ESMF_StateGet(export, "U", field, _RC)
       call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, 'V', FIELD, _RC)
+      call ESMF_StateGet(export, "V", field, _RC)
       call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call ESMF_StateGet(export, 'T', FIELD, _RC)
+      call ESMF_StateGet(export, "T", field, _RC)
       call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", VALUE=MAPL_InitialRestart, _RC)
 
-      call MAPL_GetResource(MAPL, fv3_standalone, label="FV3_STANDALONE:", default=0, _RC)
+      call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", fv3_standalone, default=0, _RC)
       if (fv3_standalone /= 0) then
-         call ESMF_StateGet(import, 'TRADV', tradv, _RC)
-         call ESMF_StateGet(export, 'TRADVEX', tradvex, _RC)
+         call ESMF_StateGet(import, "TRADV", tradv, _RC)
+         call ESMF_StateGet(export, "TRADVEX", tradvex, _RC)
          call ESMF_FieldBundleGet(tradv, fieldCount=numTracers, _RC)
          do i=1,numTracers
             call ESMF_FieldBundleGet(tradv, fieldIndex=i, field=field, _RC)
@@ -664,11 +608,11 @@ contains
       ! work whether the clock is backed-up and ticked
       ! or not.
 
-      call MAPL_GetResource(MAPL, ReplayMode, 'REPLAY_MODE:', default="NoReplay", _RC)
+      call MAPL_GridCompGetResource(gc, "REPLAY_MODE", ReplayMode, default="NoReplay", _RC)
       if (adjustl(ReplayMode) == "Intermittent") then
-         call MAPL_GetResource(MAPL, DNS_INTERVAL, 'REPLAY_INTERVAL:', default=21600., _RC)
-         call ESMF_TimeIntervalSet(intv, S=nint(DNS_INTERVAL), _RC)
-         alarm = ESMF_AlarmCreate(name='INTERMITTENT', clock=clock, ringInterval=intv, sticky=.false., _RC)
+         call MAPL_GridCompGetResource(gc, "REPLAY_INTERVAL", DNS_INTERVAL, default=21600., _RC)
+         call ESMF_TimeIntervalSet(intv, s=nint(DNS_INTERVAL), _RC)
+         alarm = ESMF_AlarmCreate(name="INTERMITTENT", clock=clock, ringInterval=intv, sticky=.false., _RC)
          call ESMF_AlarmRingerOn(alarm, _RC)
       end if
 

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -17,19 +17,14 @@ module FVdycoreCubed_GridComp
    use ESMF
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
 
-   use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
    use MAPL_Constants, only: MAPL_VectorField, MAPL_BundleItem
    use MAPL_Constants, only: MAPL_RestartSkip, MAPL_RestartRequired, MAPL_InitialRestart
-   ! use MAPL_Constants, only: MAPL_VLocationCenter, MAPL_VLocationEdge, MAPL_VLocationNone
-   use MAPL_Constants, only: MAPL_DimsHorzVert, MAPL_DimsHorzOnly, MAPL_DimsVertOnly
 
-   use MAPL_GenericMod, only: MAPL_MetaComp, MAPL_TimerAdd, MAPL_TimerOn
-   use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff
-   use MAPL_GenericMod, only: MAPL_GenericFinalize
-   use MAPL_GenericMod, only: MAPL_GetObjectFromGC, MAPL_GetResource, MAPL_GridCreate, MAPL_Get
-   ! use MAPL_GenericMod, only: MAPL_AddImportSpec, MAPL_AddExportSpec, MAPL_AddInternalSpec
+   use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
+
+   use MAPL_GenericMod, only: MAPL_TimerAdd
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
    use MAPL_BaseMod, only: MAPL_AttributeSet, MAPL_FieldBundleAdd
@@ -41,13 +36,14 @@ module FVdycoreCubed_GridComp
    use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
    use MAPL_FieldPointerUtilities, only: MAPL_FieldDestroy
    use MAPL_MaxMinMod, only: MAPL_MaxMin
-   use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
+   use MAPL_CommsMod, only: MAPL_AM_I_ROOT, MAPL_ArrayGather => ArrayGather
 
    use FileIOSharedMod, only: WRITE_PARALLEL
 
    use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompAddSpec, MAPL_STATEITEM_FIELDBUNDLE
+   use mapl3g_generic, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
    use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
    use mapl3g_Geom_API, only: MAPL_GridGet
    use mapl3g_State_API, only: MAPL_StateGetPointer
@@ -306,6 +302,8 @@ module FVdycoreCubed_GridComp
 
    logical :: DO_ADD_INCS = .true.
 
+   character(*), parameter :: PRIVATE_STATE = "DYN_STATE"
+
 contains
 
    !BOP
@@ -346,8 +344,7 @@ contains
       !DESCRIPTION: Set services (register) for the FVCAM Dynamical Core GridComp
       !EOP
 
-      type(DynState), pointer :: dyn_internal_state
-      type(DYN_wrap) :: wrap
+      type(DynState), pointer :: self
       character(len=:), allocatable :: layout_file
       character(len=ESMF_MAXSTR) :: myTracer
       class(logger_t), pointer :: logger
@@ -357,9 +354,7 @@ contains
       call logger%info("SetServices:: starting...")
 
       ! Wrap gridcomp's private state and store it in gc
-      allocate(dyn_internal_state, _STAT)
-      wrap%dyn_state => dyn_internal_state
-      call ESMF_UserCompSetInternalState(gc, 'DYNstate', wrap, _RC)
+      _SET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE)
 
 #include "DynCore_Import___.h"
 #include "DynCore_Export___.h"
@@ -461,9 +456,7 @@ contains
       type(ESMF_Clock) :: clock  ! the clock
       integer, intent(out) :: rc ! Error code, 0 all is well, error otherwise
 
-      type(DYN_wrap) :: wrap
-      type(DynState), pointer :: state
-      type(DynGrid), pointer :: DycoreGrid
+      type(DynState), pointer :: self
 
       type(ESMF_Field) :: field
       type(ESMF_State) :: internal
@@ -499,10 +492,7 @@ contains
       ! call MAPL_TimerOn(MAPL, "INITIALIZE")
 
       ! Get the private state
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
-      state => wrap%dyn_state
-
-      DycoreGrid  => state%grid ! direct handle to grid
+      _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
 
       call MAPL_GridCompGetResource(gc, "LAYOUT", layout_file, default="fvcore_layout.rc", _RC)
       call MAPL_GridCompGetResource(gc, "DO_ADD_INCS", DO_ADD_INCS, default=DO_ADD_INCS, _RC)
@@ -517,7 +507,7 @@ contains
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
       ! call MAPL_TimerOn(MAPL, "-DYN_INIT")
-      call DynInit(state, clock, import, gc, _RC)
+      call DynInit(self, clock, import, gc, _RC)
       ! call MAPL_TimerOff(MAPL, "-DYN_INIT")
 
       ! Create PLE and PREF EXPORT Coupling (Needs to be done only once per run)
@@ -542,11 +532,11 @@ contains
       call MAPL_GetPointer(export, t, "T", ALLOC=.true., _RC)
 
       ! Create A-Grid Winds
-      ifirst = state%grid%is
-      ilast  = state%grid%ie
-      jfirst = state%grid%js
-      jlast  = state%grid%je
-      km     = state%grid%npz
+      ifirst = self%grid%is
+      ilast  = self%grid%ie
+      jfirst = self%grid%js
+      jlast  = self%grid%je
+      km     = self%grid%npz
 
       allocate(ur(ifirst:ilast,jfirst:jlast,km))
       allocate(vr(ifirst:ilast,jfirst:jlast,km))
@@ -559,13 +549,13 @@ contains
 
       ! Fill Grid-Cell Area Delta-X/Y
       call MAPL_GetPointer(export, temp2d, "DXC", ALLOC=.true., _RC)
-      temp2d = DycoreGrid%dxc
+      temp2d = self%grid%dxc
 
       call MAPL_GetPointer(export, temp2d, "DYC", ALLOC=.true., _RC)
-      temp2d = DycoreGrid%dyc
+      temp2d = self%grid%dyc
 
       call MAPL_GetPointer(export, temp2d, "AREA", ALLOC=.true., _RC)
-      temp2d = DycoreGrid%area
+      temp2d = self%grid%area
 
       ! ======================================================================
       !ALT: the next section addresses the problem when export variables have been
@@ -662,8 +652,9 @@ contains
 
       class(AbstractRegridder), pointer :: L2C, C2L
 
-      type(DYN_wrap) :: wrap
-      type(DynState), pointer :: state
+      ! type(DYN_wrap) :: wrap
+      ! type(DynState), pointer :: state
+      type(DynState), pointer :: self
       type(DynGrid), pointer :: grid
       type(DynVars), pointer :: vars
 
@@ -871,18 +862,17 @@ contains
       if( associated(temp2D) ) temp2d = lats
 
       ! Retrieve the pointer to the internal state
-      call ESMF_UserCompGetInternalState(gc, "DYNstate", wrap, _RC)
-      state => wrap%dyn_state
+      _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
 
-      vars => state%vars ! direct handle to control variables
-      grid => state%grid ! direct handle to grid
-      dt =  state%dt ! dynamics time step (large)
+      vars => self%vars ! direct handle to control variables
+      grid => self%grid ! direct handle to grid
+      dt =  self%dt ! dynamics time step (large)
 
       ifirstxy = grid%is; ilastxy  = grid%ie
       jfirstxy = grid%js; jlastxy  = grid%je
       im = grid%npx; jm = grid%npy; km = grid%npz
 
-      is_ringing = ESMF_AlarmIsRinging(state%ALARMS(TIME_TO_RUN), _RC)
+      is_ringing = ESMF_AlarmIsRinging(self%ALARMS(TIME_TO_RUN), _RC)
       if (.not. is_ringing) return
 
       ! Allocate Arrays
@@ -1088,7 +1078,7 @@ contains
       phisxy = real(phis,kind=r8)
 
       ! Get tracers from import State (Note: Contains Updates from Analysis)
-      call PULL_Q (state, import, qqq, NXQ, _RC)
+      call PULL_Q (self, import, qqq, NXQ, _RC)
 
       !-----------------------------
       ! end of fewer_tracers-section
@@ -1274,38 +1264,38 @@ contains
          QG = 0.0
          do N = 1,size(names)
             if( trim(names(N)).eq."QLCN" .or. trim(names(N)).eq."QLLS" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
-                  QL = QL + state%vars%tracer(N)%content_r4
+               if( self%vars%tracer(N)%is_r4 ) then
+                  QL = QL + self%vars%tracer(N)%content_r4
                else
-                  QL = QL + state%vars%tracer(N)%content
+                  QL = QL + self%vars%tracer(N)%content
                endif
             endif
             if( trim(names(N)).eq."QICN" .or. trim(names(N)).eq."QILS" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
-                  QI = QI + state%vars%tracer(N)%content_r4
+               if( self%vars%tracer(N)%is_r4 ) then
+                  QI = QI + self%vars%tracer(N)%content_r4
                else
-                  QI = QI + state%vars%tracer(N)%content
+                  QI = QI + self%vars%tracer(N)%content
                endif
             endif
             if( trim(names(N)).eq."QRAIN" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
-                  QR = state%vars%tracer(N)%content_r4
+               if( self%vars%tracer(N)%is_r4 ) then
+                  QR = self%vars%tracer(N)%content_r4
                else
-                  QR = state%vars%tracer(N)%content
+                  QR = self%vars%tracer(N)%content
                endif
             endif
             if( trim(names(N)).eq."QSNOW" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
-                  QS = state%vars%tracer(N)%content_r4
+               if( self%vars%tracer(N)%is_r4 ) then
+                  QS = self%vars%tracer(N)%content_r4
                else
-                  QS = state%vars%tracer(N)%content
+                  QS = self%vars%tracer(N)%content
                endif
             endif
             if( trim(names(N)).eq."QGRAUPEL" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
-                  QG = state%vars%tracer(N)%content_r4
+               if( self%vars%tracer(N)%is_r4 ) then
+                  QG = self%vars%tracer(N)%content_r4
                else
-                  QG = state%vars%tracer(N)%content
+                  QG = self%vars%tracer(N)%content
                endif
             endif
          enddo
@@ -1376,10 +1366,10 @@ contains
             do N = 1,size(names)
                if( trim(names(N)).eq."QLCN" .or. trim(names(N)).eq."QLLS" ) then
                   do k=1,km
-                     if( state%vars%tracer(N)%is_r4 ) then
-                        dqldtanaint1 = dqldtanaint1 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(N)%is_r4 ) then
+                        dqldtanaint1 = dqldtanaint1 + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        dqldtanaint1 = dqldtanaint1 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
+                        dqldtanaint1 = dqldtanaint1 + self%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -1398,10 +1388,10 @@ contains
             do N = 1,size(names)
                if( trim(names(N)).eq."QICN" .or. trim(names(N)).eq."QILS" ) then
                   do k=1,km
-                     if( state%vars%tracer(N)%is_r4 ) then
-                        dqidtanaint1 = dqidtanaint1 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(N)%is_r4 ) then
+                        dqidtanaint1 = dqidtanaint1 + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        dqidtanaint1 = dqidtanaint1 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
+                        dqidtanaint1 = dqidtanaint1 + self%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -1445,9 +1435,9 @@ contains
          ! Add Analysis Tendencies
          delpold = delp ! Old Pressure Thickness
 
-         call ADD_INCS(esmfgrid, state, import, DT, is_weighted=is_weighted)
+         call ADD_INCS(esmfgrid, self, import, DT, is_weighted=is_weighted)
 
-         if (DYN_DEBUG) call DEBUG_FV_STATE("ANA ADD_INCS", state)
+         if (DYN_DEBUG) call DEBUG_FV_STATE("ANA ADD_INCS", self)
 
          delp = vars%pe(:,:,2:)-vars%pe(:,:,:km)   ! Updated Pressure Thickness
 
@@ -1455,16 +1445,16 @@ contains
          if ((.not. ADIABATIC)) then
             do n=1,NQ
                qsum1(:,:) = 0.0_r8
-               if( state%vars%TRACER(N)%IS_R4 ) then
+               if( self%vars%TRACER(N)%IS_R4 ) then
                   do k=1,km
                      where( delp(:,:,k).ne.delpold(:,:,k) )
-                        qsum1(:,:) = qsum1(:,:) + state%vars%tracer(n)%content_r4(:,:,k)*delpold(:,:,k)
+                        qsum1(:,:) = qsum1(:,:) + self%vars%tracer(n)%content_r4(:,:,k)*delpold(:,:,k)
                      end where
                   enddo
                else
                   do k=1,km
                      where( delp(:,:,k).ne.delpold(:,:,k) )
-                        qsum1(:,:) = qsum1(:,:) + state%vars%tracer(n)%content   (:,:,k)*delpold(:,:,k)
+                        qsum1(:,:) = qsum1(:,:) + self%vars%tracer(n)%content   (:,:,k)*delpold(:,:,k)
                      end where
                   enddo
                endif
@@ -1490,10 +1480,10 @@ contains
                     (trim(names(n)).ne."QRAIN") .and. &
                     (trim(names(n)).ne."QSNOW") .and. &
                     (trim(names(n)).ne."QGRAUPEL") ) then
-                  if( state%vars%TRACER(N)%IS_R4 ) then
-                     state%vars%tracer(n)%content_r4 = state%vars%tracer(n)%content_r4 * ( QDNEW/QDOLD )
+                  if( self%vars%TRACER(N)%IS_R4 ) then
+                     self%vars%tracer(n)%content_r4 = self%vars%tracer(n)%content_r4 * ( QDNEW/QDOLD )
                   else
-                     state%vars%tracer(n)%content    = state%vars%tracer(n)%content    * ( QDNEW/QDOLD )
+                     self%vars%tracer(n)%content    = self%vars%tracer(n)%content    * ( QDNEW/QDOLD )
                   endif
                endif
             enddo
@@ -1503,16 +1493,16 @@ contains
          if ((.not. ADIABATIC)) then
             do n=1,NQ
                qsum1(:,:) = 0.0_r8
-               if( state%vars%TRACER(N)%IS_R4 ) then
+               if( self%vars%TRACER(N)%IS_R4 ) then
                   do k=1,km
                      where( delp(:,:,k).ne.delpold(:,:,k) )
-                        qsum1(:,:) = qsum1(:,:) + state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
+                        qsum1(:,:) = qsum1(:,:) + self%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                      end where
                   enddo
                else
                   do k=1,km
                      where( delp(:,:,k).ne.delpold(:,:,k) )
-                        qsum1(:,:) = qsum1(:,:) + state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
+                        qsum1(:,:) = qsum1(:,:) + self%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
                      end where
                   enddo
                endif
@@ -1547,16 +1537,16 @@ contains
                   endif
                   ! IF (MAPL_AM_I_ROOT()) print *, trim(names(n))," ratio is: ",trsum2(n)
 
-                  if( state%vars%TRACER(N)%IS_R4 ) then
+                  if( self%vars%TRACER(N)%IS_R4 ) then
                      do k=1,km
                         where( delp(:,:,k).ne.delpold(:,:,k) )
-                           state%vars%tracer(n)%content_r4(:,:,k) = state%vars%tracer(n)%content_r4(:,:,k) * trsum2(n)
+                           self%vars%tracer(n)%content_r4(:,:,k) = self%vars%tracer(n)%content_r4(:,:,k) * trsum2(n)
                         end where
                      enddo
                   else
                      do k=1,km
                         where( delp(:,:,k).ne.delpold(:,:,k) )
-                           state%vars%tracer(n)%content   (:,:,k) = state%vars%tracer(n)%content   (:,:,k) * trsum2(n)
+                           self%vars%tracer(n)%content   (:,:,k) = self%vars%tracer(n)%content   (:,:,k) * trsum2(n)
                         end where
                      enddo
                   endif
@@ -1656,10 +1646,10 @@ contains
                if( trim(names(N)).eq."QLCN" .or. &
                     trim(names(N)).eq."QLLS" ) then
                   do k=1,km
-                     if( state%vars%tracer(N)%is_r4 ) then
-                        dqldtanaint2 = dqldtanaint2 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(N)%is_r4 ) then
+                        dqldtanaint2 = dqldtanaint2 + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        dqldtanaint2 = dqldtanaint2 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
+                        dqldtanaint2 = dqldtanaint2 + self%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -1677,10 +1667,10 @@ contains
                if( trim(names(N)).eq."QICN" .or. &
                     trim(names(N)).eq."QILS" ) then
                   do k=1,km
-                     if( state%vars%tracer(N)%is_r4 ) then
-                        dqidtanaint2 = dqidtanaint2 + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(N)%is_r4 ) then
+                        dqidtanaint2 = dqidtanaint2 + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        dqidtanaint2 = dqidtanaint2 + state%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
+                        dqidtanaint2 = dqidtanaint2 + self%vars%tracer(N)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -1793,12 +1783,12 @@ contains
             do k = 1,size(names)
                if( trim(names(k)).eq."QLCN" .or. &
                     trim(names(k)).eq."QLLS" ) then
-                  if( state%vars%tracer(k)%is_r4 ) then
-                     if (size(dqldt)==size(state%vars%tracer(k)%content_r4)) &
-                          dqldt = dqldt - state%vars%tracer(k)%content_r4
+                  if( self%vars%tracer(k)%is_r4 ) then
+                     if (size(dqldt)==size(self%vars%tracer(k)%content_r4)) &
+                          dqldt = dqldt - self%vars%tracer(k)%content_r4
                   else
-                     if (size(dqldt)==size(state%vars%tracer(k)%content)) &
-                          dqldt = dqldt - state%vars%tracer(k)%content
+                     if (size(dqldt)==size(self%vars%tracer(k)%content)) &
+                          dqldt = dqldt - self%vars%tracer(k)%content
                   endif
                endif
             enddo
@@ -1809,12 +1799,12 @@ contains
             do k = 1,size(names)
                if( trim(names(k)).eq."QICN" .or. &
                     trim(names(k)).eq."QILS" ) then
-                  if( state%vars%tracer(k)%is_r4 ) then
-                     if (size(dqidt)==size(state%vars%tracer(k)%content_r4)) &
-                          dqidt = dqidt - state%vars%tracer(k)%content_r4
+                  if( self%vars%tracer(k)%is_r4 ) then
+                     if (size(dqidt)==size(self%vars%tracer(k)%content_r4)) &
+                          dqidt = dqidt - self%vars%tracer(k)%content_r4
                   else
-                     if (size(dqidt)==size(state%vars%tracer(k)%content)) &
-                          dqidt = dqidt - state%vars%tracer(k)%content
+                     if (size(dqidt)==size(self%vars%tracer(k)%content)) &
+                          dqidt = dqidt - self%vars%tracer(k)%content
                   endif
                endif
             enddo
@@ -1826,12 +1816,12 @@ contains
                pos = index(names(k),"::")
                if(pos > 0) then
                   if( (names(k)(pos+2:))=="OX" ) then
-                     if( state%vars%tracer(k)%is_r4 ) then
-                        if (size(doxdt)==size(state%vars%tracer(k)%content_r4)) &
-                             doxdt = doxdt - state%vars%tracer(k)%content_r4
+                     if( self%vars%tracer(k)%is_r4 ) then
+                        if (size(doxdt)==size(self%vars%tracer(k)%content_r4)) &
+                             doxdt = doxdt - self%vars%tracer(k)%content_r4
                      else
-                        if (size(doxdt)==size(state%vars%tracer(k)%content)) &
-                             doxdt = doxdt - state%vars%tracer(k)%content
+                        if (size(doxdt)==size(self%vars%tracer(k)%content)) &
+                             doxdt = doxdt - self%vars%tracer(k)%content
                      endif
                   endif
                endif
@@ -1854,13 +1844,13 @@ contains
          do N = 1,size(names)
             if( trim(names(N)).eq."QLCN" .or. &
                  trim(names(N)).eq."QLLS" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
+               if( self%vars%tracer(N)%is_r4 ) then
                   do k=1,km
-                     temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                     temp2d = temp2d - self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                   enddo
                else
                   do k=1,km
-                     temp2d = temp2d - state%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
+                     temp2d = temp2d - self%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
                   enddo
                endif
             endif
@@ -1873,13 +1863,13 @@ contains
          do N = 1,size(names)
             if( trim(names(N)).eq."QICN" .or. &
                  trim(names(N)).eq."QILS" ) then
-               if( state%vars%tracer(N)%is_r4 ) then
+               if( self%vars%tracer(N)%is_r4 ) then
                   do k=1,km
-                     temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                     temp2d = temp2d - self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                   enddo
                else
                   do k=1,km
-                     temp2d = temp2d - state%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
+                     temp2d = temp2d - self%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
                   enddo
                endif
             endif
@@ -1893,13 +1883,13 @@ contains
             pos = index(names(N),"::")
             if(pos > 0) then
                if( (names(N)(pos+2:))=="OX" ) then
-                  if( state%vars%tracer(N)%is_r4 ) then
+                  if( self%vars%tracer(N)%is_r4 ) then
                      do k=1,km
-                        temp2d = temp2d - state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                        temp2d = temp2d - self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
                   else
                      do k=1,km
-                        temp2d = temp2d - state%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
+                        temp2d = temp2d - self%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
                      enddo
                   endif
                endif
@@ -1936,7 +1926,7 @@ contains
 
       ! call MAPL_TimerOn(MAPL, "-DYN_CORE")
       t1 = MPI_Wtime(status)
-      call DynRun(state, export, clock, gc, PLE0=pe0, _RC)
+      call DynRun(self, export, clock, gc, PLE0=pe0, _RC)
       t2 = MPI_Wtime(status)
       dyn_run_timer = t2-t1
       ! call MAPL_TimerOff(MAPL, "-DYN_CORE")
@@ -1980,7 +1970,7 @@ contains
       else               ! .not. SW_DYNAMICS
 
          ! Load Local Variable with Vapor Specific Humidity
-         if ((.not. ADIABATIC) .and. (state%grid%NQ > 0)) then
+         if ((.not. ADIABATIC) .and. (self%grid%NQ > 0)) then
             if ( qqq%is_r4 ) then
                if (size(qv)==size(qqq%content_r4)) qv = qqq%content_r4
             else
@@ -2181,10 +2171,10 @@ contains
             write(myTracer, "('Q',i5.5)") itracer-1
             call MAPL_GetPointer(export, temp3D, TRIM(myTracer), _RC)
             if((associated(temp3d)) .and. (NQ>=itracer)) then
-               if (state%vars%tracer(itracer)%is_r4) then
-                  temp3d = state%vars%tracer(itracer)%content_r4
+               if (self%vars%tracer(itracer)%is_r4) then
+                  temp3d = self%vars%tracer(itracer)%content_r4
                else
-                  temp3d = state%vars%tracer(itracer)%content
+                  temp3d = self%vars%tracer(itracer)%content
                endif
             endif
          enddo
@@ -2215,12 +2205,12 @@ contains
                     trim(names(k)).eq.'QILS' .or. &
                     trim(names(k)).eq.'QICN' .or. &
                     trim(names(k)).eq.'QLLS' ) then
-                  if( state%vars%tracer(k)%is_r4 ) then
-                     if (size(dqldt)==size(state%vars%tracer(k)%content_r4)) &
-                          qctmp = qctmp + state%vars%tracer(k)%content_r4
+                  if( self%vars%tracer(k)%is_r4 ) then
+                     if (size(dqldt)==size(self%vars%tracer(k)%content_r4)) &
+                          qctmp = qctmp + self%vars%tracer(k)%content_r4
                   else
-                     if (size(dqldt)==size(state%vars%tracer(k)%content)) &
-                          qctmp = qctmp + state%vars%tracer(k)%content
+                     if (size(dqldt)==size(self%vars%tracer(k)%content)) &
+                          qctmp = qctmp + self%vars%tracer(k)%content
                   endif
                endif
             enddo
@@ -2230,10 +2220,10 @@ contains
             do N = 1,size(names)
                if( trim(names(N)).eq.'QLCN' .or. &
                     trim(names(N)).eq.'QLLS' ) then
-                  if( state%vars%tracer(N)%is_r4 ) then
-                     dqldt = dqldt + state%vars%tracer(N)%content_r4
+                  if( self%vars%tracer(N)%is_r4 ) then
+                     dqldt = dqldt + self%vars%tracer(N)%content_r4
                   else
-                     dqldt = dqldt + state%vars%tracer(N)%content
+                     dqldt = dqldt + self%vars%tracer(N)%content
                   endif
                endif
             enddo
@@ -2244,10 +2234,10 @@ contains
             do N = 1,size(names)
                if( trim(names(N)).eq.'QICN' .or. &
                     trim(names(N)).eq.'QILS' ) then
-                  if( state%vars%tracer(N)%is_r4 ) then
-                     dqidt = dqidt + state%vars%tracer(N)%content_r4
+                  if( self%vars%tracer(N)%is_r4 ) then
+                     dqidt = dqidt + self%vars%tracer(N)%content_r4
                   else
-                     dqidt = dqidt + state%vars%tracer(N)%content
+                     dqidt = dqidt + self%vars%tracer(N)%content
                   endif
                endif
             enddo
@@ -2259,10 +2249,10 @@ contains
                pos = index(names(N),'::')
                if(pos > 0) then
                   if( (names(N)(pos+2:))=='OX' ) then
-                     if( state%vars%tracer(N)%is_r4 ) then
-                        doxdt = doxdt + state%vars%tracer(N)%content_r4
+                     if( self%vars%tracer(N)%is_r4 ) then
+                        doxdt = doxdt + self%vars%tracer(N)%content_r4
                      else
-                        doxdt = doxdt + state%vars%tracer(N)%content
+                        doxdt = doxdt + self%vars%tracer(N)%content
                      endif
                   endif
                endif
@@ -2284,13 +2274,13 @@ contains
             do N = 1,size(names)
                if( trim(names(N)).eq.'QLCN' .or. &
                     trim(names(N)).eq.'QLLS' ) then
-                  if( state%vars%tracer(N)%is_r4 ) then
+                  if( self%vars%tracer(N)%is_r4 ) then
                      do k=1,km
-                        temp2d = temp2d + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
                   else
                      do k=1,km
-                        temp2d = temp2d + state%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + self%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
                      enddo
                   endif
                endif
@@ -2303,13 +2293,13 @@ contains
             do N = 1,size(names)
                if( trim(names(N)).eq.'QICN' .or. &
                     trim(names(N)).eq.'QILS' ) then
-                  if( state%vars%tracer(N)%is_r4 ) then
+                  if( self%vars%tracer(N)%is_r4 ) then
                      do k=1,km
-                        temp2d = temp2d + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                      enddo
                   else
                      do k=1,km
-                        temp2d = temp2d + state%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + self%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
                      enddo
                   endif
                endif
@@ -2323,13 +2313,13 @@ contains
                pos = index(names(N),'::')
                if(pos > 0) then
                   if( (names(N)(pos+2:))=='OX' ) then
-                     if( state%vars%tracer(N)%is_r4 ) then
+                     if( self%vars%tracer(N)%is_r4 ) then
                         do k=1,km
-                           temp2d = temp2d + state%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
+                           temp2d = temp2d + self%vars%tracer(N)%content_r4(:,:,k)*delp(:,:,k)
                         enddo
                      else
                         do k=1,km
-                           temp2d = temp2d + state%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
+                           temp2d = temp2d + self%vars%tracer(N)%content(:,:,k)*delp(:,:,k)
                         enddo
                      endif
                   endif
@@ -2437,10 +2427,10 @@ contains
                if( trim(names(n)).eq.'QLCN' .or. &
                     trim(names(n)).eq.'QLLS' ) then
                   do k=1,km
-                     if( state%vars%tracer(n)%is_r4 ) then
-                        temp2d = temp2d + ur(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(n)%is_r4 ) then
+                        temp2d = temp2d + ur(:,:,k)*self%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        temp2d = temp2d + ur(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + ur(:,:,k)*self%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -2455,10 +2445,10 @@ contains
                if( trim(names(n)).eq.'QLCN' .or. &
                     trim(names(n)).eq.'QLLS' ) then
                   do k=1,km
-                     if( state%vars%tracer(n)%is_r4 ) then
-                        temp2d = temp2d + vr(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(n)%is_r4 ) then
+                        temp2d = temp2d + vr(:,:,k)*self%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        temp2d = temp2d + vr(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + vr(:,:,k)*self%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -2474,10 +2464,10 @@ contains
                if( trim(names(n)).eq.'QICN' .or. &
                     trim(names(n)).eq.'QILS' ) then
                   do k=1,km
-                     if( state%vars%tracer(n)%is_r4 ) then
-                        temp2d = temp2d + ur(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(n)%is_r4 ) then
+                        temp2d = temp2d + ur(:,:,k)*self%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        temp2d = temp2d + ur(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + ur(:,:,k)*self%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -2492,10 +2482,10 @@ contains
                if( trim(names(n)).eq.'QICN' .or. &
                     trim(names(n)).eq.'QILS' ) then
                   do k=1,km
-                     if( state%vars%tracer(n)%is_r4 ) then
-                        temp2d = temp2d + vr(:,:,k)*state%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
+                     if( self%vars%tracer(n)%is_r4 ) then
+                        temp2d = temp2d + vr(:,:,k)*self%vars%tracer(n)%content_r4(:,:,k)*delp(:,:,k)
                      else
-                        temp2d = temp2d + vr(:,:,k)*state%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
+                        temp2d = temp2d + vr(:,:,k)*self%vars%tracer(n)%content   (:,:,k)*delp(:,:,k)
                      endif
                   enddo
                endif
@@ -2831,7 +2821,7 @@ contains
       if (allocated(names)) deallocate( names  )
       if (allocated(names0)) deallocate( names0  )
 
-      call freeTracers(state)
+      call freeTracers(self)
 
       ! call MAPL_TimerOff(MAPL, "RUN")
       ! call MAPL_TimerOff(MAPL, "TOTAL")
@@ -3619,92 +3609,75 @@ contains
 
    end subroutine Run
 
-   subroutine PULL_Q(state, import, QQQ, iNXQ, InFieldName, RC)
+   subroutine PULL_Q(self, import, QQQ, iNXQ, InFieldName, rc)
+      type(DynState) :: self
+      type(ESMF_State) :: import
+      type(DynTracers) :: QQQ ! Specific Humidity
+      integer, intent(in) :: iNXQ
+      character(len=*), optional, intent(in) :: InFieldName
+      integer, optional, intent(out) :: rc
 
-      type (DynState)        :: state
-      type (ESMF_State)              :: import
-      type (DynTracers)               :: QQQ       ! Specific Humidity
-      integer,           intent(IN)  :: iNXQ
-      character(len=*), optional, intent(IN) :: InFieldName
-      integer, optional, intent(OUT) :: RC
-
-      integer                          :: STATUS
-      character(len=ESMF_MAXSTR)       :: IAm="Pull_Q"
-      character(len=ESMF_MAXSTR)       :: FIELDNAME, QFieldName
-      type (ESMF_FieldBundle)          :: BUNDLE
-      type (ESMF_Field)                :: field
-      type (ESMF_Array)                :: array
-      type (ESMF_TypeKind_Flag)        :: kind
-      real(r4),              pointer   :: ptr_r4(:,:,:)
-      real(r8),              pointer   :: ptr_r8(:,:,:)
-      integer                          :: N,NQ
-      integer                          :: i1,in,j1,jn,im,jm,km
-
+      character(len=ESMF_MAXSTR) :: fieldname, QFieldName
+      type(ESMF_FieldBundle) :: bundle
+      type(ESMF_Field) :: field
+      type(ESMF_Array) :: array
+      type(ESMF_TypeKind_Flag) :: kind
+      real(r4), pointer :: ptr_r4(:,:,:)
+      real(r8), pointer :: ptr_r8(:,:,:)
+      integer :: N,NQ
+      integer :: i1, in, j1, jn, im, jm, km
+      integer :: status
 
       QFieldName = "Q"
       if (present(InFieldName)) QFieldName=InFieldName
 
-      i1 = state%grid%is
-      in = state%grid%ie
-      j1 = state%grid%js
-      jn = state%grid%je
-      im = state%grid%npx
-      jm = state%grid%npy
-      km = state%grid%npz
+      i1 = self%grid%is
+      in = self%grid%ie
+      j1 = self%grid%js
+      jn = self%grid%je
+      im = self%grid%npx
+      jm = self%grid%npy
+      km = self%grid%npz
 
-      BUNDLE = bundleAdv
+      bundle = BundleAdv
 
       ! Count the friendlies
-      call ESMF_FieldBundleGet(BUNDLE, fieldCount=NQ, RC=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_FieldBundleGet(bundle, fieldCount=NQ, _RC)
 
       NQ = NQ + iNXQ
-      state%grid%NQ = NQ       ! grid%NQ is now the "official" NQ
+      self%grid%NQ = NQ ! grid%NQ is now the "official" NQ
 
       ! Tracer pointer array
-      IF( ASSOCIATED( state%vars%tracer ) ) then
-         call freeTracers(state)
-      ENDIF
+      if (associated(self%vars%tracer) ) then
+         call freeTracers(self)
+      end if
 
-      ALLOCATE(state%vars%tracer(nq), STAT=STATUS)
-      VERIFY_(STATUS)
+      allocate(self%vars%tracer(nq), _STAT)
 
-      DO n = 1, NQ-iNXQ
-         call ESMF_FieldBundleGet(bundle, fieldIndex=n, field=field, rc=status)
-         VERIFY_(STATUS)
-         call ESMF_FieldGet(FIELD, Array=Array, name=fieldname, RC=STATUS)
-         VERIFY_(STATUS)
-         call ESMF_ArrayGet(array,typekind=kind,rc=status)
-         VERIFY_(STATUS)
-
-         state%vars%TRACER(N)%IS_R4  = (kind == ESMF_TYPEKIND_R4)   ! Is real*4?
-
-         state%vars%TRACER(N)%TNAME = fieldname
-
-         if ( state%vars%TRACER(N)%IS_R4 ) then
-            call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r4, rc=status)
-            VERIFY_(STATUS)
-            state%vars%tracer(n)%content_r4 => MAPL_RemapBounds(PTR_R4, i1,in,j1,jn, &
-                 1, km)
+      do n = 1, NQ-iNXQ
+         call ESMF_FieldBundleGet(bundle, fieldIndex=n, field=field, _RC)
+         call ESMF_FieldGet(field, Array=Array, name=fieldname, _RC)
+         call ESMF_ArrayGet(array, typekind=kind, _RC)
+         self%vars%TRACER(N)%IS_R4  = (kind == ESMF_TYPEKIND_R4)   ! Is real*4?
+         self%vars%TRACER(N)%TNAME = fieldname
+         if ( self%vars%TRACER(N)%IS_R4 ) then
+            call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r4, _RC)
+            self%vars%tracer(n)%content_r4 => MAPL_RemapBounds(ptr_r4, i1, in, j1, jn, 1, km)
             if (fieldname == QFieldName) then
                qqq%is_r4 = .true.
-               qqq%content_r4 => state%vars%tracer(n)%content_r4
+               qqq%content_r4 => self%vars%tracer(n)%content_r4
             end if
-
          else
-
-            call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r8, rc=status)
-            VERIFY_(STATUS)
-
-            state%vars%tracer(n)%content => PTR_R8
+            call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r8, _RC)
+            self%vars%tracer(n)%content => ptr_r8
             if (fieldname == QFieldName) then
                qqq%is_r4   = .false.
-               qqq%content => state%vars%tracer(n)%content
+               qqq%content => self%vars%tracer(n)%content
             end if
-
          endif
-      END DO
+      end do
 
+      _RETURN(_SUCCESS)
    end subroutine PULL_Q
 
    !BOP
@@ -3727,8 +3700,7 @@ contains
       integer, intent(out) :: rc
       !EOP
 
-      type(DYN_wrap) :: wrap
-      type(DynState), pointer :: state
+      type(DynState), pointer :: self
       type(DynGrid), pointer :: grid
       type(DynVars), pointer :: vars
       type(DynTracers) :: qqq                ! Specific Humidity
@@ -3793,12 +3765,11 @@ contains
       ! call MAPL_TimerOn(GENSTATE,"RUN2")
 
       ! Retrieve the pointer to the internal state
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
-      state => wrap%dyn_state
-
-      vars => state%vars ! direct handle to control variables
-      grid => state%grid ! direct handle to grid
-      dt = state%dt      ! dynamics time step (large)
+      _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
+      
+      vars => self%vars ! direct handle to control variables
+      grid => self%grid ! direct handle to grid
+      dt = self%dt      ! dynamics time step (large)
 
       ifirstxy = grid%is; ilastxy  = grid%ie
       jfirstxy = grid%js; jlastxy  = grid%je
@@ -3861,8 +3832,8 @@ contains
          ! Load Specific Humidity
          call MAPL_GetPointer(export, QOLD, 'Q', _RC)
 
-         call PULL_Q(state, import, qqq, iNXQ, _RC)
-         if ((.not. ADIABATIC) .and. (state%grid%NQ > 0)) then
+         call PULL_Q(self, import, qqq, iNXQ, _RC)
+         if ((.not. ADIABATIC) .and. (self%grid%NQ > 0)) then
             if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
                if (size(qv)==size(qqq%content_r4)) qv = qqq%content_r4
             elseif (associated(qqq%content)) then
@@ -3896,11 +3867,10 @@ contains
 
          ! Add Diabatic Forcing to State Variables
          ! call MAPL_TimerOn (GENSTATE,"PHYS_ADD_INCS")
-         call ADD_INCS(esmfgrid, state, import, DT)
+         call ADD_INCS(esmfgrid, self, import, DT)
          ! call MAPL_TimerOff(GENSTATE,"PHYS_ADD_INCS")
 
-
-         if (DYN_DEBUG) call DEBUG_FV_STATE('PHYSICS ADD_INCS',state)
+         if (DYN_DEBUG) call DEBUG_FV_STATE('PHYSICS ADD_INCS', self)
 
          ! Update Mid-Layer Pressure and Pressure Thickness
          dp = ( vars%pe(:,:,2:) - vars%pe (:,:,:km) )
@@ -3986,11 +3956,11 @@ contains
          do itracer=1,ntracers
             write(myTracer, "('Q',i5.5)") itracer-1
             call MAPL_GetPointer(export, temp3D, TRIM(myTracer), _RC)
-            if((associated(temp3d)) .and. (state%grid%NQ>=itracer)) then
-               if (state%vars%tracer(itracer)%is_r4) then
-                  temp3d = state%vars%tracer(itracer)%content_r4
+            if((associated(temp3d)) .and. (self%grid%NQ>=itracer)) then
+               if (self%vars%tracer(itracer)%is_r4) then
+                  temp3d = self%vars%tracer(itracer)%content_r4
                else
-                  temp3d = state%vars%tracer(itracer)%content
+                  temp3d = self%vars%tracer(itracer)%content
                endif
             endif
          enddo
@@ -4338,7 +4308,7 @@ contains
          deallocate( dthdtphyint1 )
          deallocate( dthdtphyint2 )
 
-         call freeTracers(state)
+         call freeTracers(self)
 
       end if ! .not. SW_DYNAMICS
 
@@ -4349,7 +4319,7 @@ contains
       _RETURN(_SUCCESS)
    end subroutine RunAddIncs
 
-   subroutine ADD_INCS(esmfgrid, state, import, DT, is_weighted, rc)
+   subroutine ADD_INCS(esmfgrid, self, import, DT, is_weighted, rc)
 
       use fms_mod, only: set_domain, nullify_domain
       use fv_diagnostics_mod, only: prt_maxmin
@@ -4358,7 +4328,7 @@ contains
 
       !INPUT PARAMETERS:
       type(ESMF_Grid), intent(in) :: esmfgrid
-      type(DynState), pointer :: state
+      type(DynState), pointer :: self
       type(ESMF_State), intent(inout) :: import
       real(FVPRC), intent(in) :: DT
       logical, optional, intent(in) :: is_weighted
@@ -4398,12 +4368,12 @@ contains
          is_weighted_ = is_weighted
       end if
 
-      is = state%grid%is; ie = state%grid%ie
-      js = state%grid%js; je = state%grid%je
-      km = state%grid%npz
+      is = self%grid%is; ie = self%grid%ie
+      js = self%grid%js; je = self%grid%je
+      km = self%grid%npz
 
-      isd = state%grid%isd; ied = state%grid%ied
-      jsd = state%grid%jsd; jed = state%grid%jed
+      isd = self%grid%isd; ied = self%grid%ied
+      jsd = self%grid%jsd; jed = self%grid%jed
 
       ! call MAPL_Get( MAPL, LONS=LONS, LATS=LATS, RC=STATUS )
       ! VERIFY_(STATUS)
@@ -4414,23 +4384,23 @@ contains
       ! **********************************************************************
 
       ! Determine how many water species we have
-      nwat = state%vars%nwat
+      nwat = self%vars%nwat
       nwat_tracers = 0
       if ((nwat==0) .AND. (.not. ADIABATIC)) then
-         do n=1,state%grid%NQ
-            if (TRIM(state%vars%tracer(n)%tname) == 'Q'       ) nwat_tracers = nwat_tracers + 1
-            if (TRIM(state%vars%tracer(n)%tname) == 'QLCN'    ) nwat_tracers = nwat_tracers + 1
-            if (TRIM(state%vars%tracer(n)%tname) == 'QLLS'    ) nwat_tracers = nwat_tracers + 1
-            if (TRIM(state%vars%tracer(n)%tname) == 'QICN'    ) nwat_tracers = nwat_tracers + 1
-            if (TRIM(state%vars%tracer(n)%tname) == 'QILS'    ) nwat_tracers = nwat_tracers + 1
+         do n=1,self%grid%NQ
+            if (TRIM(self%vars%tracer(n)%tname) == 'Q'       ) nwat_tracers = nwat_tracers + 1
+            if (TRIM(self%vars%tracer(n)%tname) == 'QLCN'    ) nwat_tracers = nwat_tracers + 1
+            if (TRIM(self%vars%tracer(n)%tname) == 'QLLS'    ) nwat_tracers = nwat_tracers + 1
+            if (TRIM(self%vars%tracer(n)%tname) == 'QICN'    ) nwat_tracers = nwat_tracers + 1
+            if (TRIM(self%vars%tracer(n)%tname) == 'QILS'    ) nwat_tracers = nwat_tracers + 1
          enddo
          ! We must have these first 5 at a minimum
          _ASSERT(nwat_tracers == 5, 'expecting 5 water species: Q QLCN QLLS QICN QILS')
          ! Check for QRAIN, QSNOW, QGRAUPEL
-         do n=1,state%grid%NQ
-            if (TRIM(state%vars%tracer(n)%tname) == 'QRAIN'   ) nwat_tracers = nwat_tracers + 1
-            if (TRIM(state%vars%tracer(n)%tname) == 'QSNOW'   ) nwat_tracers = nwat_tracers + 1
-            if (TRIM(state%vars%tracer(n)%tname) == 'QGRAUPEL') nwat_tracers = nwat_tracers + 1
+         do n=1,self%grid%NQ
+            if (TRIM(self%vars%tracer(n)%tname) == 'QRAIN'   ) nwat_tracers = nwat_tracers + 1
+            if (TRIM(self%vars%tracer(n)%tname) == 'QSNOW'   ) nwat_tracers = nwat_tracers + 1
+            if (TRIM(self%vars%tracer(n)%tname) == 'QGRAUPEL') nwat_tracers = nwat_tracers + 1
          enddo
          if (nwat_tracers >= 5) nwat = 3 ! state has QV, QLIQ, QICE
          if (nwat_tracers == 8) nwat = 6 ! state has QV, QLIQ, QICE, QRAIN, QSNOW, QGRAUPEL
@@ -4467,7 +4437,7 @@ contains
          allocate(   Q(is:ie,js:je,1:km,nwat) )
          allocate( CVM(is:ie,js:je,1:km) )
          Q(:,:,:,:) = 0.0
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='Q', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='Q', RC=rc )
          if (DYN_COLDSTART .and. overwrite_Q .and. (.not. ADIABATIC)) then
             ! USE Q computed by FV3
             call getQ(Q(:,:,:,sphum), 'Q')
@@ -4491,26 +4461,26 @@ contains
       endif
       if (nwat >= 3) then
          ! Grab QLIQ from imports
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QLLS', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QLLS', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content_r4)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content
          endif
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QLCN', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QLCN', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content_r4)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,liq_wat))==size(qqq%content)) Q(:,:,:,liq_wat) = Q(:,:,:,liq_wat) + qqq%content
          endif
          ! Grab QICE from imports
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QILS', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QILS', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,ice_wat))==size(qqq%content_r4)) Q(:,:,:,ice_wat) = Q(:,:,:,ice_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,ice_wat))==size(qqq%content)) Q(:,:,:,ice_wat) = Q(:,:,:,ice_wat) + qqq%content
          endif
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QICN', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QICN', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,ice_wat))==size(qqq%content_r4)) Q(:,:,:,ice_wat) = Q(:,:,:,ice_wat) + qqq%content_r4
          elseif (associated(qqq%content)) then
@@ -4519,21 +4489,21 @@ contains
       endif
       if (nwat >= 6) then
          ! Grab RAIN from imports
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QRAIN', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QRAIN', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,rainwat))==size(qqq%content_r4)) Q(:,:,:,rainwat) = qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,rainwat))==size(qqq%content)) Q(:,:,:,rainwat) = qqq%content
          endif
          ! Grab SNOW from imports
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QSNOW', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QSNOW', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,snowwat))==size(qqq%content_r4)) Q(:,:,:,snowwat) = qqq%content_r4
          elseif (associated(qqq%content)) then
             if (size(Q(:,:,:,snowwat))==size(qqq%content)) Q(:,:,:,snowwat) = qqq%content
          endif
          ! Grab GRAUPEL from imports
-         call PULL_Q ( state, import, qqq, NXQ, InFieldName='QGRAUPEL', RC=rc )
+         call PULL_Q(self, import, qqq, NXQ, InFieldName='QGRAUPEL', RC=rc )
          if ( (qqq%is_r4) .and. (associated(qqq%content_r4)) ) then
             if (size(Q(:,:,:,graupel))==size(qqq%content_r4)) Q(:,:,:,graupel) = qqq%content_r4
          elseif (associated(qqq%content)) then
@@ -4563,7 +4533,7 @@ contains
          !if (.not. HYDROSTATIC ) then
          !  call ESMFL_StateGetPointerToData ( import,TEND,'DWDT',RC=STATUS )
          !  VERIFY_(STATUS)
-         !  state%vars%W = state%vars%W + DT*TEND(is:ie,js:je,1:km)
+         !  self%vars%W = self%vars%W + DT*TEND(is:ie,js:je,1:km)
          !endif
 
          ! Put the wind tendencies on the Native Dynamics grid
@@ -4571,8 +4541,8 @@ contains
 
 
          ! Add the wind tendencies to the control variables
-         state%vars%U = state%vars%U + DT*TEND_UN(is:ie,js:je,1:km)
-         state%vars%V = state%vars%V + DT*TEND_VN(is:ie,js:je,1:km)
+         self%vars%U = self%vars%U + DT*TEND_UN(is:ie,js:je,1:km)
+         self%vars%V = self%vars%V + DT*TEND_VN(is:ie,js:je,1:km)
 
          deallocate( tend_ua )
          deallocate( tend_va )
@@ -4585,7 +4555,7 @@ contains
 
          if(is_weighted_) then
             do k=1,km
-               DPOLD(:,:,k) = ( state%vars%pe(:,:,k+1)-state%vars%pe(:,:,k) )
+               DPOLD(:,:,k) = ( self%vars%pe(:,:,k+1)-self%vars%pe(:,:,k) )
             enddo
          else
             DPOLD = 1.0
@@ -4596,7 +4566,7 @@ contains
          ! **********************************************************************
 
          call MAPL_GetPointer(import, TEND, "DPEDT", _RC)
-         state%vars%PE = state%vars%PE + DT*TEND
+         self%vars%PE = self%vars%PE + DT*TEND
 
          ! **********************************************************************
          ! ****           Compute New Pressure Thickness                     ****
@@ -4606,7 +4576,7 @@ contains
 
          if(is_weighted_) then
             do k=1,km
-               DPNEW(:,:,k) = ( state%vars%pe(:,:,k+1)-state%vars%pe(:,:,k) )
+               DPNEW(:,:,k) = ( self%vars%pe(:,:,k+1)-self%vars%pe(:,:,k) )
             enddo
          else
             DPNEW = 1.0
@@ -4623,7 +4593,7 @@ contains
          call MAPL_GetPointer(import, TEND, "DTDT", _RC)
 
          !if (DYN_DEBUG) then
-         !   call prt_maxmin('AI PT1', state%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
+         !   call prt_maxmin('AI PT1', self%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
          !endif
 
          select case (nwat)
@@ -4643,46 +4613,46 @@ contains
          end select
 
          ! Make previous PT into just T
-         state%vars%PT = state%vars%PT*state%vars%PKZ
+         self%vars%PT = self%vars%PT*self%vars%PKZ
 
          if (.not. HYDROSTATIC ) then
             ! remove old T from DZ
-            state%vars%DZ = state%vars%DZ / state%vars%PT
+            self%vars%DZ = self%vars%DZ / self%vars%PT
 
             ! Update T
-            state%vars%PT =  state%vars%PT                         *DPOLD
-            state%vars%PT = (state%vars%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
+            self%vars%PT =  self%vars%PT                         *DPOLD
+            self%vars%PT = (self%vars%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
 
             ! update DZ with new T
-            state%vars%DZ = state%vars%DZ * state%vars%PT
+            self%vars%DZ = self%vars%DZ * self%vars%PT
          else
             ! Update T
-            state%vars%PT =  state%vars%PT                         *DPOLD
-            state%vars%PT = (state%vars%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
+            self%vars%PT =  self%vars%PT                         *DPOLD
+            self%vars%PT = (self%vars%PT + DT*TEND*(MAPL_CP/CVM))/DPNEW
          endif
 
          if (DEBUG_TQ_ERRORS) then
             do L=1,KM
                do J=js,je
                   do I=is,ie
-                     if ( (state%vars%PT(I,J,L) > 333.0) .OR. (state%vars%PT(I,J,L)/=state%vars%PT(I,J,L)) .OR. &
+                     if ( (self%vars%PT(I,J,L) > 333.0) .OR. (self%vars%PT(I,J,L)/=self%vars%PT(I,J,L)) .OR. &
                           (Q(I,J,L,sphum  ) < 0.0) .OR. (Q(I,J,L,sphum  )/=Q(I,J,L,sphum  )) .OR. &
                           (Q(I,J,L,liq_wat) < 0.0) .OR. (Q(I,J,L,liq_wat)/=Q(I,J,L,liq_wat)) .OR. &
                           (Q(I,J,L,ice_wat) < 0.0) .OR. (Q(I,J,L,ice_wat)/=Q(I,J,L,ice_wat)) .OR. &
                           (Q(I,J,L,rainwat) < 0.0) .OR. (Q(I,J,L,rainwat)/=Q(I,J,L,rainwat)) .OR. &
                           (Q(I,J,L,snowwat) < 0.0) .OR. (Q(I,J,L,snowwat)/=Q(I,J,L,snowwat)) .OR. &
                           (Q(I,J,L,graupel) < 0.0) .OR. (Q(I,J,L,graupel)/=Q(I,J,L,graupel)) ) then
-                        print *, "T or Q  spike detected : ", state%vars%PT(I,J,L)
+                        print *, "T or Q  spike detected : ", self%vars%PT(I,J,L)
                         print *, "  Temp  ANA|PHY  Increment : ", (DT*TEND(I,J,L)*(MAPL_CP/CVM(I,J,L)))/DPNEW(I,J,L)
                         print *, "    IN ADD_INCS inside DYN   "
                         II=I-is+1
                         JJ=J-js+1
                         print *, "  Latitude       =", LATS(II,JJ)*180.0/MAPL_PI
                         print *, "  Longitude      =", LONS(II,JJ)*180.0/MAPL_PI
-                        print *, "  Pressure (mb)  =", 0.5*(state%vars%PE(I,J,L+1)+state%vars%PE(I,J,L))/100.0
+                        print *, "  Pressure (mb)  =", 0.5*(self%vars%PE(I,J,L+1)+self%vars%PE(I,J,L))/100.0
 
-                        print *, "  UWND =", state%vars%U(I,J,L), " UINC =", DT*TEND_UN(I,J,L)
-                        print *, "  VWND =", state%vars%V(I,J,L), " VINC =", DT*TEND_VN(I,J,L)
+                        print *, "  UWND =", self%vars%U(I,J,L), " UINC =", DT*TEND_UN(I,J,L)
+                        print *, "  VWND =", self%vars%V(I,J,L), " VINC =", DT*TEND_VN(I,J,L)
                         if (nwat >= 6) then
                            print *, "  QV=", Q(I,J,L,sphum  ), "  QL=", Q(I,J,L,liq_wat), "  QI=", Q(I,J,L,ice_wat)
                            print *, "  QR=", Q(I,J,L,rainwat), "  QS=", Q(I,J,L,snowwat), "  QG=", Q(I,J,L,graupel)
@@ -4700,14 +4670,14 @@ contains
          ! Update PKZ from hydrostatic pressures
          !  This isn't entirely necessary, FV3 overwrites this in fv_dynamics
          !  but we have to get back to PT here
-         !!   call getPKZ(state%vars%PKZ,state%vars%PT,Q,state%vars%PE,state%vars%DZ,HYDROSTATIC)
-         call getPKZ(state%vars%PKZ,state%vars%PE)
+         !!   call getPKZ(self%vars%PKZ,self%vars%PT,Q,self%vars%PE,self%vars%DZ,HYDROSTATIC)
+         call getPKZ(self%vars%PKZ,self%vars%PE)
 
          ! Make T back into PT
-         state%vars%PT = state%vars%PT/state%vars%PKZ
+         self%vars%PT = self%vars%PT/self%vars%PKZ
 
          !if (DYN_DEBUG) then
-         !call prt_maxmin('AI PT2', state%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
+         !call prt_maxmin('AI PT2', self%vars%PT ,  is, ie, js, je, 0, km, 1.d00, MAPL_AM_I_ROOT())
          !endif
 
          deallocate (DPNEW)
@@ -4844,63 +4814,36 @@ contains
 
    !INTERFACE:
    subroutine Finalize(gc, import, export, clock, rc)
-
       !ARGUMENTS:
-      type (ESMF_GridComp) :: gc
-      type (ESMF_State) :: import
-      type (ESMF_State) :: export
-      type (ESMF_Clock) :: clock
+      type(ESMF_GridComp) :: gc
+      type(ESMF_State) :: import
+      type(ESMF_State) :: export
+      type(ESMF_Clock) :: clock
       integer, intent(out) :: rc
       !EOP
 
-      type (DYN_wrap) :: wrap
+      type(DYN_wrap) :: wrap
       type (DynState), pointer  :: state
+      integer :: status
+      class(logger_t), pointer :: logger
 
-      character(len=ESMF_MAXSTR)        :: IAm
-      character(len=ESMF_MAXSTR)        :: comp_name
-      integer                           :: status
+      call MAPL_GridCompGet(gc, logger=logger, _RC)
+      call logger%info("Finalize:: starting...")
 
-      type (MAPL_MetaComp),     pointer :: MAPL
-      type (ESMF_Config)                :: cf
-
-      Iam = "Finalize"
-      call ESMF_GridCompGet( gc, name=comp_name, config=cf, RC=STATUS )
-      VERIFY_(STATUS)
-      Iam = trim(comp_name) // Iam
+      ! call MAPL_TimerOn(MAPL,"TOTAL")
+      ! call MAPL_TimerOn(MAPL,"FINALIZE")
 
       ! Retrieve the pointer to the state
-      call MAPL_GetObjectFromGC (gc, MAPL,  RC=STATUS )
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"TOTAL")
-      call MAPL_TimerOn(MAPL,"FINALIZE")
-
-      ! Retrieve the pointer to the state
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, status)
-      VERIFY_(STATUS)
-
+      call ESMF_UserCompGetInternalState(gc, 'DYN_STATE', wrap, _RC)
       state => wrap%dyn_state
 
       call DynFinalize( state )
 
-      ! Call Generic Finalize
-      call MAPL_TimerOff(MAPL,"FINALIZE")
-      call MAPL_TimerOff(MAPL,"TOTAL")
+      ! call MAPL_TimerOff(MAPL,"FINALIZE")
+      ! call MAPL_TimerOff(MAPL,"TOTAL")
 
-      call MAPL_GenericFinalize ( gc, import, export, clock,  RC=STATUS)
-      VERIFY_(STATUS)
-
+      call logger%info("Finalize:: ...complete")
       _RETURN(_SUCCESS)
-
-   contains
-
-      subroutine PRINT_TIMES(TIMES,DAYS)
-         integer(kind=8), intent(INOUT) :: TIMES(:,:)
-         real(r8),        intent(IN   ) :: DAYS
-         TIMES = 0
-         return
-      end subroutine PRINT_TIMES
-
    end subroutine FINALIZE
 
    subroutine get_slp ( km,ps,phis,slp,pe,pk,tv,H1000,H850,H500)
@@ -5091,7 +5034,7 @@ contains
       real(REAL8), parameter :: r0_6=0.6
       real(REAL8), parameter :: r1_0=1.0
 
-      call ESMF_UserCompGetInternalState(gc, 'DYNstate', wrap, _RC)
+      call ESMF_UserCompGetInternalState(gc, 'DYN_STATE', wrap, _RC)
       state => wrap%dyn_state
       grid  => state%grid ! direct handle to grid
 
@@ -5961,7 +5904,7 @@ contains
 
       !call write_parallel('GlobalSUm')
       locArr(:,:) = arr(:,:)
-      call ArrayGather(locArr, glbArr, grid%grid)
+      call MAPL_ArrayGather(locArr, glbArr, grid%grid)
       arr_global(:,:) = glbArr
 
       IF (MAPL_AM_I_ROOT()) Then
@@ -6004,7 +5947,7 @@ contains
 
       ! call write_parallel('GlobalSUm')
       locArr(:,:) = arr(:,:)
-      call ArrayGather(locArr, glbArr, grid%grid)
+      call MAPL_ArrayGather(locArr, glbArr, grid%grid)
       arr_global(:,:) = glbArr
 
       IF (MAPL_AM_I_ROOT()) Then
@@ -6057,7 +6000,7 @@ contains
       ! call write_parallel('GlobalSUm')
       do k=kstrt,kend
          locArr(:,:) = arr(:,:,k)
-         call ArrayGather(locArr, arr_global(:,:,k), grid%grid)
+         call MAPL_ArrayGather(locArr, arr_global(:,:,k), grid%grid)
       enddo
 
       IF (amIRoot) Then
@@ -6119,7 +6062,7 @@ contains
 
       do k=kstrt,kend
          locArr(:,:) = arr(:,:,k)
-         call ArrayGather(locArr, glbArr, grid%grid)
+         call MAPL_ArrayGather(locArr, glbArr, grid%grid)
          if (amIRoot) then
             arr_global(:,:,k) = glbArr
          end if
@@ -6141,12 +6084,12 @@ contains
          gsum_p = 0
          do k=kstrt,kend
             locArr(:,:) = arr(:,:,k)*grid%area(:,:)*delp(:,:,k)
-            call ArrayGather(locArr, glbArr, grid%grid)
+            call MAPL_ArrayGather(locArr, glbArr, grid%grid)
             if (amIRoot) then
                arr_global(:,:,k) = glbArr
             end if
             locArr(:,:) = delp(:,:,k)
-            call ArrayGather(locArr, glbArr, grid%grid)
+            call MAPL_ArrayGather(locArr, glbArr, grid%grid)
             if (amIRoot) then
                gsum_p = gsum_p + SUM(SUM(glbArr,DIM=1),DIM=1)
             end if

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -517,7 +517,7 @@ contains
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
       ! call MAPL_TimerOn(MAPL, "-DYN_INIT")
-      call DynInit(state, clock, internal, import, gc, _RC)
+      call DynInit(state, clock, import, gc, _RC)
       ! call MAPL_TimerOff(MAPL, "-DYN_INIT")
 
       ! Create PLE and PREF EXPORT Coupling (Needs to be done only once per run)

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -2,272 +2,272 @@ schema_version: 2.0.0
 component: DynCore
 
 category: EXPORT
-#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    SHORT_NAME     |                                 LONG_NAME                                 |       UNITS        |        DIMS         |       VLOCATION        |     FIELD_TYPE     |   PRECISION
-#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-        KE         |                   vertically_integrated_kinetic_energy                    |       J m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       TAVE        |                    vertically_averaged_dry_temperature                    |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       UAVE        |                      vertically_averaged_zonal_wind                       |      m sec-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-      KEPHY        |       vertically_integrated_kinetic_energy_tendency_due_to_physics        |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      PEPHY        |              total_potential_energy_tendency_due_to_physics               |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      TEPHY        |                   mountain_work_tendency_due_to_physics                   |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      KEANA        |               total_kinetic_energy_tendency_due_to_analysis               |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      PEANA        |              total_potential_energy_tendency_due_to_analysis              |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      TEANA        |                  mountain_work_tendency_due_to_analysis                   |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      KEHOT        |         vertically_integrated_kinetic_energy_tendency_due_to_HOT          |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       KEDP        |   vertically_integrated_kinetic_energy_tendency_due_to_pressure_change    |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      KEADV        |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics_advection  |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       KEPG        |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_gradient   |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      KEDYN        |       vertically_integrated_kinetic_energy_tendency_due_to_dynamics       |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      PEDYN        |      vertically_integrated_potential_energy_tendency_due_to_dynamics      |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      TEDYN        |                  mountain_work_tendency_due_to_dynamics                   |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     KECDCOR       |        vertically_integrated_kinetic_energy_tendency_due_to_cdcore        |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     PECDCOR       |       vertically_integrated_potential_energy_tendency_due_to_cdcore       |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     TECDCOR       |                   mountain_work_tendency_due_to_cdcore                    |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      QFIXER       |       vertically_integrated_potential_energy_tendency_due_to_CONSV        |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     KEREMAP       |        vertically_integrated_kinetic_energy_tendency_due_to_remap         |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     PEREMAP       |       vertically_integrated_potential_energy_tendency_due_to_remap        |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     TEREMAP       |                    mountain_work_tendency_due_to_remap                    |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      KEGEN        |            vertically_integrated_generation_of_kinetic_energy             |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DKERESIN      |     vertically_integrated_kinetic_energy_residual_from_inertial_terms     |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DKERESPG      |        vertically_integrated_kinetic_energy_residual_from_PG_terms        |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DMDTANA       |            vertically_integrated_mass_tendency_due_to_analysis            |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DOXDTANAINT     |           vertically_integrated_ozone_tendency_due_to_analysis            |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DQVDTANAINT     |        vertically_integrated_water_vapor_tendency_due_to_analysis         |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DQLDTANAINT     |        vertically_integrated_liquid_water_tendency_due_to_analysis        |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DQIDTANAINT     |         vertically_integrated_ice_water_tendency_due_to_analysis          |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DMDTDYN       |            vertically_integrated_mass_tendency_due_to_dynamics            |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DOXDTDYNINT     |           vertically_integrated_ozone_tendency_due_to_dynamics            |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DTHVDTDYNINT    |            vertically_integrated_THV_tendency_due_to_dynamics             |    K kg m-2 s-1    |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DTHVDTREMAP     |       vertically_integrated_THV_tendency_due_to_vertical_remapping        |    K kg m-2 s-1    |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DTHVDTCONSV     |         vertically_integrated_THV_tendency_due_to_TE_conservation         |    K kg m-2 s-1    |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DTHVDTPHYINT    |             vertically_integrated_THV_tendency_due_to_physics             |    K kg m-2 s-1    |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DTHVDTANAINT    |            vertically_integrated_THV_tendency_due_to_analysis             |    K kg m-2 s-1    |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DQVDTDYNINT     |        vertically_integrated_water_vapor_tendency_due_to_dynamics         |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DQLDTDYNINT     |        vertically_integrated_liquid_water_tendency_due_to_dynamics        |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   DQIDTDYNINT     |         vertically_integrated_ice_water_tendency_due_to_dynamics          |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      CONVKE       |             vertically_integrated_kinetic_energy_convergence              |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     CONVTHV       |                 vertically_integrated_thetav_convergence                  |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     CONVCPT       |                vertically_integrated_enthalpy_convergence                 |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     CONVPHI       |              vertically_integrated_geopotential_convergence               |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        U          |                               eastward_wind                               |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-        V          |                              northward_wind                               |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-        T          |                              air_temperature                              |         K          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        PL         |                            mid_level_pressure                             |         Pa         |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       ZLE0        |                        edge_heights_above_surface                         |         m          |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |
-       ZL0         |                      mid_layer_heights_above_surface                      |         m          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       ZLE         |                               edge_heights                                |         m          |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |
-        ZL         |                             mid_layer_heights                             |         m          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        S          |                        mid_layer_dry_static_energy                        |         m          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       PLE         |                               edge_pressure                               |         Pa         |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |
-        TH         |                           potential_temperature                           |         K          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       PLK         |                           mid-layer_p$^\kappa$                            |    Pa$^\kappa$     |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       PKE         |                              edge_p$^\kappa$                              |    Pa$^\kappa$     |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |
-       DELZ        |                      nonhydrostatic_layer_thickness                       |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        W          |                             vertical_velocity                             |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-      OMEGA        |                  hydrostatic_vertical_pressure_velocity                   |       Pa s-1       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        CX         |                    eastward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
-        CY         |                   northward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
-        CU         |                    eastward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        CV         |                   northward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        MX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        MY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       MFX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
-       MFY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
-       MFZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |  ESMF_KIND_R8
-        MZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |  ESMF_KIND_R4
-        PV         |                   ertels_isentropic_potential_vorticity                   |    m+2 kg-1 s-1    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       EPV         |                        ertels_potential_vorticity                         |   K m+2 kg-1 s-1   |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        Q          |                             specific_humidity                             |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        QC         |                        specific_mass_of_condensate                        |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DUDTSUBZ      |                tendency_of_eastward_wind_due_to_subgrid_dz                |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-     DVDTSUBZ      |               tendency_of_northward_wind_due_to_subgrid_dz                |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-     DTDTSUBZ      |               tendency_of_air_temperature_due_to_subgrid_dz               |       K s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DWDTSUBZ      |              tendency_of_vertical_velocity_due_to_subgrid_dz              |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DTDT_RAY      |             air_temperature_tendency_due_to_Rayleigh_friction             |       K s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DUDT_RAY      |            tendency_of_eastward_wind_due_to_Rayleigh_friction             |       m s-2        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-     DVDT_RAY      |            tendency_of_northward_wind_due_to_Rayleigh_friction            |       m s-2        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-     DWDT_RAY      |            vertical_velocity_tendency_due_to_Rayleigh_friction            |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DUDTANA       |                 tendency_of_eastward_wind_due_to_analysis                 |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-     DVDTANA       |                tendency_of_northward_wind_due_to_analysis                 |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |  MAPL_VectorField  |
-     DTDTANA       |                tendency_of_air_temperature_due_to_analysis                |       K s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-    DDELPDTANA     |              tendency_of_pressure_thickness_due_to_analysis               |       K s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DUDTDYN       |                 tendency_of_eastward_wind_due_to_dynamics                 |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DVDTDYN       |                tendency_of_northward_wind_due_to_dynamics                 |       m/s/s        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DTDTDYN       |                tendency_of_air_temperature_due_to_dynamics                |       K s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DQVDTDYN      |               tendency_of_specific_humidity_due_to_dynamics               |      kg/kg/s       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DQIDTDYN      |                   tendency_of_ice_water_due_to_dynamics                   |      kg/kg/s       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DQLDTDYN      |                 tendency_of_liquid_water_due_to_dynamics                  |      kg/kg/s       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DOXDTDYN      |                     tendency_of_ozone_due_to_dynamics                     |   mol mol-1 s-1    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       PREF        |                          reference_air_pressure                           |         Pa         |  MAPL_DimsVertOnly  |   MAPL_VlocationEdge   |                    |
-        AK         |                          hybrid_sigma_pressure_a                          |         1          |  MAPL_DimsVertOnly  |   MAPL_VlocationEdge   |                    |
-        BK         |                          hybrid_sigma_pressure_b                          |         1          |  MAPL_DimsVertOnly  |   MAPL_VlocationEdge   |                    |
-       PHIS        |                              surface_height                               |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        PS         |                             surface_pressure                              |         Pa         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        TA         |                          surface_air_temperature                          |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        QA         |                         surface_specific_humidity                         |         1          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        US         |                           surface_eastward_wind                           |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-        VS         |                          surface_northward_wind                           |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-      SPEED        |                            surface_wind_speed                             |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     WSPD_10M      |                             wind_speed_at_10m                             |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
- VVEL_UP_100_1000  |               max_vertical_velocity_up_between_100_1000_hPa               |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
- VVEL_DN_100_1000  |              max_vertical_velocity_down_between_100_1000_hPa              |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        DZ         |                           surface_layer_height                            |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       SLP         |                            sea_level_pressure                             |         Pa         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      H1000        |                             height_at_1000_mb                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-    TROPP_EPV      |                 tropopause_pressure_based_on_EPV_estimate                 |         Pa         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-  TROPP_THERMAL    |               tropopause_pressure_based_on_thermal_estimate               |         Pa         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-  TROPP_BLENDED    |               tropopause_pressure_based_on_blended_estimate               |         Pa         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-  TROPK_BLENDED    |                tropopause_index_based_on_blended_estimate                 |      unitless      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      TROPT        |            tropopause_temperature_using_blended_TROPP_estimate            |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      TROPQ        |         tropopause_specific_humidity_using_blended_TROPP_estimate         |       kg/kg        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       PLE0        |                  pressure_at_layer_edges_before_dynamics                  |         Pa         |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |  ESMF_KIND_R8
-       PLE1        |                  pressure_at_layer_edges_after_dynamics                   |         Pa         |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |  ESMF_KIND_R8
-       DELP        |                            pressure_thickness                             |         Pa         |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DELPTOP       |                      pressure_thickness_at_model_top                      |         Pa         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     U_AGRID       |                          eastward_wind_on_A-Grid                          |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     V_AGRID       |                         northward_wind_on_A-Grid                          |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     U_CGRID       |                          eastward_wind_on_C-Grid                          |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     V_CGRID       |                         northward_wind_on_C-Grid                          |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     U_DGRID       |                      eastward_wind_on_native_D-Grid                       |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     V_DGRID       |                      northward_wind_on_native_D-Grid                      |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        TV         |                          air_virtual_temperature                          |         K          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       THV         |                   scaled_virtual_potential_temperature                    |   K/Pa$^\kappa$    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-    DPLEDTDYN      |                 tendency_of_edge_pressure_due_to_dynamics                 |       Pa s-1       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-    DDELPDTDYN     |              tendency_of_pressure_thickness_due_to_dynamics               |       Pa s-1       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-       UKE         |                eastward_flux_of_atmospheric_kinetic_energy                |     J m-1 s-1      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VKE         |               northward_flux_of_atmospheric_kinetic_energy                |     J m-1 s-1      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       UCPT        |                   eastward_flux_of_atmospheric_enthalpy                   |     J m-1 s-1      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VCPT        |                  northward_flux_of_atmospheric_enthalpy                   |     J m-1 s-1      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       UPHI        |               eastward_flux_of_atmospheric_potential_energy               |     J m-1 s-1      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VPHI        |              northward_flux_of_atmospheric_potential_energy               |     J m-1 s-1      |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       UQV         |                 eastward_flux_of_atmospheric_water_vapor                  |     kg m-1 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VQV         |                 northward_flux_of_atmospheric_water_vapor                 |     kg m-1 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       UQL         |                 eastward_flux_of_atmospheric_liquid_water                 |     kg m-1 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VQL         |                northward_flux_of_atmospheric_liquid_water                 |     kg m-1 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       UQI         |                     eastward_flux_of_atmospheric_ice                      |     kg m-1 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VQI         |                     northward_flux_of_atmospheric_ice                     |     kg m-1 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       DKE         |       tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics       |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DCPT        |         tendency_of_atmosphere_dry_energy_content_due_to_dynamics         |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DPET        |    tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics    |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       WRKT        |                      work_done_by_atmosphere_at_top                       |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DQV         |        tendency_of_atmosphere_water_vapor_content_due_to_dynamics         |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DQL         |        tendency_of_atmosphere_liquid_water_content_due_to_dynamics        |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DQI         |            tendency_of_atmosphere_ice_content_due_to_dynamics             |     kg m-2 s-1     |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       CNV         |              generation_of_atmosphere_kinetic_energy_content              |       W m-2        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       UH25        |                        updraft_helicity_2_to_5_km                         |      m+2 s-2       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       UH03        |                        updraft_helicity_0_to_3_km                         |      m+2 s-2       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      SRH01        |                     storm_relative_helicity_0_to_1_km                     |      m+2 s-2       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      SRH03        |                     storm_relative_helicity_0_to_3_km                     |      m+2 s-2       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-      SRH25        |                     storm_relative_helicity_2_to_5_km                     |      m+2 s-2       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       VORT        |                      vorticity_at_mid_layer_heights                       |        s-1         |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     VORT850       |                           vorticity_at_850_hPa                            |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     VORT700       |                           vorticity_at_700_hPa                            |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     VORT500       |                           vorticity_at_500_hPa                            |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     VORT200       |                           vorticity_at_200_hPa                            |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DIVG        |                      divergence_at_mid_layer_heights                      |        s-1         |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     DIVG850       |                           divergence_at_850_hPa                           |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DIVG700       |                           divergence_at_700_hPa                           |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DIVG500       |                           divergence_at_500_hPa                           |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     DIVG200       |                           divergence_at_200_hPa                           |        s-1         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       U850        |                         eastward_wind_at_850_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       U700        |                         eastward_wind_at_700_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       U500        |                         eastward_wind_at_500_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       U300        |                         eastward_wind_at_300_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       U250        |                         eastward_wind_at_250_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       U200        |                         eastward_wind_at_200_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       U100        |                         eastward_wind_at_100_hPa                          |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       UTOP        |                        eastward_wind_at_model_top                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V850        |                         northward_wind_at_850_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V700        |                         northward_wind_at_700_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V500        |                         northward_wind_at_500_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V300        |                         northward_wind_at_300_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V250        |                         northward_wind_at_250_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V200        |                         northward_wind_at_200_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V100        |                         northward_wind_at_100_hPa                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       VTOP        |                        northward_wind_at_model_top                        |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       T850        |                        air_temperature_at_850_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       T700        |                        air_temperature_at_700_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       T500        |                        air_temperature_at_500_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       T300        |                        air_temperature_at_300_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       T250        |                        air_temperature_at_250_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       T200        |                        air_temperature_at_200_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       T100        |                        air_temperature_at_100_hPa                         |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       TTOP        |                       air_temperature_at_model_top                        |         K          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q850        |                       specific_humidity_at_850_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q700        |                       specific_humidity_at_700_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q500        |                       specific_humidity_at_500_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q300        |                       specific_humidity_at_300_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q250        |                       specific_humidity_at_250_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q200        |                       specific_humidity_at_200_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Q100        |                       specific_humidity_at_100_hPa                        |      kg kg-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Z700        |                      geopotential_height_at_700_hPa                       |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Z500        |                      geopotential_height_at_500_hPa                       |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       Z300        |                      geopotential_height_at_300_hPa                       |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H850        |                             height_at_850_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H700        |                             height_at_700_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H500        |                             height_at_500_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H300        |                             height_at_300_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H250        |                             height_at_250_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H200        |                             height_at_200_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       H100        |                             height_at_100_hPa                             |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     OMEGA850      |                             omega_at_850_hPa                              |       Pa s-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     OMEGA700      |                             omega_at_700_hPa                              |       Pa s-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     OMEGA500      |                             omega_at_500_hPa                              |       Pa s-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     OMEGA200      |                             omega_at_200_hPa                              |       Pa s-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-     OMEGA10       |                              omega_at_10_hPa                              |       Pa s-1       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       W850        |                               w_at_850_hPa                                |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       W500        |                               w_at_500_hPa                                |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       W200        |                               w_at_200_hPa                                |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       W10         |                                w_at_10_hPa                                |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       U50M        |                        eastward_wind_at_50_meters                         |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       V50M        |                        northward_wind_at_50_meters                        |       m s-1        |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |  MAPL_VectorField  |
-       DXC         |                               cgrid_delta_x                               |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       DYC         |                               cgrid_delta_y                               |         m          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       AREA        |                              agrid_cell_area                              |        m+2         |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-        PT         |                       scaled_potential_temperature                        |  K Pa$^{-\kappa}$  |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-        PE         |                               air_pressure                                |         Pa         |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |
-       LONS        |                             Center_longitudes                             |      radians       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       LATS        |                             Center_latitudes                              |      radians       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-   TIME_IN_DYN     |                        timer_for_main_dynamics_run                        |      seconds       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-       PID         |                                process_id                                 |         1          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
-    QV_DYN_IN      |                    spec_humidity_at_begin_of_time_step                    |      kg kg-1       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     T_DYN_IN      |                     temperature_at_begin_of_time_step                     |         K          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     U_DYN_IN      |                       u_wind_at_begin_of_time_step                        |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-     V_DYN_IN      |                       v_wind_at_begin_of_time_step                        |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
-    PLE_DYN_IN     |                    edge_pressure_at_begin_of_time_step                    |         Pa         |  MAPL_DimsHorzVert  |   MAPL_VlocationEdge   |                    |
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    SHORT_NAME     |                                 LONG_NAME                                 |       UNITS        |  DIMS | VLOC |     FIELD_TYPE     |   PRECISION
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+        KE         |                   vertically_integrated_kinetic_energy                    |       J m-2        |  xy   |  N   |                    |
+       TAVE        |                    vertically_averaged_dry_temperature                    |         K          |  xy   |  N   |                    |
+       UAVE        |                      vertically_averaged_zonal_wind                       |      m sec-1       |  xy   |  N   |  MAPL_VectorField  |
+      KEPHY        |       vertically_integrated_kinetic_energy_tendency_due_to_physics        |       W m-2        |  xy   |  N   |                    |
+      PEPHY        |              total_potential_energy_tendency_due_to_physics               |       W m-2        |  xy   |  N   |                    |
+      TEPHY        |                   mountain_work_tendency_due_to_physics                   |       W m-2        |  xy   |  N   |                    |
+      KEANA        |               total_kinetic_energy_tendency_due_to_analysis               |       W m-2        |  xy   |  N   |                    |
+      PEANA        |              total_potential_energy_tendency_due_to_analysis              |       W m-2        |  xy   |  N   |                    |
+      TEANA        |                  mountain_work_tendency_due_to_analysis                   |       W m-2        |  xy   |  N   |                    |
+      KEHOT        |         vertically_integrated_kinetic_energy_tendency_due_to_HOT          |       W m-2        |  xy   |  N   |                    |
+       KEDP        |   vertically_integrated_kinetic_energy_tendency_due_to_pressure_change    |       W m-2        |  xy   |  N   |                    |
+      KEADV        |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics_advection  |       W m-2        |  xy   |  N   |                    |
+       KEPG        |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_gradient   |       W m-2        |  xy   |  N   |                    |
+      KEDYN        |       vertically_integrated_kinetic_energy_tendency_due_to_dynamics       |       W m-2        |  xy   |  N   |                    |
+      PEDYN        |      vertically_integrated_potential_energy_tendency_due_to_dynamics      |       W m-2        |  xy   |  N   |                    |
+      TEDYN        |                  mountain_work_tendency_due_to_dynamics                   |       W m-2        |  xy   |  N   |                    |
+     KECDCOR       |        vertically_integrated_kinetic_energy_tendency_due_to_cdcore        |       W m-2        |  xy   |  N   |                    |
+     PECDCOR       |       vertically_integrated_potential_energy_tendency_due_to_cdcore       |       W m-2        |  xy   |  N   |                    |
+     TECDCOR       |                   mountain_work_tendency_due_to_cdcore                    |       W m-2        |  xy   |  N   |                    |
+      QFIXER       |       vertically_integrated_potential_energy_tendency_due_to_CONSV        |       W m-2        |  xy   |  N   |                    |
+     KEREMAP       |        vertically_integrated_kinetic_energy_tendency_due_to_remap         |       W m-2        |  xy   |  N   |                    |
+     PEREMAP       |       vertically_integrated_potential_energy_tendency_due_to_remap        |       W m-2        |  xy   |  N   |                    |
+     TEREMAP       |                    mountain_work_tendency_due_to_remap                    |       W m-2        |  xy   |  N   |                    |
+      KEGEN        |            vertically_integrated_generation_of_kinetic_energy             |       W m-2        |  xy   |  N   |                    |
+     DKERESIN      |     vertically_integrated_kinetic_energy_residual_from_inertial_terms     |       W m-2        |  xy   |  N   |                    |
+     DKERESPG      |        vertically_integrated_kinetic_energy_residual_from_PG_terms        |       W m-2        |  xy   |  N   |                    |
+     DMDTANA       |            vertically_integrated_mass_tendency_due_to_analysis            |     kg m-2 s-1     |  xy   |  N   |                    |
+   DOXDTANAINT     |           vertically_integrated_ozone_tendency_due_to_analysis            |     kg m-2 s-1     |  xy   |  N   |                    |
+   DQVDTANAINT     |        vertically_integrated_water_vapor_tendency_due_to_analysis         |     kg m-2 s-1     |  xy   |  N   |                    |
+   DQLDTANAINT     |        vertically_integrated_liquid_water_tendency_due_to_analysis        |     kg m-2 s-1     |  xy   |  N   |                    |
+   DQIDTANAINT     |         vertically_integrated_ice_water_tendency_due_to_analysis          |     kg m-2 s-1     |  xy   |  N   |                    |
+     DMDTDYN       |            vertically_integrated_mass_tendency_due_to_dynamics            |     kg m-2 s-1     |  xy   |  N   |                    |
+   DOXDTDYNINT     |           vertically_integrated_ozone_tendency_due_to_dynamics            |     kg m-2 s-1     |  xy   |  N   |                    |
+   DTHVDTDYNINT    |            vertically_integrated_THV_tendency_due_to_dynamics             |    K kg m-2 s-1    |  xy   |  N   |                    |
+   DTHVDTREMAP     |       vertically_integrated_THV_tendency_due_to_vertical_remapping        |    K kg m-2 s-1    |  xy   |  N   |                    |
+   DTHVDTCONSV     |         vertically_integrated_THV_tendency_due_to_TE_conservation         |    K kg m-2 s-1    |  xy   |  N   |                    |
+   DTHVDTPHYINT    |             vertically_integrated_THV_tendency_due_to_physics             |    K kg m-2 s-1    |  xy   |  N   |                    |
+   DTHVDTANAINT    |            vertically_integrated_THV_tendency_due_to_analysis             |    K kg m-2 s-1    |  xy   |  N   |                    |
+   DQVDTDYNINT     |        vertically_integrated_water_vapor_tendency_due_to_dynamics         |     kg m-2 s-1     |  xy   |  N   |                    |
+   DQLDTDYNINT     |        vertically_integrated_liquid_water_tendency_due_to_dynamics        |     kg m-2 s-1     |  xy   |  N   |                    |
+   DQIDTDYNINT     |         vertically_integrated_ice_water_tendency_due_to_dynamics          |     kg m-2 s-1     |  xy   |  N   |                    |
+      CONVKE       |             vertically_integrated_kinetic_energy_convergence              |       W m-2        |  xy   |  N   |                    |
+     CONVTHV       |                 vertically_integrated_thetav_convergence                  |       W m-2        |  xy   |  N   |                    |
+     CONVCPT       |                vertically_integrated_enthalpy_convergence                 |       W m-2        |  xy   |  N   |                    |
+     CONVPHI       |              vertically_integrated_geopotential_convergence               |       W m-2        |  xy   |  N   |                    |
+        U          |                               eastward_wind                               |       m s-1        |  xyz  |  C   |  MAPL_VectorField  |
+        V          |                              northward_wind                               |       m s-1        |  xyz  |  C   |  MAPL_VectorField  |
+        T          |                              air_temperature                              |         K          |  xyz  |  C   |                    |
+        PL         |                            mid_level_pressure                             |         Pa         |  xyz  |  C   |                    |
+       ZLE0        |                        edge_heights_above_surface                         |         m          |  xyz  |  E   |                    |
+       ZL0         |                      mid_layer_heights_above_surface                      |         m          |  xyz  |  C   |                    |
+       ZLE         |                               edge_heights                                |         m          |  xyz  |  E   |                    |
+        ZL         |                             mid_layer_heights                             |         m          |  xyz  |  C   |                    |
+        S          |                        mid_layer_dry_static_energy                        |         m          |  xyz  |  C   |                    |
+       PLE         |                               edge_pressure                               |         Pa         |  xyz  |  E   |                    |
+        TH         |                           potential_temperature                           |         K          |  xyz  |  C   |                    |
+       PLK         |                           mid-layer_p$^\kappa$                            |    Pa$^\kappa$     |  xyz  |  C   |                    |
+       PKE         |                              edge_p$^\kappa$                              |    Pa$^\kappa$     |  xyz  |  E   |                    |
+       DELZ        |                      nonhydrostatic_layer_thickness                       |       m s-1        |  xyz  |  C   |                    |
+        W          |                             vertical_velocity                             |       m s-1        |  xyz  |  C   |                    |
+      OMEGA        |                  hydrostatic_vertical_pressure_velocity                   |       Pa s-1       |  xyz  |  C   |                    |
+        CX         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  ESMF_KIND_R8
+        CY         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  ESMF_KIND_R8
+        CU         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |
+        CV         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |
+        MX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |
+        MY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |
+       MFX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |  ESMF_KIND_R8
+       MFY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |  ESMF_KIND_R8
+       MFZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  ESMF_KIND_R8
+        MZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  ESMF_KIND_R4
+        PV         |                   ertels_isentropic_potential_vorticity                   |    m+2 kg-1 s-1    |  xyz  |  C   |                    |
+       EPV         |                        ertels_potential_vorticity                         |   K m+2 kg-1 s-1   |  xyz  |  C   |                    |
+        Q          |                             specific_humidity                             |         1          |  xyz  |  C   |                    |
+        QC         |                        specific_mass_of_condensate                        |         1          |  xyz  |  C   |                    |
+     DUDTSUBZ      |                tendency_of_eastward_wind_due_to_subgrid_dz                |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
+     DVDTSUBZ      |               tendency_of_northward_wind_due_to_subgrid_dz                |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
+     DTDTSUBZ      |               tendency_of_air_temperature_due_to_subgrid_dz               |       K s-1        |  xyz  |  C   |                    |
+     DWDTSUBZ      |              tendency_of_vertical_velocity_due_to_subgrid_dz              |       m/s/s        |  xyz  |  C   |                    |
+     DTDT_RAY      |             air_temperature_tendency_due_to_Rayleigh_friction             |       K s-1        |  xyz  |  C   |                    |
+     DUDT_RAY      |            tendency_of_eastward_wind_due_to_Rayleigh_friction             |       m s-2        |  xyz  |  C   |  MAPL_VectorField  |
+     DVDT_RAY      |            tendency_of_northward_wind_due_to_Rayleigh_friction            |       m s-2        |  xyz  |  C   |  MAPL_VectorField  |
+     DWDT_RAY      |            vertical_velocity_tendency_due_to_Rayleigh_friction            |       m/s/s        |  xyz  |  C   |                    |
+     DUDTANA       |                 tendency_of_eastward_wind_due_to_analysis                 |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
+     DVDTANA       |                tendency_of_northward_wind_due_to_analysis                 |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
+     DTDTANA       |                tendency_of_air_temperature_due_to_analysis                |       K s-1        |  xyz  |  C   |                    |
+    DDELPDTANA     |              tendency_of_pressure_thickness_due_to_analysis               |       K s-1        |  xyz  |  C   |                    |
+     DUDTDYN       |                 tendency_of_eastward_wind_due_to_dynamics                 |       m/s/s        |  xyz  |  C   |                    |
+     DVDTDYN       |                tendency_of_northward_wind_due_to_dynamics                 |       m/s/s        |  xyz  |  C   |                    |
+     DTDTDYN       |                tendency_of_air_temperature_due_to_dynamics                |       K s-1        |  xyz  |  C   |                    |
+     DQVDTDYN      |               tendency_of_specific_humidity_due_to_dynamics               |      kg/kg/s       |  xyz  |  C   |                    |
+     DQIDTDYN      |                   tendency_of_ice_water_due_to_dynamics                   |      kg/kg/s       |  xyz  |  C   |                    |
+     DQLDTDYN      |                 tendency_of_liquid_water_due_to_dynamics                  |      kg/kg/s       |  xyz  |  C   |                    |
+     DOXDTDYN      |                     tendency_of_ozone_due_to_dynamics                     |   mol mol-1 s-1    |  xyz  |  C   |                    |
+       PREF        |                          reference_air_pressure                           |         Pa         |    z  |  E   |                    |
+        AK         |                          hybrid_sigma_pressure_a                          |         1          |    z  |  E   |                    |
+        BK         |                          hybrid_sigma_pressure_b                          |         1          |    z  |  E   |                    |
+       PHIS        |                              surface_height                               |         m          |  xy   |  N   |                    |
+        PS         |                             surface_pressure                              |         Pa         |  xy   |  N   |                    |
+        TA         |                          surface_air_temperature                          |         K          |  xy   |  N   |                    |
+        QA         |                         surface_specific_humidity                         |         1          |  xy   |  N   |                    |
+        US         |                           surface_eastward_wind                           |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+        VS         |                          surface_northward_wind                           |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+      SPEED        |                            surface_wind_speed                             |       m s-1        |  xy   |  N   |                    |
+     WSPD_10M      |                             wind_speed_at_10m                             |       m s-1        |  xy   |  N   |                    |
+ VVEL_UP_100_1000  |               max_vertical_velocity_up_between_100_1000_hPa               |       m s-1        |  xy   |  N   |                    |
+ VVEL_DN_100_1000  |              max_vertical_velocity_down_between_100_1000_hPa              |       m s-1        |  xy   |  N   |                    |
+        DZ         |                           surface_layer_height                            |         m          |  xy   |  N   |                    |
+       SLP         |                            sea_level_pressure                             |         Pa         |  xy   |  N   |                    |
+      H1000        |                             height_at_1000_mb                             |         m          |  xy   |  N   |                    |
+    TROPP_EPV      |                 tropopause_pressure_based_on_EPV_estimate                 |         Pa         |  xy   |  N   |                    |
+  TROPP_THERMAL    |               tropopause_pressure_based_on_thermal_estimate               |         Pa         |  xy   |  N   |                    |
+  TROPP_BLENDED    |               tropopause_pressure_based_on_blended_estimate               |         Pa         |  xy   |  N   |                    |
+  TROPK_BLENDED    |                tropopause_index_based_on_blended_estimate                 |      unitless      |  xy   |  N   |                    |
+      TROPT        |            tropopause_temperature_using_blended_TROPP_estimate            |         K          |  xy   |  N   |                    |
+      TROPQ        |         tropopause_specific_humidity_using_blended_TROPP_estimate         |       kg/kg        |  xy   |  N   |                    |
+       PLE0        |                  pressure_at_layer_edges_before_dynamics                  |         Pa         |  xyz  |  E   |                    |  ESMF_KIND_R8
+       PLE1        |                  pressure_at_layer_edges_after_dynamics                   |         Pa         |  xyz  |  E   |                    |  ESMF_KIND_R8
+       DELP        |                            pressure_thickness                             |         Pa         |  xyz  |  C   |                    |
+     DELPTOP       |                      pressure_thickness_at_model_top                      |         Pa         |  xy   |  N   |                    |
+     U_AGRID       |                          eastward_wind_on_A-Grid                          |       m s-1        |  xyz  |  C   |                    |
+     V_AGRID       |                         northward_wind_on_A-Grid                          |       m s-1        |  xyz  |  C   |                    |
+     U_CGRID       |                          eastward_wind_on_C-Grid                          |       m s-1        |  xyz  |  C   |                    |
+     V_CGRID       |                         northward_wind_on_C-Grid                          |       m s-1        |  xyz  |  C   |                    |
+     U_DGRID       |                      eastward_wind_on_native_D-Grid                       |       m s-1        |  xyz  |  C   |                    |
+     V_DGRID       |                      northward_wind_on_native_D-Grid                      |       m s-1        |  xyz  |  C   |                    |
+        TV         |                          air_virtual_temperature                          |         K          |  xyz  |  C   |                    |
+       THV         |                   scaled_virtual_potential_temperature                    |   K/Pa$^\kappa$    |  xyz  |  C   |                    |
+    DPLEDTDYN      |                 tendency_of_edge_pressure_due_to_dynamics                 |       Pa s-1       |  xyz  |  C   |                    |
+    DDELPDTDYN     |              tendency_of_pressure_thickness_due_to_dynamics               |       Pa s-1       |  xyz  |  C   |                    |
+       UKE         |                eastward_flux_of_atmospheric_kinetic_energy                |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
+       VKE         |               northward_flux_of_atmospheric_kinetic_energy                |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
+       UCPT        |                   eastward_flux_of_atmospheric_enthalpy                   |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
+       VCPT        |                  northward_flux_of_atmospheric_enthalpy                   |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
+       UPHI        |               eastward_flux_of_atmospheric_potential_energy               |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
+       VPHI        |              northward_flux_of_atmospheric_potential_energy               |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
+       UQV         |                 eastward_flux_of_atmospheric_water_vapor                  |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
+       VQV         |                 northward_flux_of_atmospheric_water_vapor                 |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
+       UQL         |                 eastward_flux_of_atmospheric_liquid_water                 |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
+       VQL         |                northward_flux_of_atmospheric_liquid_water                 |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
+       UQI         |                     eastward_flux_of_atmospheric_ice                      |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
+       VQI         |                     northward_flux_of_atmospheric_ice                     |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
+       DKE         |       tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics       |       W m-2        |  xy   |  N   |                    |
+       DCPT        |         tendency_of_atmosphere_dry_energy_content_due_to_dynamics         |       W m-2        |  xy   |  N   |                    |
+       DPET        |    tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics    |       W m-2        |  xy   |  N   |                    |
+       WRKT        |                      work_done_by_atmosphere_at_top                       |       W m-2        |  xy   |  N   |                    |
+       DQV         |        tendency_of_atmosphere_water_vapor_content_due_to_dynamics         |     kg m-2 s-1     |  xy   |  N   |                    |
+       DQL         |        tendency_of_atmosphere_liquid_water_content_due_to_dynamics        |     kg m-2 s-1     |  xy   |  N   |                    |
+       DQI         |            tendency_of_atmosphere_ice_content_due_to_dynamics             |     kg m-2 s-1     |  xy   |  N   |                    |
+       CNV         |              generation_of_atmosphere_kinetic_energy_content              |       W m-2        |  xy   |  N   |                    |
+       UH25        |                        updraft_helicity_2_to_5_km                         |      m+2 s-2       |  xy   |  N   |                    |
+       UH03        |                        updraft_helicity_0_to_3_km                         |      m+2 s-2       |  xy   |  N   |                    |
+      SRH01        |                     storm_relative_helicity_0_to_1_km                     |      m+2 s-2       |  xy   |  N   |                    |
+      SRH03        |                     storm_relative_helicity_0_to_3_km                     |      m+2 s-2       |  xy   |  N   |                    |
+      SRH25        |                     storm_relative_helicity_2_to_5_km                     |      m+2 s-2       |  xy   |  N   |                    |
+       VORT        |                      vorticity_at_mid_layer_heights                       |        s-1         |  xyz  |  C   |                    |
+     VORT850       |                           vorticity_at_850_hPa                            |        s-1         |  xy   |  N   |                    |
+     VORT700       |                           vorticity_at_700_hPa                            |        s-1         |  xy   |  N   |                    |
+     VORT500       |                           vorticity_at_500_hPa                            |        s-1         |  xy   |  N   |                    |
+     VORT200       |                           vorticity_at_200_hPa                            |        s-1         |  xy   |  N   |                    |
+       DIVG        |                      divergence_at_mid_layer_heights                      |        s-1         |  xyz  |  C   |                    |
+     DIVG850       |                           divergence_at_850_hPa                           |        s-1         |  xy   |  N   |                    |
+     DIVG700       |                           divergence_at_700_hPa                           |        s-1         |  xy   |  N   |                    |
+     DIVG500       |                           divergence_at_500_hPa                           |        s-1         |  xy   |  N   |                    |
+     DIVG200       |                           divergence_at_200_hPa                           |        s-1         |  xy   |  N   |                    |
+       U850        |                         eastward_wind_at_850_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       U700        |                         eastward_wind_at_700_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       U500        |                         eastward_wind_at_500_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       U300        |                         eastward_wind_at_300_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       U250        |                         eastward_wind_at_250_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       U200        |                         eastward_wind_at_200_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       U100        |                         eastward_wind_at_100_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       UTOP        |                        eastward_wind_at_model_top                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V850        |                         northward_wind_at_850_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V700        |                         northward_wind_at_700_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V500        |                         northward_wind_at_500_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V300        |                         northward_wind_at_300_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V250        |                         northward_wind_at_250_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V200        |                         northward_wind_at_200_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V100        |                         northward_wind_at_100_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       VTOP        |                        northward_wind_at_model_top                        |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       T850        |                        air_temperature_at_850_hPa                         |         K          |  xy   |  N   |                    |
+       T700        |                        air_temperature_at_700_hPa                         |         K          |  xy   |  N   |                    |
+       T500        |                        air_temperature_at_500_hPa                         |         K          |  xy   |  N   |                    |
+       T300        |                        air_temperature_at_300_hPa                         |         K          |  xy   |  N   |                    |
+       T250        |                        air_temperature_at_250_hPa                         |         K          |  xy   |  N   |                    |
+       T200        |                        air_temperature_at_200_hPa                         |         K          |  xy   |  N   |                    |
+       T100        |                        air_temperature_at_100_hPa                         |         K          |  xy   |  N   |                    |
+       TTOP        |                       air_temperature_at_model_top                        |         K          |  xy   |  N   |                    |
+       Q850        |                       specific_humidity_at_850_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Q700        |                       specific_humidity_at_700_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Q500        |                       specific_humidity_at_500_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Q300        |                       specific_humidity_at_300_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Q250        |                       specific_humidity_at_250_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Q200        |                       specific_humidity_at_200_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Q100        |                       specific_humidity_at_100_hPa                        |      kg kg-1       |  xy   |  N   |                    |
+       Z700        |                      geopotential_height_at_700_hPa                       |         m          |  xy   |  N   |                    |
+       Z500        |                      geopotential_height_at_500_hPa                       |         m          |  xy   |  N   |                    |
+       Z300        |                      geopotential_height_at_300_hPa                       |         m          |  xy   |  N   |                    |
+       H850        |                             height_at_850_hPa                             |         m          |  xy   |  N   |                    |
+       H700        |                             height_at_700_hPa                             |         m          |  xy   |  N   |                    |
+       H500        |                             height_at_500_hPa                             |         m          |  xy   |  N   |                    |
+       H300        |                             height_at_300_hPa                             |         m          |  xy   |  N   |                    |
+       H250        |                             height_at_250_hPa                             |         m          |  xy   |  N   |                    |
+       H200        |                             height_at_200_hPa                             |         m          |  xy   |  N   |                    |
+       H100        |                             height_at_100_hPa                             |         m          |  xy   |  N   |                    |
+     OMEGA850      |                             omega_at_850_hPa                              |       Pa s-1       |  xy   |  N   |                    |
+     OMEGA700      |                             omega_at_700_hPa                              |       Pa s-1       |  xy   |  N   |                    |
+     OMEGA500      |                             omega_at_500_hPa                              |       Pa s-1       |  xy   |  N   |                    |
+     OMEGA200      |                             omega_at_200_hPa                              |       Pa s-1       |  xy   |  N   |                    |
+     OMEGA10       |                              omega_at_10_hPa                              |       Pa s-1       |  xy   |  N   |                    |
+       W850        |                               w_at_850_hPa                                |       m s-1        |  xy   |  N   |                    |
+       W500        |                               w_at_500_hPa                                |       m s-1        |  xy   |  N   |                    |
+       W200        |                               w_at_200_hPa                                |       m s-1        |  xy   |  N   |                    |
+       W10         |                                w_at_10_hPa                                |       m s-1        |  xy   |  N   |                    |
+       U50M        |                        eastward_wind_at_50_meters                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       V50M        |                        northward_wind_at_50_meters                        |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
+       DXC         |                               cgrid_delta_x                               |         m          |  xy   |  N   |                    |
+       DYC         |                               cgrid_delta_y                               |         m          |  xy   |  N   |                    |
+       AREA        |                              agrid_cell_area                              |        m+2         |  xy   |  N   |                    |
+        PT         |                       scaled_potential_temperature                        |  K Pa$^{-\kappa}$  |  xyz  |  C   |                    |
+        PE         |                               air_pressure                                |         Pa         |  xyz  |  E   |                    |
+       LONS        |                             Center_longitudes                             |      radians       |  xy   |  N   |                    |
+       LATS        |                             Center_latitudes                              |      radians       |  xy   |  N   |                    |
+   TIME_IN_DYN     |                        timer_for_main_dynamics_run                        |      seconds       |  xy   |  N   |                    |
+       PID         |                                process_id                                 |         1          |  xy   |  N   |                    |
+    QV_DYN_IN      |                    spec_humidity_at_begin_of_time_step                    |      kg kg-1       |  xyz  |  C   |                    |
+     T_DYN_IN      |                     temperature_at_begin_of_time_step                     |         K          |  xyz  |  C   |                    |
+     U_DYN_IN      |                       u_wind_at_begin_of_time_step                        |       m s-1        |  xyz  |  C   |                    |
+     V_DYN_IN      |                       v_wind_at_begin_of_time_step                        |       m s-1        |  xyz  |  C   |                    |
+    PLE_DYN_IN     |                    edge_pressure_at_begin_of_time_step                    |         Pa         |  xyz  |  E   |                    |
 
 
 category: IMPORT
-#------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SHORT_NAME  |                      LONG_NAME                      |   UNITS    |        DIMS         |     FIELD_TYPE     |       VLOCATION        |      RESTART
-#------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    DUDT     |               eastward_wind_tendency                |   m s-2    |  MAPL_DimsHorzVert  |  MAPL_VectorField  |  MAPL_VlocationCenter  |
-    DVDT     |               northward_wind_tendency               |   m s-2    |  MAPL_DimsHorzVert  |  MAPL_VectorField  |  MAPL_VlocationCenter  |
-    DWDT     |             vertical_velocity_tendency              |   m s-2    |  MAPL_DimsHorzVert  |  MAPL_VectorField  |  MAPL_VlocationCenter  |
-    DTDT     |        delta-p_weighted_temperature_tendency        |  Pa K s-1  |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DQVANA    |      specific_humidity_increment_from_analysis      |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DQLANA    |  specific_humidity_liquid_increment_from_analysis   |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DQIANA    |    specific_humidity_ice_increment_from_analysis    |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DQRANA    |   specific_humidity_rain_increment_from_analysis    |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DQSANA    |   specific_humidity_snow_increment_from_analysis    |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DQGANA    |  specific_humidity_graupel_increment_from_analysis  |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DOXANA    |            ozone_increment_from_analysis            |  kg kg-1   |  MAPL_DimsHorzVert  |                    |  MAPL_VlocationCenter  |
-   DPEDT     |               edge_pressure_tendency                |   Pa s-1   |  MAPL_DimsHorzVert  |                    |   MAPL_VlocationEdge   |
-    PHIS     |             surface_geopotential_height             |  m+2 s-2   |  MAPL_DimsHorzOnly  |                    |   MAPL_VlocationNone   |
-   VARFLT    |           variance_of_filtered_topography           |    m+2     |  MAPL_DimsHorzOnly  |                    |   MAPL_VlocationNone   |  MAPL_RestartSkip
+#------------------------------------------------------------------------------------------------------------------------------
+ SHORT_NAME  |                      LONG_NAME                      |   UNITS    |  DIMS |     FIELD_TYPE     | VLOC |  RESTART
+#------------------------------------------------------------------------------------------------------------------------------
+    DUDT     |               eastward_wind_tendency                |   m s-2    |  xyz  |  MAPL_VectorField  |  C   |
+    DVDT     |               northward_wind_tendency               |   m s-2    |  xyz  |  MAPL_VectorField  |  C   |
+    DWDT     |             vertical_velocity_tendency              |   m s-2    |  xyz  |  MAPL_VectorField  |  C   |
+    DTDT     |        delta-p_weighted_temperature_tendency        |  Pa K s-1  |  xyz  |                    |  C   |
+   DQVANA    |      specific_humidity_increment_from_analysis      |  kg kg-1   |  xyz  |                    |  C   |
+   DQLANA    |  specific_humidity_liquid_increment_from_analysis   |  kg kg-1   |  xyz  |                    |  C   |
+   DQIANA    |    specific_humidity_ice_increment_from_analysis    |  kg kg-1   |  xyz  |                    |  C   |
+   DQRANA    |   specific_humidity_rain_increment_from_analysis    |  kg kg-1   |  xyz  |                    |  C   |
+   DQSANA    |   specific_humidity_snow_increment_from_analysis    |  kg kg-1   |  xyz  |                    |  C   |
+   DQGANA    |  specific_humidity_graupel_increment_from_analysis  |  kg kg-1   |  xyz  |                    |  C   |
+   DOXANA    |            ozone_increment_from_analysis            |  kg kg-1   |  xyz  |                    |  C   |
+   DPEDT     |               edge_pressure_tendency                |   Pa s-1   |  xyz  |                    |  E   |
+    PHIS     |             surface_geopotential_height             |  m+2 s-2   |  xy   |                    |  N   |
+   VARFLT    |           variance_of_filtered_topography           |    m+2     |  xy   |                    |  N   |  MAPL_RestartSkip
 
 
 category: INTERNAL
-#---------------------------------------------------------------------------------------------------------------------------------------------------------
- SHORT_NAME  |           LONG_NAME            |       UNITS        |   PRECISION    |        DIMS         |        RESTART         |       VLOCATION
-#---------------------------------------------------------------------------------------------------------------------------------------------------------
-     AK      |    hybrid_sigma_pressure_a     |         Pa         |  ESMF_KIND_R8  |  MAPL_DimsVertOnly  |  MAPL_RestartRequired  |   MAPL_VlocationEdge
-     BK      |    hybrid_sigma_pressure_b     |         1          |  ESMF_KIND_R8  |  MAPL_DimsVertOnly  |  MAPL_RestartRequired  |   MAPL_VlocationEdge
-     U       |         eastward_wind          |       m s-1        |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |  MAPL_RestartRequired  |  MAPL_VlocationCenter
-     V       |         northward_wind         |       m s-1        |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |  MAPL_RestartRequired  |  MAPL_VlocationCenter
-     PT      |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |  MAPL_RestartRequired  |  MAPL_VlocationCenter
-     PE      |          air_pressure          |         Pa         |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |  MAPL_RestartRequired  |   MAPL_VlocationEdge
-    PKZ      |       pressure_to_kappa        |    Pa$^\kappa$     |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |  MAPL_RestartRequired  |  MAPL_VlocationCenter
-     DZ      |        height_thickness        |         m          |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |                        |  MAPL_VlocationCenter
-     W       |       vertical_velocity        |       m s-1        |  ESMF_KIND_R8  |  MAPL_DimsHorzVert  |                        |  MAPL_VlocationCenter
+#---------------------------------------------------------------------------------------------------------------------------
+ SHORT_NAME  |           LONG_NAME            |       UNITS        |   PRECISION    |  DIMS |        RESTART         | VLOC
+#---------------------------------------------------------------------------------------------------------------------------
+     AK      |    hybrid_sigma_pressure_a     |         Pa         |  ESMF_KIND_R8  |    z  |  MAPL_RestartRequired  |  E
+     BK      |    hybrid_sigma_pressure_b     |         1          |  ESMF_KIND_R8  |    z  |  MAPL_RestartRequired  |  E
+     U       |         eastward_wind          |       m s-1        |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
+     V       |         northward_wind         |       m s-1        |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
+     PT      |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
+     PE      |          air_pressure          |         Pa         |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  E
+    PKZ      |       pressure_to_kappa        |    Pa$^\kappa$     |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
+     DZ      |        height_thickness        |         m          |  ESMF_KIND_R8  |  xyz  |                        |  C
+     W       |       vertical_velocity        |       m s-1        |  ESMF_KIND_R8  |  xyz  |                        |  C

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -2,9 +2,9 @@ schema_version: 2.0.0
 component: DynCore
 
 category: EXPORT
-#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    SHORT_NAME     |                                 LONG_NAME                                 |       UNITS        |  DIMS | VLOC |     FIELD_TYPE     |   PRECISION
-#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    SHORT_NAME     |                                 LONG_NAME                                 |       UNITS        |  DIMS | VLOC |     FIELD_TYPE     | TYPEKIND
+#------------------------------------------------------------------------------------------------------------------------------------------------------------------
         KE         |                   vertically_integrated_kinetic_energy                    |       J m-2        |  xy   |  N   |                    |
        TAVE        |                    vertically_averaged_dry_temperature                    |         K          |  xy   |  N   |                    |
        UAVE        |                      vertically_averaged_zonal_wind                       |      m sec-1       |  xy   |  N   |  MAPL_VectorField  |
@@ -66,16 +66,16 @@ category: EXPORT
        DELZ        |                      nonhydrostatic_layer_thickness                       |       m s-1        |  xyz  |  C   |                    |
         W          |                             vertical_velocity                             |       m s-1        |  xyz  |  C   |                    |
       OMEGA        |                  hydrostatic_vertical_pressure_velocity                   |       Pa s-1       |  xyz  |  C   |                    |
-        CX         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  ESMF_KIND_R8
-        CY         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  ESMF_KIND_R8
+        CX         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  R8
+        CY         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  R8
         CU         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |
         CV         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |
         MX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |
         MY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |
-       MFX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |  ESMF_KIND_R8
-       MFY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |  ESMF_KIND_R8
-       MFZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  ESMF_KIND_R8
-        MZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  ESMF_KIND_R4
+       MFX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |  R8
+       MFY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |  R8
+       MFZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  R8
+        MZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  R4
         PV         |                   ertels_isentropic_potential_vorticity                   |    m+2 kg-1 s-1    |  xyz  |  C   |                    |
        EPV         |                        ertels_potential_vorticity                         |   K m+2 kg-1 s-1   |  xyz  |  C   |                    |
         Q          |                             specific_humidity                             |         1          |  xyz  |  C   |                    |
@@ -121,8 +121,8 @@ category: EXPORT
   TROPK_BLENDED    |                tropopause_index_based_on_blended_estimate                 |      unitless      |  xy   |  N   |                    |
       TROPT        |            tropopause_temperature_using_blended_TROPP_estimate            |         K          |  xy   |  N   |                    |
       TROPQ        |         tropopause_specific_humidity_using_blended_TROPP_estimate         |       kg/kg        |  xy   |  N   |                    |
-       PLE0        |                  pressure_at_layer_edges_before_dynamics                  |         Pa         |  xyz  |  E   |                    |  ESMF_KIND_R8
-       PLE1        |                  pressure_at_layer_edges_after_dynamics                   |         Pa         |  xyz  |  E   |                    |  ESMF_KIND_R8
+       PLE0        |                  pressure_at_layer_edges_before_dynamics                  |         Pa         |  xyz  |  E   |                    |  R8
+       PLE1        |                  pressure_at_layer_edges_after_dynamics                   |         Pa         |  xyz  |  E   |                    |  R8
        DELP        |                            pressure_thickness                             |         Pa         |  xyz  |  C   |                    |
      DELPTOP       |                      pressure_thickness_at_model_top                      |         Pa         |  xy   |  N   |                    |
      U_AGRID       |                          eastward_wind_on_A-Grid                          |       m s-1        |  xyz  |  C   |                    |
@@ -259,15 +259,15 @@ category: IMPORT
 
 
 category: INTERNAL
-#---------------------------------------------------------------------------------------------------------------------------
- SHORT_NAME  |           LONG_NAME            |       UNITS        |   PRECISION    |  DIMS |        RESTART         | VLOC
-#---------------------------------------------------------------------------------------------------------------------------
-     AK      |    hybrid_sigma_pressure_a     |         Pa         |  ESMF_KIND_R8  |    z  |  MAPL_RestartRequired  |  E
-     BK      |    hybrid_sigma_pressure_b     |         1          |  ESMF_KIND_R8  |    z  |  MAPL_RestartRequired  |  E
-     U       |         eastward_wind          |       m s-1        |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
-     V       |         northward_wind         |       m s-1        |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
-     PT      |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
-     PE      |          air_pressure          |         Pa         |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  E
-    PKZ      |       pressure_to_kappa        |    Pa$^\kappa$     |  ESMF_KIND_R8  |  xyz  |  MAPL_RestartRequired  |  C
-     DZ      |        height_thickness        |         m          |  ESMF_KIND_R8  |  xyz  |                        |  C
-     W       |       vertical_velocity        |       m s-1        |  ESMF_KIND_R8  |  xyz  |                        |  C
+#---------------------------------------------------------------------------------------------------------------------
+ SHORT_NAME  |           LONG_NAME            |       UNITS        | TYPEKIND |  DIMS |        RESTART         | VLOC
+#---------------------------------------------------------------------------------------------------------------------
+     AK      |    hybrid_sigma_pressure_a     |         Pa         |     R8   |    z  |  MAPL_RestartRequired  |  E
+     BK      |    hybrid_sigma_pressure_b     |         1          |     R8   |    z  |  MAPL_RestartRequired  |  E
+     U       |         eastward_wind          |       m s-1        |     R8   |  xyz  |  MAPL_RestartRequired  |  C
+     V       |         northward_wind         |       m s-1        |     R8   |  xyz  |  MAPL_RestartRequired  |  C
+     PT      |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |     R8   |  xyz  |  MAPL_RestartRequired  |  C
+     PE      |          air_pressure          |         Pa         |     R8   |  xyz  |  MAPL_RestartRequired  |  E
+    PKZ      |       pressure_to_kappa        |    Pa$^\kappa$     |     R8   |  xyz  |  MAPL_RestartRequired  |  C
+     DZ      |        height_thickness        |         m          |     R8   |  xyz  |                        |  C
+     W       |       vertical_velocity        |       m s-1        |     R8   |  xyz  |                        |  C

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -66,10 +66,10 @@ category: EXPORT
        DELZ        |                      nonhydrostatic_layer_thickness                       |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
         W          |                             vertical_velocity                             |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
       OMEGA        |                  hydrostatic_vertical_pressure_velocity                   |       Pa s-1       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
- #      CX         |                    eastward_accumulated_courant_number                    |                    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
- #      CY         |                   northward_accumulated_courant_number                    |                    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
- #      CU         |                    eastward_accumulated_courant_number                    |                    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
- #      CV         |                   northward_accumulated_courant_number                    |                    |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
+        CX         |                    eastward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
+        CY         |                   northward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
+        CU         |                    eastward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
+        CV         |                   northward_accumulated_courant_number                    |         1          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
         MX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
         MY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
        MFX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |  ESMF_KIND_R8
@@ -230,7 +230,7 @@ category: EXPORT
        LONS        |                             Center_longitudes                             |      radians       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
        LATS        |                             Center_latitudes                              |      radians       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
    TIME_IN_DYN     |                        timer_for_main_dynamics_run                        |      seconds       |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
- #     PID         |                                process_id                                 |                    |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
+       PID         |                                process_id                                 |         1          |  MAPL_DimsHorzOnly  |   MAPL_VlocationNone   |                    |
     QV_DYN_IN      |                    spec_humidity_at_begin_of_time_step                    |      kg kg-1       |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
      T_DYN_IN      |                     temperature_at_begin_of_time_step                     |         K          |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |
      U_DYN_IN      |                       u_wind_at_begin_of_time_step                        |       m s-1        |  MAPL_DimsHorzVert  |  MAPL_VlocationCenter  |                    |

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -3,271 +3,271 @@ component: DynCore
 
 category: EXPORT
 #------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    SHORT_NAME     |                                 LONG_NAME                                 |       UNITS        |  DIMS | VLOC |     FIELD_TYPE     | TYPEKIND
+  SHORT_NAME     |  LONG_NAME                                                                |  UNITS             |  DIMS | VLOC |  FIELD_TYPE        | TYPEKIND
 #------------------------------------------------------------------------------------------------------------------------------------------------------------------
-        KE         |                   vertically_integrated_kinetic_energy                    |       J m-2        |  xy   |  N   |                    |
-       TAVE        |                    vertically_averaged_dry_temperature                    |         K          |  xy   |  N   |                    |
-       UAVE        |                      vertically_averaged_zonal_wind                       |      m sec-1       |  xy   |  N   |  MAPL_VectorField  |
-      KEPHY        |       vertically_integrated_kinetic_energy_tendency_due_to_physics        |       W m-2        |  xy   |  N   |                    |
-      PEPHY        |              total_potential_energy_tendency_due_to_physics               |       W m-2        |  xy   |  N   |                    |
-      TEPHY        |                   mountain_work_tendency_due_to_physics                   |       W m-2        |  xy   |  N   |                    |
-      KEANA        |               total_kinetic_energy_tendency_due_to_analysis               |       W m-2        |  xy   |  N   |                    |
-      PEANA        |              total_potential_energy_tendency_due_to_analysis              |       W m-2        |  xy   |  N   |                    |
-      TEANA        |                  mountain_work_tendency_due_to_analysis                   |       W m-2        |  xy   |  N   |                    |
-      KEHOT        |         vertically_integrated_kinetic_energy_tendency_due_to_HOT          |       W m-2        |  xy   |  N   |                    |
-       KEDP        |   vertically_integrated_kinetic_energy_tendency_due_to_pressure_change    |       W m-2        |  xy   |  N   |                    |
-      KEADV        |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics_advection  |       W m-2        |  xy   |  N   |                    |
-       KEPG        |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_gradient   |       W m-2        |  xy   |  N   |                    |
-      KEDYN        |       vertically_integrated_kinetic_energy_tendency_due_to_dynamics       |       W m-2        |  xy   |  N   |                    |
-      PEDYN        |      vertically_integrated_potential_energy_tendency_due_to_dynamics      |       W m-2        |  xy   |  N   |                    |
-      TEDYN        |                  mountain_work_tendency_due_to_dynamics                   |       W m-2        |  xy   |  N   |                    |
-     KECDCOR       |        vertically_integrated_kinetic_energy_tendency_due_to_cdcore        |       W m-2        |  xy   |  N   |                    |
-     PECDCOR       |       vertically_integrated_potential_energy_tendency_due_to_cdcore       |       W m-2        |  xy   |  N   |                    |
-     TECDCOR       |                   mountain_work_tendency_due_to_cdcore                    |       W m-2        |  xy   |  N   |                    |
-      QFIXER       |       vertically_integrated_potential_energy_tendency_due_to_CONSV        |       W m-2        |  xy   |  N   |                    |
-     KEREMAP       |        vertically_integrated_kinetic_energy_tendency_due_to_remap         |       W m-2        |  xy   |  N   |                    |
-     PEREMAP       |       vertically_integrated_potential_energy_tendency_due_to_remap        |       W m-2        |  xy   |  N   |                    |
-     TEREMAP       |                    mountain_work_tendency_due_to_remap                    |       W m-2        |  xy   |  N   |                    |
-      KEGEN        |            vertically_integrated_generation_of_kinetic_energy             |       W m-2        |  xy   |  N   |                    |
-     DKERESIN      |     vertically_integrated_kinetic_energy_residual_from_inertial_terms     |       W m-2        |  xy   |  N   |                    |
-     DKERESPG      |        vertically_integrated_kinetic_energy_residual_from_PG_terms        |       W m-2        |  xy   |  N   |                    |
-     DMDTANA       |            vertically_integrated_mass_tendency_due_to_analysis            |     kg m-2 s-1     |  xy   |  N   |                    |
-   DOXDTANAINT     |           vertically_integrated_ozone_tendency_due_to_analysis            |     kg m-2 s-1     |  xy   |  N   |                    |
-   DQVDTANAINT     |        vertically_integrated_water_vapor_tendency_due_to_analysis         |     kg m-2 s-1     |  xy   |  N   |                    |
-   DQLDTANAINT     |        vertically_integrated_liquid_water_tendency_due_to_analysis        |     kg m-2 s-1     |  xy   |  N   |                    |
-   DQIDTANAINT     |         vertically_integrated_ice_water_tendency_due_to_analysis          |     kg m-2 s-1     |  xy   |  N   |                    |
-     DMDTDYN       |            vertically_integrated_mass_tendency_due_to_dynamics            |     kg m-2 s-1     |  xy   |  N   |                    |
-   DOXDTDYNINT     |           vertically_integrated_ozone_tendency_due_to_dynamics            |     kg m-2 s-1     |  xy   |  N   |                    |
-   DTHVDTDYNINT    |            vertically_integrated_THV_tendency_due_to_dynamics             |    K kg m-2 s-1    |  xy   |  N   |                    |
-   DTHVDTREMAP     |       vertically_integrated_THV_tendency_due_to_vertical_remapping        |    K kg m-2 s-1    |  xy   |  N   |                    |
-   DTHVDTCONSV     |         vertically_integrated_THV_tendency_due_to_TE_conservation         |    K kg m-2 s-1    |  xy   |  N   |                    |
-   DTHVDTPHYINT    |             vertically_integrated_THV_tendency_due_to_physics             |    K kg m-2 s-1    |  xy   |  N   |                    |
-   DTHVDTANAINT    |            vertically_integrated_THV_tendency_due_to_analysis             |    K kg m-2 s-1    |  xy   |  N   |                    |
-   DQVDTDYNINT     |        vertically_integrated_water_vapor_tendency_due_to_dynamics         |     kg m-2 s-1     |  xy   |  N   |                    |
-   DQLDTDYNINT     |        vertically_integrated_liquid_water_tendency_due_to_dynamics        |     kg m-2 s-1     |  xy   |  N   |                    |
-   DQIDTDYNINT     |         vertically_integrated_ice_water_tendency_due_to_dynamics          |     kg m-2 s-1     |  xy   |  N   |                    |
-      CONVKE       |             vertically_integrated_kinetic_energy_convergence              |       W m-2        |  xy   |  N   |                    |
-     CONVTHV       |                 vertically_integrated_thetav_convergence                  |       W m-2        |  xy   |  N   |                    |
-     CONVCPT       |                vertically_integrated_enthalpy_convergence                 |       W m-2        |  xy   |  N   |                    |
-     CONVPHI       |              vertically_integrated_geopotential_convergence               |       W m-2        |  xy   |  N   |                    |
-        U          |                               eastward_wind                               |       m s-1        |  xyz  |  C   |  MAPL_VectorField  |
-        V          |                              northward_wind                               |       m s-1        |  xyz  |  C   |  MAPL_VectorField  |
-        T          |                              air_temperature                              |         K          |  xyz  |  C   |                    |
-        PL         |                            mid_level_pressure                             |         Pa         |  xyz  |  C   |                    |
-       ZLE0        |                        edge_heights_above_surface                         |         m          |  xyz  |  E   |                    |
-       ZL0         |                      mid_layer_heights_above_surface                      |         m          |  xyz  |  C   |                    |
-       ZLE         |                               edge_heights                                |         m          |  xyz  |  E   |                    |
-        ZL         |                             mid_layer_heights                             |         m          |  xyz  |  C   |                    |
-        S          |                        mid_layer_dry_static_energy                        |         m          |  xyz  |  C   |                    |
-       PLE         |                               edge_pressure                               |         Pa         |  xyz  |  E   |                    |
-        TH         |                           potential_temperature                           |         K          |  xyz  |  C   |                    |
-       PLK         |                           mid-layer_p$^\kappa$                            |    Pa$^\kappa$     |  xyz  |  C   |                    |
-       PKE         |                              edge_p$^\kappa$                              |    Pa$^\kappa$     |  xyz  |  E   |                    |
-       DELZ        |                      nonhydrostatic_layer_thickness                       |       m s-1        |  xyz  |  C   |                    |
-        W          |                             vertical_velocity                             |       m s-1        |  xyz  |  C   |                    |
-      OMEGA        |                  hydrostatic_vertical_pressure_velocity                   |       Pa s-1       |  xyz  |  C   |                    |
-        CX         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  R8
-        CY         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |  R8
-        CU         |                    eastward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |
-        CV         |                   northward_accumulated_courant_number                    |         1          |  xyz  |  C   |                    |
-        MX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |
-        MY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |
-       MFX         |             pressure_weighted_accumulated_eastward_mass_flux              |       Pa m+2       |  xyz  |  C   |                    |  R8
-       MFY         |             pressure_weighted_accumulated_northward_mass_flux             |       Pa m+2       |  xyz  |  C   |                    |  R8
-       MFZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  R8
-        MZ         |                            vertical_mass_flux                             |     kg m-2 s-1     |  xyz  |  E   |                    |  R4
-        PV         |                   ertels_isentropic_potential_vorticity                   |    m+2 kg-1 s-1    |  xyz  |  C   |                    |
-       EPV         |                        ertels_potential_vorticity                         |   K m+2 kg-1 s-1   |  xyz  |  C   |                    |
-        Q          |                             specific_humidity                             |         1          |  xyz  |  C   |                    |
-        QC         |                        specific_mass_of_condensate                        |         1          |  xyz  |  C   |                    |
-     DUDTSUBZ      |                tendency_of_eastward_wind_due_to_subgrid_dz                |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
-     DVDTSUBZ      |               tendency_of_northward_wind_due_to_subgrid_dz                |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
-     DTDTSUBZ      |               tendency_of_air_temperature_due_to_subgrid_dz               |       K s-1        |  xyz  |  C   |                    |
-     DWDTSUBZ      |              tendency_of_vertical_velocity_due_to_subgrid_dz              |       m/s/s        |  xyz  |  C   |                    |
-     DTDT_RAY      |             air_temperature_tendency_due_to_Rayleigh_friction             |       K s-1        |  xyz  |  C   |                    |
-     DUDT_RAY      |            tendency_of_eastward_wind_due_to_Rayleigh_friction             |       m s-2        |  xyz  |  C   |  MAPL_VectorField  |
-     DVDT_RAY      |            tendency_of_northward_wind_due_to_Rayleigh_friction            |       m s-2        |  xyz  |  C   |  MAPL_VectorField  |
-     DWDT_RAY      |            vertical_velocity_tendency_due_to_Rayleigh_friction            |       m/s/s        |  xyz  |  C   |                    |
-     DUDTANA       |                 tendency_of_eastward_wind_due_to_analysis                 |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
-     DVDTANA       |                tendency_of_northward_wind_due_to_analysis                 |       m/s/s        |  xyz  |  C   |  MAPL_VectorField  |
-     DTDTANA       |                tendency_of_air_temperature_due_to_analysis                |       K s-1        |  xyz  |  C   |                    |
-    DDELPDTANA     |              tendency_of_pressure_thickness_due_to_analysis               |       K s-1        |  xyz  |  C   |                    |
-     DUDTDYN       |                 tendency_of_eastward_wind_due_to_dynamics                 |       m/s/s        |  xyz  |  C   |                    |
-     DVDTDYN       |                tendency_of_northward_wind_due_to_dynamics                 |       m/s/s        |  xyz  |  C   |                    |
-     DTDTDYN       |                tendency_of_air_temperature_due_to_dynamics                |       K s-1        |  xyz  |  C   |                    |
-     DQVDTDYN      |               tendency_of_specific_humidity_due_to_dynamics               |      kg/kg/s       |  xyz  |  C   |                    |
-     DQIDTDYN      |                   tendency_of_ice_water_due_to_dynamics                   |      kg/kg/s       |  xyz  |  C   |                    |
-     DQLDTDYN      |                 tendency_of_liquid_water_due_to_dynamics                  |      kg/kg/s       |  xyz  |  C   |                    |
-     DOXDTDYN      |                     tendency_of_ozone_due_to_dynamics                     |   mol mol-1 s-1    |  xyz  |  C   |                    |
-       PREF        |                          reference_air_pressure                           |         Pa         |    z  |  E   |                    |
-        AK         |                          hybrid_sigma_pressure_a                          |         1          |    z  |  E   |                    |
-        BK         |                          hybrid_sigma_pressure_b                          |         1          |    z  |  E   |                    |
-       PHIS        |                              surface_height                               |         m          |  xy   |  N   |                    |
-        PS         |                             surface_pressure                              |         Pa         |  xy   |  N   |                    |
-        TA         |                          surface_air_temperature                          |         K          |  xy   |  N   |                    |
-        QA         |                         surface_specific_humidity                         |         1          |  xy   |  N   |                    |
-        US         |                           surface_eastward_wind                           |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-        VS         |                          surface_northward_wind                           |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-      SPEED        |                            surface_wind_speed                             |       m s-1        |  xy   |  N   |                    |
-     WSPD_10M      |                             wind_speed_at_10m                             |       m s-1        |  xy   |  N   |                    |
- VVEL_UP_100_1000  |               max_vertical_velocity_up_between_100_1000_hPa               |       m s-1        |  xy   |  N   |                    |
- VVEL_DN_100_1000  |              max_vertical_velocity_down_between_100_1000_hPa              |       m s-1        |  xy   |  N   |                    |
-        DZ         |                           surface_layer_height                            |         m          |  xy   |  N   |                    |
-       SLP         |                            sea_level_pressure                             |         Pa         |  xy   |  N   |                    |
-      H1000        |                             height_at_1000_mb                             |         m          |  xy   |  N   |                    |
-    TROPP_EPV      |                 tropopause_pressure_based_on_EPV_estimate                 |         Pa         |  xy   |  N   |                    |
-  TROPP_THERMAL    |               tropopause_pressure_based_on_thermal_estimate               |         Pa         |  xy   |  N   |                    |
-  TROPP_BLENDED    |               tropopause_pressure_based_on_blended_estimate               |         Pa         |  xy   |  N   |                    |
-  TROPK_BLENDED    |                tropopause_index_based_on_blended_estimate                 |      unitless      |  xy   |  N   |                    |
-      TROPT        |            tropopause_temperature_using_blended_TROPP_estimate            |         K          |  xy   |  N   |                    |
-      TROPQ        |         tropopause_specific_humidity_using_blended_TROPP_estimate         |       kg/kg        |  xy   |  N   |                    |
-       PLE0        |                  pressure_at_layer_edges_before_dynamics                  |         Pa         |  xyz  |  E   |                    |  R8
-       PLE1        |                  pressure_at_layer_edges_after_dynamics                   |         Pa         |  xyz  |  E   |                    |  R8
-       DELP        |                            pressure_thickness                             |         Pa         |  xyz  |  C   |                    |
-     DELPTOP       |                      pressure_thickness_at_model_top                      |         Pa         |  xy   |  N   |                    |
-     U_AGRID       |                          eastward_wind_on_A-Grid                          |       m s-1        |  xyz  |  C   |                    |
-     V_AGRID       |                         northward_wind_on_A-Grid                          |       m s-1        |  xyz  |  C   |                    |
-     U_CGRID       |                          eastward_wind_on_C-Grid                          |       m s-1        |  xyz  |  C   |                    |
-     V_CGRID       |                         northward_wind_on_C-Grid                          |       m s-1        |  xyz  |  C   |                    |
-     U_DGRID       |                      eastward_wind_on_native_D-Grid                       |       m s-1        |  xyz  |  C   |                    |
-     V_DGRID       |                      northward_wind_on_native_D-Grid                      |       m s-1        |  xyz  |  C   |                    |
-        TV         |                          air_virtual_temperature                          |         K          |  xyz  |  C   |                    |
-       THV         |                   scaled_virtual_potential_temperature                    |   K/Pa$^\kappa$    |  xyz  |  C   |                    |
-    DPLEDTDYN      |                 tendency_of_edge_pressure_due_to_dynamics                 |       Pa s-1       |  xyz  |  C   |                    |
-    DDELPDTDYN     |              tendency_of_pressure_thickness_due_to_dynamics               |       Pa s-1       |  xyz  |  C   |                    |
-       UKE         |                eastward_flux_of_atmospheric_kinetic_energy                |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
-       VKE         |               northward_flux_of_atmospheric_kinetic_energy                |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
-       UCPT        |                   eastward_flux_of_atmospheric_enthalpy                   |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
-       VCPT        |                  northward_flux_of_atmospheric_enthalpy                   |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
-       UPHI        |               eastward_flux_of_atmospheric_potential_energy               |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
-       VPHI        |              northward_flux_of_atmospheric_potential_energy               |     J m-1 s-1      |  xy   |  N   |  MAPL_VectorField  |
-       UQV         |                 eastward_flux_of_atmospheric_water_vapor                  |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
-       VQV         |                 northward_flux_of_atmospheric_water_vapor                 |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
-       UQL         |                 eastward_flux_of_atmospheric_liquid_water                 |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
-       VQL         |                northward_flux_of_atmospheric_liquid_water                 |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
-       UQI         |                     eastward_flux_of_atmospheric_ice                      |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
-       VQI         |                     northward_flux_of_atmospheric_ice                     |     kg m-1 s-1     |  xy   |  N   |  MAPL_VectorField  |
-       DKE         |       tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics       |       W m-2        |  xy   |  N   |                    |
-       DCPT        |         tendency_of_atmosphere_dry_energy_content_due_to_dynamics         |       W m-2        |  xy   |  N   |                    |
-       DPET        |    tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics    |       W m-2        |  xy   |  N   |                    |
-       WRKT        |                      work_done_by_atmosphere_at_top                       |       W m-2        |  xy   |  N   |                    |
-       DQV         |        tendency_of_atmosphere_water_vapor_content_due_to_dynamics         |     kg m-2 s-1     |  xy   |  N   |                    |
-       DQL         |        tendency_of_atmosphere_liquid_water_content_due_to_dynamics        |     kg m-2 s-1     |  xy   |  N   |                    |
-       DQI         |            tendency_of_atmosphere_ice_content_due_to_dynamics             |     kg m-2 s-1     |  xy   |  N   |                    |
-       CNV         |              generation_of_atmosphere_kinetic_energy_content              |       W m-2        |  xy   |  N   |                    |
-       UH25        |                        updraft_helicity_2_to_5_km                         |      m+2 s-2       |  xy   |  N   |                    |
-       UH03        |                        updraft_helicity_0_to_3_km                         |      m+2 s-2       |  xy   |  N   |                    |
-      SRH01        |                     storm_relative_helicity_0_to_1_km                     |      m+2 s-2       |  xy   |  N   |                    |
-      SRH03        |                     storm_relative_helicity_0_to_3_km                     |      m+2 s-2       |  xy   |  N   |                    |
-      SRH25        |                     storm_relative_helicity_2_to_5_km                     |      m+2 s-2       |  xy   |  N   |                    |
-       VORT        |                      vorticity_at_mid_layer_heights                       |        s-1         |  xyz  |  C   |                    |
-     VORT850       |                           vorticity_at_850_hPa                            |        s-1         |  xy   |  N   |                    |
-     VORT700       |                           vorticity_at_700_hPa                            |        s-1         |  xy   |  N   |                    |
-     VORT500       |                           vorticity_at_500_hPa                            |        s-1         |  xy   |  N   |                    |
-     VORT200       |                           vorticity_at_200_hPa                            |        s-1         |  xy   |  N   |                    |
-       DIVG        |                      divergence_at_mid_layer_heights                      |        s-1         |  xyz  |  C   |                    |
-     DIVG850       |                           divergence_at_850_hPa                           |        s-1         |  xy   |  N   |                    |
-     DIVG700       |                           divergence_at_700_hPa                           |        s-1         |  xy   |  N   |                    |
-     DIVG500       |                           divergence_at_500_hPa                           |        s-1         |  xy   |  N   |                    |
-     DIVG200       |                           divergence_at_200_hPa                           |        s-1         |  xy   |  N   |                    |
-       U850        |                         eastward_wind_at_850_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       U700        |                         eastward_wind_at_700_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       U500        |                         eastward_wind_at_500_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       U300        |                         eastward_wind_at_300_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       U250        |                         eastward_wind_at_250_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       U200        |                         eastward_wind_at_200_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       U100        |                         eastward_wind_at_100_hPa                          |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       UTOP        |                        eastward_wind_at_model_top                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V850        |                         northward_wind_at_850_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V700        |                         northward_wind_at_700_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V500        |                         northward_wind_at_500_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V300        |                         northward_wind_at_300_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V250        |                         northward_wind_at_250_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V200        |                         northward_wind_at_200_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V100        |                         northward_wind_at_100_hPa                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       VTOP        |                        northward_wind_at_model_top                        |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       T850        |                        air_temperature_at_850_hPa                         |         K          |  xy   |  N   |                    |
-       T700        |                        air_temperature_at_700_hPa                         |         K          |  xy   |  N   |                    |
-       T500        |                        air_temperature_at_500_hPa                         |         K          |  xy   |  N   |                    |
-       T300        |                        air_temperature_at_300_hPa                         |         K          |  xy   |  N   |                    |
-       T250        |                        air_temperature_at_250_hPa                         |         K          |  xy   |  N   |                    |
-       T200        |                        air_temperature_at_200_hPa                         |         K          |  xy   |  N   |                    |
-       T100        |                        air_temperature_at_100_hPa                         |         K          |  xy   |  N   |                    |
-       TTOP        |                       air_temperature_at_model_top                        |         K          |  xy   |  N   |                    |
-       Q850        |                       specific_humidity_at_850_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Q700        |                       specific_humidity_at_700_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Q500        |                       specific_humidity_at_500_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Q300        |                       specific_humidity_at_300_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Q250        |                       specific_humidity_at_250_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Q200        |                       specific_humidity_at_200_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Q100        |                       specific_humidity_at_100_hPa                        |      kg kg-1       |  xy   |  N   |                    |
-       Z700        |                      geopotential_height_at_700_hPa                       |         m          |  xy   |  N   |                    |
-       Z500        |                      geopotential_height_at_500_hPa                       |         m          |  xy   |  N   |                    |
-       Z300        |                      geopotential_height_at_300_hPa                       |         m          |  xy   |  N   |                    |
-       H850        |                             height_at_850_hPa                             |         m          |  xy   |  N   |                    |
-       H700        |                             height_at_700_hPa                             |         m          |  xy   |  N   |                    |
-       H500        |                             height_at_500_hPa                             |         m          |  xy   |  N   |                    |
-       H300        |                             height_at_300_hPa                             |         m          |  xy   |  N   |                    |
-       H250        |                             height_at_250_hPa                             |         m          |  xy   |  N   |                    |
-       H200        |                             height_at_200_hPa                             |         m          |  xy   |  N   |                    |
-       H100        |                             height_at_100_hPa                             |         m          |  xy   |  N   |                    |
-     OMEGA850      |                             omega_at_850_hPa                              |       Pa s-1       |  xy   |  N   |                    |
-     OMEGA700      |                             omega_at_700_hPa                              |       Pa s-1       |  xy   |  N   |                    |
-     OMEGA500      |                             omega_at_500_hPa                              |       Pa s-1       |  xy   |  N   |                    |
-     OMEGA200      |                             omega_at_200_hPa                              |       Pa s-1       |  xy   |  N   |                    |
-     OMEGA10       |                              omega_at_10_hPa                              |       Pa s-1       |  xy   |  N   |                    |
-       W850        |                               w_at_850_hPa                                |       m s-1        |  xy   |  N   |                    |
-       W500        |                               w_at_500_hPa                                |       m s-1        |  xy   |  N   |                    |
-       W200        |                               w_at_200_hPa                                |       m s-1        |  xy   |  N   |                    |
-       W10         |                                w_at_10_hPa                                |       m s-1        |  xy   |  N   |                    |
-       U50M        |                        eastward_wind_at_50_meters                         |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       V50M        |                        northward_wind_at_50_meters                        |       m s-1        |  xy   |  N   |  MAPL_VectorField  |
-       DXC         |                               cgrid_delta_x                               |         m          |  xy   |  N   |                    |
-       DYC         |                               cgrid_delta_y                               |         m          |  xy   |  N   |                    |
-       AREA        |                              agrid_cell_area                              |        m+2         |  xy   |  N   |                    |
-        PT         |                       scaled_potential_temperature                        |  K Pa$^{-\kappa}$  |  xyz  |  C   |                    |
-        PE         |                               air_pressure                                |         Pa         |  xyz  |  E   |                    |
-       LONS        |                             Center_longitudes                             |      radians       |  xy   |  N   |                    |
-       LATS        |                             Center_latitudes                              |      radians       |  xy   |  N   |                    |
-   TIME_IN_DYN     |                        timer_for_main_dynamics_run                        |      seconds       |  xy   |  N   |                    |
-       PID         |                                process_id                                 |         1          |  xy   |  N   |                    |
-    QV_DYN_IN      |                    spec_humidity_at_begin_of_time_step                    |      kg kg-1       |  xyz  |  C   |                    |
-     T_DYN_IN      |                     temperature_at_begin_of_time_step                     |         K          |  xyz  |  C   |                    |
-     U_DYN_IN      |                       u_wind_at_begin_of_time_step                        |       m s-1        |  xyz  |  C   |                    |
-     V_DYN_IN      |                       v_wind_at_begin_of_time_step                        |       m s-1        |  xyz  |  C   |                    |
-    PLE_DYN_IN     |                    edge_pressure_at_begin_of_time_step                    |         Pa         |  xyz  |  E   |                    |
+  KE             |  vertically_integrated_kinetic_energy                                     |  J m-2             |  xy   |  N   |                    |
+  TAVE           |  vertically_averaged_dry_temperature                                      |  K                 |  xy   |  N   |                    |
+  UAVE           |  vertically_averaged_zonal_wind                                           |  m sec-1           |  xy   |  N   |  MAPL_VectorField  |
+  KEPHY          |  vertically_integrated_kinetic_energy_tendency_due_to_physics             |  W m-2             |  xy   |  N   |                    |
+  PEPHY          |  total_potential_energy_tendency_due_to_physics                           |  W m-2             |  xy   |  N   |                    |
+  TEPHY          |  mountain_work_tendency_due_to_physics                                    |  W m-2             |  xy   |  N   |                    |
+  KEANA          |  total_kinetic_energy_tendency_due_to_analysis                            |  W m-2             |  xy   |  N   |                    |
+  PEANA          |  total_potential_energy_tendency_due_to_analysis                          |  W m-2             |  xy   |  N   |                    |
+  TEANA          |  mountain_work_tendency_due_to_analysis                                   |  W m-2             |  xy   |  N   |                    |
+  KEHOT          |  vertically_integrated_kinetic_energy_tendency_due_to_HOT                 |  W m-2             |  xy   |  N   |                    |
+  KEDP           |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_change     |  W m-2             |  xy   |  N   |                    |
+  KEADV          |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics_advection  |  W m-2             |  xy   |  N   |                    |
+  KEPG           |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_gradient   |  W m-2             |  xy   |  N   |                    |
+  KEDYN          |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics            |  W m-2             |  xy   |  N   |                    |
+  PEDYN          |  vertically_integrated_potential_energy_tendency_due_to_dynamics          |  W m-2             |  xy   |  N   |                    |
+  TEDYN          |  mountain_work_tendency_due_to_dynamics                                   |  W m-2             |  xy   |  N   |                    |
+  KECDCOR        |  vertically_integrated_kinetic_energy_tendency_due_to_cdcore              |  W m-2             |  xy   |  N   |                    |
+  PECDCOR        |  vertically_integrated_potential_energy_tendency_due_to_cdcore            |  W m-2             |  xy   |  N   |                    |
+  TECDCOR        |  mountain_work_tendency_due_to_cdcore                                     |  W m-2             |  xy   |  N   |                    |
+  QFIXER         |  vertically_integrated_potential_energy_tendency_due_to_CONSV             |  W m-2             |  xy   |  N   |                    |
+  KEREMAP        |  vertically_integrated_kinetic_energy_tendency_due_to_remap               |  W m-2             |  xy   |  N   |                    |
+  PEREMAP        |  vertically_integrated_potential_energy_tendency_due_to_remap             |  W m-2             |  xy   |  N   |                    |
+  TEREMAP        |  mountain_work_tendency_due_to_remap                                      |  W m-2             |  xy   |  N   |                    |
+  KEGEN          |  vertically_integrated_generation_of_kinetic_energy                       |  W m-2             |  xy   |  N   |                    |
+  DKERESIN       |  vertically_integrated_kinetic_energy_residual_from_inertial_terms        |  W m-2             |  xy   |  N   |                    |
+  DKERESPG       |  vertically_integrated_kinetic_energy_residual_from_PG_terms              |  W m-2             |  xy   |  N   |                    |
+  DMDTANA        |  vertically_integrated_mass_tendency_due_to_analysis                      |  kg m-2 s-1        |  xy   |  N   |                    |
+  DOXDTANAINT    |  vertically_integrated_ozone_tendency_due_to_analysis                     |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQVDTANAINT    |  vertically_integrated_water_vapor_tendency_due_to_analysis               |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQLDTANAINT    |  vertically_integrated_liquid_water_tendency_due_to_analysis              |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQIDTANAINT    |  vertically_integrated_ice_water_tendency_due_to_analysis                 |  kg m-2 s-1        |  xy   |  N   |                    |
+  DMDTDYN        |  vertically_integrated_mass_tendency_due_to_dynamics                      |  kg m-2 s-1        |  xy   |  N   |                    |
+  DOXDTDYNINT    |  vertically_integrated_ozone_tendency_due_to_dynamics                     |  kg m-2 s-1        |  xy   |  N   |                    |
+  DTHVDTDYNINT   |  vertically_integrated_THV_tendency_due_to_dynamics                       |  K kg m-2 s-1      |  xy   |  N   |                    |
+  DTHVDTREMAP    |  vertically_integrated_THV_tendency_due_to_vertical_remapping             |  K kg m-2 s-1      |  xy   |  N   |                    |
+  DTHVDTCONSV    |  vertically_integrated_THV_tendency_due_to_TE_conservation                |  K kg m-2 s-1      |  xy   |  N   |                    |
+  DTHVDTPHYINT   |  vertically_integrated_THV_tendency_due_to_physics                        |  K kg m-2 s-1      |  xy   |  N   |                    |
+  DTHVDTANAINT   |  vertically_integrated_THV_tendency_due_to_analysis                       |  K kg m-2 s-1      |  xy   |  N   |                    |
+  DQVDTDYNINT    |  vertically_integrated_water_vapor_tendency_due_to_dynamics               |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQLDTDYNINT    |  vertically_integrated_liquid_water_tendency_due_to_dynamics              |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQIDTDYNINT    |  vertically_integrated_ice_water_tendency_due_to_dynamics                 |  kg m-2 s-1        |  xy   |  N   |                    |
+  CONVKE         |  vertically_integrated_kinetic_energy_convergence                         |  W m-2             |  xy   |  N   |                    |
+  CONVTHV        |  vertically_integrated_thetav_convergence                                 |  W m-2             |  xy   |  N   |                    |
+  CONVCPT        |  vertically_integrated_enthalpy_convergence                               |  W m-2             |  xy   |  N   |                    |
+  CONVPHI        |  vertically_integrated_geopotential_convergence                           |  W m-2             |  xy   |  N   |                    |
+  U              |  eastward_wind                                                            |  m s-1             |  xyz  |  C   |  MAPL_VectorField  |
+  V              |  northward_wind                                                           |  m s-1             |  xyz  |  C   |  MAPL_VectorField  |
+  T              |  air_temperature                                                          |  K                 |  xyz  |  C   |                    |
+  PL             |  mid_level_pressure                                                       |  Pa                |  xyz  |  C   |                    |
+  ZLE0           |  edge_heights_above_surface                                               |  m                 |  xyz  |  E   |                    |
+  ZL0            |  mid_layer_heights_above_surface                                          |  m                 |  xyz  |  C   |                    |
+  ZLE            |  edge_heights                                                             |  m                 |  xyz  |  E   |                    |
+  ZL             |  mid_layer_heights                                                        |  m                 |  xyz  |  C   |                    |
+  S              |  mid_layer_dry_static_energy                                              |  m                 |  xyz  |  C   |                    |
+  PLE            |  edge_pressure                                                            |  Pa                |  xyz  |  E   |                    |
+  TH             |  potential_temperature                                                    |  K                 |  xyz  |  C   |                    |
+  PLK            |  mid-layer_p$^\kappa$                                                     |  Pa$^\kappa$       |  xyz  |  C   |                    |
+  PKE            |  edge_p$^\kappa$                                                          |  Pa$^\kappa$       |  xyz  |  E   |                    |
+  DELZ           |  nonhydrostatic_layer_thickness                                           |  m s-1             |  xyz  |  C   |                    |
+  W              |  vertical_velocity                                                        |  m s-1             |  xyz  |  C   |                    |
+  OMEGA          |  hydrostatic_vertical_pressure_velocity                                   |  Pa s-1            |  xyz  |  C   |                    |
+  CX             |  eastward_accumulated_courant_number                                      |  1                 |  xyz  |  C   |                    |  R8
+  CY             |  northward_accumulated_courant_number                                     |  1                 |  xyz  |  C   |                    |  R8
+  CU             |  eastward_accumulated_courant_number                                      |  1                 |  xyz  |  C   |                    |
+  CV             |  northward_accumulated_courant_number                                     |  1                 |  xyz  |  C   |                    |
+  MX             |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |
+  MY             |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |
+  MFX            |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |  R8
+  MFY            |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |  R8
+  MFZ            |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R8
+  MZ             |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R4
+  PV             |  ertels_isentropic_potential_vorticity                                    |  m+2 kg-1 s-1      |  xyz  |  C   |                    |
+  EPV            |  ertels_potential_vorticity                                               |  K m+2 kg-1 s-1    |  xyz  |  C   |                    |
+  Q              |  specific_humidity                                                        |  1                 |  xyz  |  C   |                    |
+  QC             |  specific_mass_of_condensate                                              |  1                 |  xyz  |  C   |                    |
+  DUDTSUBZ       |  tendency_of_eastward_wind_due_to_subgrid_dz                              |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+  DVDTSUBZ       |  tendency_of_northward_wind_due_to_subgrid_dz                             |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+  DTDTSUBZ       |  tendency_of_air_temperature_due_to_subgrid_dz                            |  K s-1             |  xyz  |  C   |                    |
+  DWDTSUBZ       |  tendency_of_vertical_velocity_due_to_subgrid_dz                          |  m/s/s             |  xyz  |  C   |                    |
+  DTDT_RAY       |  air_temperature_tendency_due_to_Rayleigh_friction                        |  K s-1             |  xyz  |  C   |                    |
+  DUDT_RAY       |  tendency_of_eastward_wind_due_to_Rayleigh_friction                       |  m s-2             |  xyz  |  C   |  MAPL_VectorField  |
+  DVDT_RAY       |  tendency_of_northward_wind_due_to_Rayleigh_friction                      |  m s-2             |  xyz  |  C   |  MAPL_VectorField  |
+  DWDT_RAY       |  vertical_velocity_tendency_due_to_Rayleigh_friction                      |  m/s/s             |  xyz  |  C   |                    |
+  DUDTANA        |  tendency_of_eastward_wind_due_to_analysis                                |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+  DVDTANA        |  tendency_of_northward_wind_due_to_analysis                               |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+  DTDTANA        |  tendency_of_air_temperature_due_to_analysis                              |  K s-1             |  xyz  |  C   |                    |
+  DDELPDTANA     |  tendency_of_pressure_thickness_due_to_analysis                           |  K s-1             |  xyz  |  C   |                    |
+  DUDTDYN        |  tendency_of_eastward_wind_due_to_dynamics                                |  m/s/s             |  xyz  |  C   |                    |
+  DVDTDYN        |  tendency_of_northward_wind_due_to_dynamics                               |  m/s/s             |  xyz  |  C   |                    |
+  DTDTDYN        |  tendency_of_air_temperature_due_to_dynamics                              |  K s-1             |  xyz  |  C   |                    |
+  DQVDTDYN       |  tendency_of_specific_humidity_due_to_dynamics                            |  kg/kg/s           |  xyz  |  C   |                    |
+  DQIDTDYN       |  tendency_of_ice_water_due_to_dynamics                                    |  kg/kg/s           |  xyz  |  C   |                    |
+  DQLDTDYN       |  tendency_of_liquid_water_due_to_dynamics                                 |  kg/kg/s           |  xyz  |  C   |                    |
+  DOXDTDYN       |  tendency_of_ozone_due_to_dynamics                                        |  mol mol-1 s-1     |  xyz  |  C   |                    |
+  PREF           |  reference_air_pressure                                                   |  Pa                |    z  |  E   |                    |
+  AK             |  hybrid_sigma_pressure_a                                                  |  1                 |    z  |  E   |                    |
+  BK             |  hybrid_sigma_pressure_b                                                  |  1                 |    z  |  E   |                    |
+  PHIS           |  surface_height                                                           |  m                 |  xy   |  N   |                    |
+  PS             |  surface_pressure                                                         |  Pa                |  xy   |  N   |                    |
+  TA             |  surface_air_temperature                                                  |  K                 |  xy   |  N   |                    |
+  QA             |  surface_specific_humidity                                                |  1                 |  xy   |  N   |                    |
+  US             |  surface_eastward_wind                                                    |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  VS             |  surface_northward_wind                                                   |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  SPEED          |  surface_wind_speed                                                       |  m s-1             |  xy   |  N   |                    |
+  WSPD_10M       |  wind_speed_at_10m                                                        |  m s-1             |  xy   |  N   |                    |
+  VVEL_UP_100_1000  | max_vertical_velocity_up_between_100_1000_hPa                          |  m s-1             |  xy   |  N   |                    |
+  VVEL_DN_100_1000  | max_vertical_velocity_down_between_100_1000_hPa                        |  m s-1             |  xy   |  N   |                    |
+  DZ             |  surface_layer_height                                                     |  m                 |  xy   |  N   |                    |
+  SLP            |  sea_level_pressure                                                       |  Pa                |  xy   |  N   |                    |
+  H1000          |  height_at_1000_mb                                                        |  m                 |  xy   |  N   |                    |
+  TROPP_EPV      |  tropopause_pressure_based_on_EPV_estimate                                |  Pa                |  xy   |  N   |                    |
+  TROPP_THERMAL  |  tropopause_pressure_based_on_thermal_estimate                            |  Pa                |  xy   |  N   |                    |
+  TROPP_BLENDED  |  tropopause_pressure_based_on_blended_estimate                            |  Pa                |  xy   |  N   |                    |
+  TROPK_BLENDED  |  tropopause_index_based_on_blended_estimate                               |  unitless          |  xy   |  N   |                    |
+  TROPT          |  tropopause_temperature_using_blended_TROPP_estimate                      |  K                 |  xy   |  N   |                    |
+  TROPQ          |  tropopause_specific_humidity_using_blended_TROPP_estimate                |  kg/kg             |  xy   |  N   |                    |
+  PLE0           |  pressure_at_layer_edges_before_dynamics                                  |  Pa                |  xyz  |  E   |                    |  R8
+  PLE1           |  pressure_at_layer_edges_after_dynamics                                   |  Pa                |  xyz  |  E   |                    |  R8
+  DELP           |  pressure_thickness                                                       |  Pa                |  xyz  |  C   |                    |
+  DELPTOP        |  pressure_thickness_at_model_top                                          |  Pa                |  xy   |  N   |                    |
+  U_AGRID        |  eastward_wind_on_A-Grid                                                  |  m s-1             |  xyz  |  C   |                    |
+  V_AGRID        |  northward_wind_on_A-Grid                                                 |  m s-1             |  xyz  |  C   |                    |
+  U_CGRID        |  eastward_wind_on_C-Grid                                                  |  m s-1             |  xyz  |  C   |                    |
+  V_CGRID        |  northward_wind_on_C-Grid                                                 |  m s-1             |  xyz  |  C   |                    |
+  U_DGRID        |  eastward_wind_on_native_D-Grid                                           |  m s-1             |  xyz  |  C   |                    |
+  V_DGRID        |  northward_wind_on_native_D-Grid                                          |  m s-1             |  xyz  |  C   |                    |
+  TV             |  air_virtual_temperature                                                  |  K                 |  xyz  |  C   |                    |
+  THV            |  scaled_virtual_potential_temperature                                     |  K/Pa$^\kappa$     |  xyz  |  C   |                    |
+  DPLEDTDYN      |  tendency_of_edge_pressure_due_to_dynamics                                |  Pa s-1            |  xyz  |  C   |                    |
+  DDELPDTDYN     |  tendency_of_pressure_thickness_due_to_dynamics                           |  Pa s-1            |  xyz  |  C   |                    |
+  UKE            |  eastward_flux_of_atmospheric_kinetic_energy                              |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  VKE            |  northward_flux_of_atmospheric_kinetic_energy                             |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  UCPT           |  eastward_flux_of_atmospheric_enthalpy                                    |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  VCPT           |  northward_flux_of_atmospheric_enthalpy                                   |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  UPHI           |  eastward_flux_of_atmospheric_potential_energy                            |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  VPHI           |  northward_flux_of_atmospheric_potential_energy                           |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  UQV            |  eastward_flux_of_atmospheric_water_vapor                                 |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  VQV            |  northward_flux_of_atmospheric_water_vapor                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  UQL            |  eastward_flux_of_atmospheric_liquid_water                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  VQL            |  northward_flux_of_atmospheric_liquid_water                               |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  UQI            |  eastward_flux_of_atmospheric_ice                                         |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  VQI            |  northward_flux_of_atmospheric_ice                                        |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  DKE            |  tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics            |  W m-2             |  xy   |  N   |                    |
+  DCPT           |  tendency_of_atmosphere_dry_energy_content_due_to_dynamics                |  W m-2             |  xy   |  N   |                    |
+  DPET           |  tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics      |  W m-2             |  xy   |  N   |                    |
+  WRKT           |  work_done_by_atmosphere_at_top                                           |  W m-2             |  xy   |  N   |                    |
+  DQV            |  tendency_of_atmosphere_water_vapor_content_due_to_dynamics               |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQL            |  tendency_of_atmosphere_liquid_water_content_due_to_dynamics              |  kg m-2 s-1        |  xy   |  N   |                    |
+  DQI            |  tendency_of_atmosphere_ice_content_due_to_dynamics                       |  kg m-2 s-1        |  xy   |  N   |                    |
+  CNV            |  generation_of_atmosphere_kinetic_energy_content                          |  W m-2             |  xy   |  N   |                    |
+  UH25           |  updraft_helicity_2_to_5_km                                               |  m+2 s-2           |  xy   |  N   |                    |
+  UH03           |  updraft_helicity_0_to_3_km                                               |  m+2 s-2           |  xy   |  N   |                    |
+  SRH01          |  storm_relative_helicity_0_to_1_km                                        |  m+2 s-2           |  xy   |  N   |                    |
+  SRH03          |  storm_relative_helicity_0_to_3_km                                        |  m+2 s-2           |  xy   |  N   |                    |
+  SRH25          |  storm_relative_helicity_2_to_5_km                                        |  m+2 s-2           |  xy   |  N   |                    |
+  VORT           |  vorticity_at_mid_layer_heights                                           |  s-1               |  xyz  |  C   |                    |
+  VORT850        |  vorticity_at_850_hPa                                                     |  s-1               |  xy   |  N   |                    |
+  VORT700        |  vorticity_at_700_hPa                                                     |  s-1               |  xy   |  N   |                    |
+  VORT500        |  vorticity_at_500_hPa                                                     |  s-1               |  xy   |  N   |                    |
+  VORT200        |  vorticity_at_200_hPa                                                     |  s-1               |  xy   |  N   |                    |
+  DIVG           |  divergence_at_mid_layer_heights                                          |  s-1               |  xyz  |  C   |                    |
+  DIVG850        |  divergence_at_850_hPa                                                    |  s-1               |  xy   |  N   |                    |
+  DIVG700        |  divergence_at_700_hPa                                                    |  s-1               |  xy   |  N   |                    |
+  DIVG500        |  divergence_at_500_hPa                                                    |  s-1               |  xy   |  N   |                    |
+  DIVG200        |  divergence_at_200_hPa                                                    |  s-1               |  xy   |  N   |                    |
+  U850           |  eastward_wind_at_850_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U700           |  eastward_wind_at_700_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U500           |  eastward_wind_at_500_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U300           |  eastward_wind_at_300_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U250           |  eastward_wind_at_250_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U200           |  eastward_wind_at_200_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U100           |  eastward_wind_at_100_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  UTOP           |  eastward_wind_at_model_top                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V850           |  northward_wind_at_850_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V700           |  northward_wind_at_700_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V500           |  northward_wind_at_500_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V300           |  northward_wind_at_300_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V250           |  northward_wind_at_250_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V200           |  northward_wind_at_200_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V100           |  northward_wind_at_100_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  VTOP           |  northward_wind_at_model_top                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T850           |  air_temperature_at_850_hPa                                               |  K                 |  xy   |  N   |                    |
+  T700           |  air_temperature_at_700_hPa                                               |  K                 |  xy   |  N   |                    |
+  T500           |  air_temperature_at_500_hPa                                               |  K                 |  xy   |  N   |                    |
+  T300           |  air_temperature_at_300_hPa                                               |  K                 |  xy   |  N   |                    |
+  T250           |  air_temperature_at_250_hPa                                               |  K                 |  xy   |  N   |                    |
+  T200           |  air_temperature_at_200_hPa                                               |  K                 |  xy   |  N   |                    |
+  T100           |  air_temperature_at_100_hPa                                               |  K                 |  xy   |  N   |                    |
+  TTOP           |  air_temperature_at_model_top                                             |  K                 |  xy   |  N   |                    |
+  Q850           |  specific_humidity_at_850_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Q700           |  specific_humidity_at_700_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Q500           |  specific_humidity_at_500_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Q300           |  specific_humidity_at_300_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Q250           |  specific_humidity_at_250_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Q200           |  specific_humidity_at_200_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Q100           |  specific_humidity_at_100_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  Z700           |  geopotential_height_at_700_hPa                                           |  m                 |  xy   |  N   |                    |
+  Z500           |  geopotential_height_at_500_hPa                                           |  m                 |  xy   |  N   |                    |
+  Z300           |  geopotential_height_at_300_hPa                                           |  m                 |  xy   |  N   |                    |
+  H850           |  height_at_850_hPa                                                        |  m                 |  xy   |  N   |                    |
+  H700           |  height_at_700_hPa                                                        |  m                 |  xy   |  N   |                    |
+  H500           |  height_at_500_hPa                                                        |  m                 |  xy   |  N   |                    |
+  H300           |  height_at_300_hPa                                                        |  m                 |  xy   |  N   |                    |
+  H250           |  height_at_250_hPa                                                        |  m                 |  xy   |  N   |                    |
+  H200           |  height_at_200_hPa                                                        |  m                 |  xy   |  N   |                    |
+  H100           |  height_at_100_hPa                                                        |  m                 |  xy   |  N   |                    |
+  OMEGA850       |  omega_at_850_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
+  OMEGA700       |  omega_at_700_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
+  OMEGA500       |  omega_at_500_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
+  OMEGA200       |  omega_at_200_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
+  OMEGA10        |  omega_at_10_hPa                                                          |  Pa s-1            |  xy   |  N   |                    |
+  W850           |  w_at_850_hPa                                                             |  m s-1             |  xy   |  N   |                    |
+  W500           |  w_at_500_hPa                                                             |  m s-1             |  xy   |  N   |                    |
+  W200           |  w_at_200_hPa                                                             |  m s-1             |  xy   |  N   |                    |
+  W10            |  w_at_10_hPa                                                              |  m s-1             |  xy   |  N   |                    |
+  U50M           |  eastward_wind_at_50_meters                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V50M           |  northward_wind_at_50_meters                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  DXC            |  cgrid_delta_x                                                            |  m                 |  xy   |  N   |                    |
+  DYC            |  cgrid_delta_y                                                            |  m                 |  xy   |  N   |                    |
+  AREA           |  agrid_cell_area                                                          |  m+2               |  xy   |  N   |                    |
+  PT             |  scaled_potential_temperature                                             |  K Pa$^{-\kappa}$  |  xyz  |  C   |                    |
+  PE             |  air_pressure                                                             |  Pa                |  xyz  |  E   |                    |
+  LONS           |  Center_longitudes                                                        |  radians           |  xy   |  N   |                    |
+  LATS           |  Center_latitudes                                                         |  radians           |  xy   |  N   |                    |
+  TIME_IN_DYN    |  timer_for_main_dynamics_run                                              |  seconds           |  xy   |  N   |                    |
+  PID            |  process_id                                                               |  1                 |  xy   |  N   |                    |
+  QV_DYN_IN      |  spec_humidity_at_begin_of_time_step                                      |  kg kg-1           |  xyz  |  C   |                    |
+  T_DYN_IN       |  temperature_at_begin_of_time_step                                        |  K                 |  xyz  |  C   |                    |
+  U_DYN_IN       |  u_wind_at_begin_of_time_step                                             |  m s-1             |  xyz  |  C   |                    |
+  V_DYN_IN       |  v_wind_at_begin_of_time_step                                             |  m s-1             |  xyz  |  C   |                    |
+  PLE_DYN_IN     |  edge_pressure_at_begin_of_time_step                                      |  Pa                |  xyz  |  E   |                    |
 
 
 category: IMPORT
 #------------------------------------------------------------------------------------------------------------------------------
- SHORT_NAME  |                      LONG_NAME                      |   UNITS    |  DIMS |     FIELD_TYPE     | VLOC |  RESTART
+ SHORT_NAME |  LONG_NAME                                          |   UNITS    |  DIMS |     FIELD_TYPE     | VLOC |  RESTART
 #------------------------------------------------------------------------------------------------------------------------------
-    DUDT     |               eastward_wind_tendency                |   m s-2    |  xyz  |  MAPL_VectorField  |  C   |
-    DVDT     |               northward_wind_tendency               |   m s-2    |  xyz  |  MAPL_VectorField  |  C   |
-    DWDT     |             vertical_velocity_tendency              |   m s-2    |  xyz  |  MAPL_VectorField  |  C   |
-    DTDT     |        delta-p_weighted_temperature_tendency        |  Pa K s-1  |  xyz  |                    |  C   |
-   DQVANA    |      specific_humidity_increment_from_analysis      |  kg kg-1   |  xyz  |                    |  C   |
-   DQLANA    |  specific_humidity_liquid_increment_from_analysis   |  kg kg-1   |  xyz  |                    |  C   |
-   DQIANA    |    specific_humidity_ice_increment_from_analysis    |  kg kg-1   |  xyz  |                    |  C   |
-   DQRANA    |   specific_humidity_rain_increment_from_analysis    |  kg kg-1   |  xyz  |                    |  C   |
-   DQSANA    |   specific_humidity_snow_increment_from_analysis    |  kg kg-1   |  xyz  |                    |  C   |
-   DQGANA    |  specific_humidity_graupel_increment_from_analysis  |  kg kg-1   |  xyz  |                    |  C   |
-   DOXANA    |            ozone_increment_from_analysis            |  kg kg-1   |  xyz  |                    |  C   |
-   DPEDT     |               edge_pressure_tendency                |   Pa s-1   |  xyz  |                    |  E   |
-    PHIS     |             surface_geopotential_height             |  m+2 s-2   |  xy   |                    |  N   |
-   VARFLT    |           variance_of_filtered_topography           |    m+2     |  xy   |                    |  N   |  MAPL_RestartSkip
+  DUDT      |  eastward_wind_tendency                             |  m s-2     |  xyz  |  MAPL_VectorField  |  C   |
+  DVDT      |  northward_wind_tendency                            |  m s-2     |  xyz  |  MAPL_VectorField  |  C   |
+  DWDT      |  vertical_velocity_tendency                         |  m s-2     |  xyz  |  MAPL_VectorField  |  C   |
+  DTDT      |  delta-p_weighted_temperature_tendency              |  Pa K s-1  |  xyz  |                    |  C   |
+  DQVANA    |  specific_humidity_increment_from_analysis          |  kg kg-1   |  xyz  |                    |  C   |
+  DQLANA    |  specific_humidity_liquid_increment_from_analysis   |  kg kg-1   |  xyz  |                    |  C   |
+  DQIANA    |  specific_humidity_ice_increment_from_analysis      |  kg kg-1   |  xyz  |                    |  C   |
+  DQRANA    |  specific_humidity_rain_increment_from_analysis     |  kg kg-1   |  xyz  |                    |  C   |
+  DQSANA    |  specific_humidity_snow_increment_from_analysis     |  kg kg-1   |  xyz  |                    |  C   |
+  DQGANA    |  specific_humidity_graupel_increment_from_analysis  |  kg kg-1   |  xyz  |                    |  C   |
+  DOXANA    |  ozone_increment_from_analysis                      |  kg kg-1   |  xyz  |                    |  C   |
+  DPEDT     |  edge_pressure_tendency                             |  Pa s-1    |  xyz  |                    |  E   |
+  PHIS      |  surface_geopotential_height                        |  m+2 s-2   |  xy   |                    |  N   |
+  VARFLT    |  variance_of_filtered_topography                    |  m+2       |  xy   |                    |  N   |  SKIP
 
 
 category: INTERNAL
-#---------------------------------------------------------------------------------------------------------------------
- SHORT_NAME  |           LONG_NAME            |       UNITS        | TYPEKIND |  DIMS |        RESTART         | VLOC
-#---------------------------------------------------------------------------------------------------------------------
-     AK      |    hybrid_sigma_pressure_a     |         Pa         |     R8   |    z  |  MAPL_RestartRequired  |  E
-     BK      |    hybrid_sigma_pressure_b     |         1          |     R8   |    z  |  MAPL_RestartRequired  |  E
-     U       |         eastward_wind          |       m s-1        |     R8   |  xyz  |  MAPL_RestartRequired  |  C
-     V       |         northward_wind         |       m s-1        |     R8   |  xyz  |  MAPL_RestartRequired  |  C
-     PT      |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |     R8   |  xyz  |  MAPL_RestartRequired  |  C
-     PE      |          air_pressure          |         Pa         |     R8   |  xyz  |  MAPL_RestartRequired  |  E
-    PKZ      |       pressure_to_kappa        |    Pa$^\kappa$     |     R8   |  xyz  |  MAPL_RestartRequired  |  C
-     DZ      |        height_thickness        |         m          |     R8   |  xyz  |                        |  C
-     W       |       vertical_velocity        |       m s-1        |     R8   |  xyz  |                        |  C
+#---------------------------------------------------------------------------------------------------------
+ SHORT_NAME |  LONG_NAME                     |  UNITS             |  TYPEKIND  |  DIMS |   RESTART  | VLOC
+#---------------------------------------------------------------------------------------------------------
+  AK        |  hybrid_sigma_pressure_a       |  Pa                |  R8        |    z  |  REQUIRED  |  E
+  BK        |  hybrid_sigma_pressure_b       |  1                 |  R8        |    z  |  REQUIRED  |  E
+  U         |  eastward_wind                 |  m s-1             |  R8        |  xyz  |  REQUIRED  |  C
+  V         |  northward_wind                |  m s-1             |  R8        |  xyz  |  REQUIRED  |  C
+  PT        |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |  R8        |  xyz  |  REQUIRED  |  C
+  PE        |  air_pressure                  |  Pa                |  R8        |  xyz  |  REQUIRED  |  E
+  PKZ       |  pressure_to_kappa             |  Pa$^\kappa$       |  R8        |  xyz  |  REQUIRED  |  C
+  DZ        |  height_thickness              |  m                 |  R8        |  xyz  |            |  C
+  W         |  vertical_velocity             |  m s-1             |  R8        |  xyz  |            |  C

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -1,31 +1,28 @@
 #include "MAPL_Generic.h"
 
 module FV_StateMod
-!BOP
-!
-! !MODULE: FV_StateMod --- GEOS5/CAM Cubed-Sphere fvcore state variables/init/run/finalize
-!
-! !USES:
+   !BOP
+   !MODULE: FV_StateMod --- GEOS5/CAM Cubed-Sphere fvcore state variables/init/run/finalize
+
+   !USES:
 #if defined( MAPL_MODE )
    use ESMF                ! ESMF base class
    use MAPL                ! MAPL base class
 #endif
+   use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
+   use MAPL_ConstantsMod, only: MAPL_KAPPA, MAPL_PI_R8, MAPL_ALHL, MAPL_PSDRY
+   use mapl3g_generic, only: MAPL_GridCompGetResource
 
-   use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS, &
-                                MAPL_KAPPA, MAPL_PI_R8, MAPL_ALHL, MAPL_PSDRY
-
-   use fv_mp_mod,         only: start_group_halo_update, complete_group_halo_update
-   use fv_mp_mod,         only: group_halo_update_type
+   use fv_mp_mod, only: start_group_halo_update, complete_group_halo_update, group_halo_update_type
 
    use fms_mod, only: fms_init, set_domain, nullify_domain
    use mpp_domains_mod, only: mpp_update_domains, CGRID_NE, DGRID_NE, mpp_get_boundary
    use mpp_parameter_mod, only: AGRID_PARAM=>AGRID, CORNER
-   use fv_timing_mod,    only: timing_on, timing_off, timing_init, timing_prt
+   use fv_timing_mod, only: timing_on, timing_off, timing_init, timing_prt
    use mpp_mod, only: mpp_pe, mpp_root_pe
-   use mpp_domains_mod,  only: domain2d
+   use mpp_domains_mod, only: domain2d
 
-   use fv_grid_utils_mod,  only: inner_prod, mid_pt_sphere, cubed_to_latlon, &
-                           ptop_min, g_sum
+   use fv_grid_utils_mod,  only: inner_prod, mid_pt_sphere, cubed_to_latlon, ptop_min, g_sum
    use fv_grid_tools_mod,  only: get_unit_vector
    use fv_control_mod, only: fv_init1, fv_init2
    use fv_arrays_mod , only: fv_atmos_type, FVPRC, REAL4, REAL8
@@ -35,229 +32,218 @@ module FV_StateMod
    use sw_core_mod, only: d2a2c_vect
    use fv_sg_mod, only: fv_subgrid_z
 
-   use fv_diagnostics_mod, only: prt_maxmin, prt_minmax, range_check, &
-                                 get_vorticity, updraft_helicity, bunkers_vector, helicity_relative_CAPS
+   use fv_diagnostics_mod, only: prt_maxmin, prt_minmax, range_check
+   use fv_diagnostics_mod, only: get_vorticity, updraft_helicity, bunkers_vector, helicity_relative_CAPS
 #ifdef RUN_GTFV3
    use ieee_exceptions, only: ieee_get_halting_mode, ieee_set_halting_mode, ieee_all
    use geos_gtfv3_interface_mod, only: geos_gtfv3_interface_f
    use geos_gtfv3_interface_mod, only: geos_gtfv3_interface_f_init, geos_gtfv3_interface_f_finalize
 #endif
 
-implicit none
-private
+   implicit none
+   private
 
 #include "mpif.h"
 
-  real(REAL8), save :: elapsed_time = 0
-  real(REAL8), save :: massD0
-  real(REAL8), save :: massADDED = 0.0
+   real(REAL8), save :: elapsed_time = 0
+   real(REAL8), save :: massD0
+   real(REAL8), save :: massADDED = 0.0
 
-  real(FVPRC), parameter :: tiny_number=1.e-15
-  real(FVPRC), parameter :: huge_number=1.e+15
+   real(FVPRC), parameter :: tiny_number=1.e-15
+   real(FVPRC), parameter :: huge_number=1.e+15
 
-! !PUBLIC DATA MEMBERS:
+   !PUBLIC DATA MEMBERS:
+   logical :: FV_OFF = .false.
+   integer :: INT_FV_OFF = 0
+   logical :: ADJUST_DT = .false.
+   logical :: DEBUG = .false.
+   logical :: DEBUG_DYN = .false.
+   logical :: DEBUG_ADV = .false.
+   logical :: COLDSTART = .false.
+   logical :: SW_DYNAMICS = .false.
+   integer :: INT_ADIABATIC = 0
+   logical :: ADIABATIC = .false.
+   logical :: FV_HYDROSTATIC = .true.
+   integer :: INT_check_mass = 0
+   logical :: check_mass = .false.
+   integer :: INT_fix_mass = 1
+   logical :: fix_mass = .true.
+   integer :: CASE_ID = 11
+   integer :: AdvCore_Advection = 0
+   integer :: FV3_QSPLIT = 0
+   character(:), allocatable :: FV3_CONFIG
 
-  logical :: FV_OFF = .false.
-  integer :: INT_FV_OFF = 0
-  logical :: ADJUST_DT = .false.
-  logical :: DEBUG = .false.
-  logical :: DEBUG_DYN = .false.
-  logical :: DEBUG_ADV = .false.
-  logical :: COLDSTART = .false.
-  logical :: SW_DYNAMICS = .false.
-  integer :: INT_ADIABATIC = 0
-  logical :: ADIABATIC = .false.
-  logical :: FV_HYDROSTATIC = .true.
-  integer :: INT_check_mass = 0
-  logical :: check_mass = .false.
-  integer :: INT_fix_mass = 1
-  logical :: fix_mass = .true.
-  integer :: CASE_ID = 11
-  integer :: AdvCore_Advection = 0
-  integer :: FV3_QSPLIT = 0
-  character(LEN=ESMF_MAXSTR) :: FV3_CONFIG
+   public FV_Atm
+   public FV_Setup, FV_InitState, FV_Run, FV_Finalize, FV_DA_Incs
+   public FV_HYDROSTATIC, ADIABATIC, DEBUG, DEBUG_DYN, DEBUG_ADV, COLDSTART, CASE_ID, SW_DYNAMICS, AdvCore_Advection
+   public FV_RESET_CONSTANTS
+   public FV_To_State, State_To_FV
+   public T_TRACERS, T_FVDYCORE_VARS, T_FVDYCORE_GRID, T_FVDYCORE_STATE
+   public fv_fillMassFluxes
+   public fv_computeMassFluxes
+   public fv_getVerticalMassFlux
+   public fv_getPK
+   public fv_getOmega
+   public fv_getVorticity
+   public fv_getDivergence
+   public fv_getUpdraftHelicity
+   public fv_getEPV
+   public fv_getDELZ
+   public fv_getPKZ
+   public fv_getQ
 
-  public FV_Atm
-  public FV_Setup, FV_InitState, FV_Run, FV_Finalize, FV_DA_Incs
-  public FV_HYDROSTATIC, ADIABATIC, DEBUG, DEBUG_DYN, DEBUG_ADV, COLDSTART, CASE_ID, SW_DYNAMICS, AdvCore_Advection
-  public FV_RESET_CONSTANTS
-  public FV_To_State, State_To_FV
-  public T_TRACERS, T_FVDYCORE_VARS, T_FVDYCORE_GRID, T_FVDYCORE_STATE
-  public fv_fillMassFluxes
-  public fv_computeMassFluxes
-  public fv_getVerticalMassFlux
-  public fv_getPK
-  public fv_getOmega
-  public fv_getVorticity
-  public fv_getDivergence
-  public fv_getUpdraftHelicity
-  public fv_getEPV
-  public fv_getDELZ
-  public fv_getPKZ
-  public fv_getQ
+   public debug_fv_state
 
-  public debug_fv_state
+   public fv_getAllWinds
+   public INTERP_AGRID_TO_DGRID
 
-  public fv_getAllWinds
-  public INTERP_AGRID_TO_DGRID
+   interface fv_computeMassFluxes
+      module procedure fv_computeMassFluxes_r4
+      module procedure fv_computeMassFluxes_r8
+   end interface fv_computeMassFluxes
 
-  interface fv_computeMassFluxes
-     module procedure fv_computeMassFluxes_r4
-     module procedure fv_computeMassFluxes_r8
-  end interface
+   interface fv_getAllWinds
+      module procedure fv_getAllWinds_3D_R4
+      module procedure fv_getAllWinds_3D
+      module procedure fv_getAllWinds_2D
+   end interface fv_getAllWinds
 
-  INTERFACE fv_getAllWinds
+   interface INTERP_AGRID_TO_DGRID
+      module procedure a2d3d    ! 2d to 3d
+      module procedure a2d2d    ! 2d to 2d
+   end interface INTERP_AGRID_TO_DGRID
 
-   MODULE PROCEDURE fv_getAllWinds_3D_R4
-   MODULE PROCEDURE fv_getAllWinds_3D
-   MODULE PROCEDURE fv_getAllWinds_2D
+   logical, save :: Init_FV_Domain = .true.
 
-  END INTERFACE
+   type(fv_atmos_type), allocatable, save :: FV_Atm(:)
+   logical, allocatable, save             :: grids_on_this_pe(:)
 
-  INTERFACE INTERP_AGRID_TO_DGRID
+   type T_TRACERS
+      logical :: is_r4
+      real(REAL8), dimension(:,:,:), pointer :: content
+      real(REAL4), dimension(:,:,:), pointer :: content_r4
+      character(LEN=ESMF_MAXSTR) :: tname
+   end type T_TRACERS
 
-   MODULE PROCEDURE a2d3d    ! 2d to 3d
-   MODULE PROCEDURE a2d2d    ! 2d to 2d
+   ! T_FVDYCORE_VARS contains the prognostic variables for FVdycore
+   type T_FVDYCORE_VARS
+      real(REAL8), dimension(:,:,:), pointer :: U      => NULL() ! U winds (D-grid)
+      real(REAL8), dimension(:,:,:), pointer :: V      => NULL() ! V winds (D-grid)
+      real(REAL8), dimension(:,:,:), pointer :: PT     => NULL() ! scaled virtual pot. temp.
+      real(REAL8), dimension(:,:,:), pointer :: PE     => NULL() ! Pressure at layer edges
+      real(REAL8), dimension(:,:,:), pointer :: PKZ    => NULL() ! P^kappa mean
+      real(REAL8), dimension(:,:,:), pointer :: DZ     => NULL() ! Height Thickness
+      real(REAL8), dimension(:,:,:), pointer :: W      => NULL() ! Vertical Velocity
+      type(T_TRACERS), dimension(:), pointer :: tracer => NULL() ! Tracers
+      integer :: nwat ! Number of water species
+   end type T_FVDYCORE_VARS
 
-  END INTERFACE
+   ! T_FVDYCORE_GRID contains information about the horizontal and vertical
+   ! discretization, unlike in ARIES where these data are split into HORZ_GRID
+   ! and VERT_GRID.  The reason for this: currently all of this information is
+   ! initialized in one call to FVCAM dynamics_init.
 
-  logical, save :: Init_FV_Domain = .true.
-
-  type(fv_atmos_type), allocatable, save :: FV_Atm(:)
-  logical, allocatable, save             :: grids_on_this_pe(:)
-
-  type T_TRACERS
-       logical                                   :: is_r4
-       real(REAL8), dimension(:,:,:  ), pointer     :: content
-       real(REAL4), dimension(:,:,:  ), pointer     :: content_r4
-       character(LEN=ESMF_MAXSTR)                          :: tname
-  end type T_TRACERS
-
-! T_FVDYCORE_VARS contains the prognostic variables for FVdycore
-  type T_FVDYCORE_VARS
-       real(REAL8), dimension(:,:,:  ), pointer     :: U      => NULL() ! U winds (D-grid)
-       real(REAL8), dimension(:,:,:  ), pointer     :: V      => NULL() ! V winds (D-grid)
-       real(REAL8), dimension(:,:,:  ), pointer     :: PT     => NULL() ! scaled virtual pot. temp.
-       real(REAL8), dimension(:,:,:  ), pointer     :: PE     => NULL() ! Pressure at layer edges
-       real(REAL8), dimension(:,:,:  ), pointer     :: PKZ    => NULL() ! P^kappa mean
-       real(REAL8), dimension(:,:,:  ), pointer     :: DZ     => NULL() ! Height Thickness
-       real(REAL8), dimension(:,:,:  ), pointer     :: W      => NULL() ! Vertical Velocity
-       type(T_TRACERS), dimension(:), pointer    :: tracer => NULL() ! Tracers
-       integer :: nwat ! Number of water species
-  end type T_FVDYCORE_VARS
-
-! T_FVDYCORE_GRID contains information about the horizontal and vertical
-! discretization, unlike in ARIES where these data are split into HORZ_GRID
-! and VERT_GRID.  The reason for this: currently all of this information is
-! initialized in one call to FVCAM dynamics_init.
-
-  type T_FVDYCORE_GRID
-!
+   type T_FVDYCORE_GRID
 #if defined( MAPL_MODE )
-    type (MAPL_MetaComp),   pointer :: FVgenstate
-    type (ESMF_Grid)                :: GRID           ! The 'horizontal' grid (2D decomp only)
+      type (MAPL_MetaComp),   pointer :: FVgenstate
+      type (ESMF_Grid)                :: GRID           ! The 'horizontal' grid (2D decomp only)
 #endif
 
-    integer                         :: NG               ! Ghosting
-!
-    integer                         :: IS               ! Start X-index (exclusive, unghosted)
-    integer                         :: IE               ! End X-index (exclusive, unghosted)
-    integer                         :: JS               ! Start Y-index (exclusive, unghosted)
-    integer                         :: JE               ! End Y-index (exclusive, unghosted)
-!
-    integer                         :: ISD              ! Start X-index (exclusive, ghosted)
-    integer                         :: IED              ! End X-index (exclusive, ghosted)
-    integer                         :: JSD              ! Start Y-index (exclusive, ghosted)
-    integer                         :: JED              ! End Y-index (exclusive, ghosted)
-!
-    integer                         :: NPX             ! Full X- dim
-    integer                         :: NPY             ! Full Y- dim
-    integer                         :: NPZ             ! Numer of levels
-    integer                         :: NPZ_P1          ! NPZ+1 (?)
+      integer                         :: NG               ! Ghosting
 
-    integer                         :: NTILES          ! How many log-rectangular tiles does my grid Have
-                                                       ! lat-lon      = 1
-                                                       ! cubed-sphere = 6
+      integer                         :: IS               ! Start X-index (exclusive, unghosted)
+      integer                         :: IE               ! End X-index (exclusive, unghosted)
+      integer                         :: JS               ! Start Y-index (exclusive, unghosted)
+      integer                         :: JE               ! End Y-index (exclusive, unghosted)
 
-    real(REAL8), allocatable           :: DXC(:,:)     ! local C-Grid DeltaX
-    real(REAL8), allocatable           :: DYC(:,:)     ! local C-Grid DeltaY
+      integer                         :: ISD              ! Start X-index (exclusive, ghosted)
+      integer                         :: IED              ! End X-index (exclusive, ghosted)
+      integer                         :: JSD              ! Start Y-index (exclusive, ghosted)
+      integer                         :: JED              ! End Y-index (exclusive, ghosted)
 
-    real(REAL8), allocatable           :: AREA(:,:)    ! local cell area
-    real(REAL8)                        :: GLOBALAREA   ! global area
+      integer                         :: NPX             ! Full X- dim
+      integer                         :: NPY             ! Full Y- dim
+      integer                         :: NPZ             ! Numer of levels
+      integer                         :: NPZ_P1          ! NPZ+1 (?)
 
-    integer                         :: KS              ! Number of true pressure levels (out of NPZ+1)
-    real(REAL8)                        :: PTOP            ! pressure at top (ak(1))
-    real(REAL8)                        :: PINT            ! initial pressure (ak(npz+1))
-    real(REAL8), dimension(:), pointer :: AK => NULL()    ! Sigma mapping
-    real(REAL8), dimension(:), pointer :: BK => NULL()    ! Sigma mapping
-    real(REAL8)                        :: f_coriolis_angle = 0
-!
-! Tracers
-!
-    integer                         :: NQ              ! Number of advected tracers
-  end type T_FVDYCORE_GRID
+      integer                         :: NTILES          ! log-rectangular tiles in grid: 1 for lat/lon, 6 for cubed-sphere
 
-  integer, parameter :: NUM_FVDYCORE_ALARMS        = 3
-  integer, parameter :: NUM_TIMES      = 8
-  integer, parameter :: TIME_TO_RUN  = 1
+      real(REAL8), allocatable           :: DXC(:,:)     ! local C-Grid DeltaX
+      real(REAL8), allocatable           :: DYC(:,:)     ! local C-Grid DeltaY
 
-  type T_FVDYCORE_STATE
+      real(REAL8), allocatable           :: AREA(:,:)    ! local cell area
+      real(REAL8)                        :: GLOBALAREA   ! global area
+
+      integer                         :: KS              ! Number of true pressure levels (out of NPZ+1)
+      real(REAL8)                        :: PTOP            ! pressure at top (ak(1))
+      real(REAL8)                        :: PINT            ! initial pressure (ak(npz+1))
+      real(REAL8), dimension(:), pointer :: AK => NULL()    ! Sigma mapping
+      real(REAL8), dimension(:), pointer :: BK => NULL()    ! Sigma mapping
+      real(REAL8)                        :: f_coriolis_angle = 0
+      !
+      ! Tracers
+      !
+      integer                         :: NQ              ! Number of advected tracers
+   end type T_FVDYCORE_GRID
+
+   integer, parameter :: NUM_FVDYCORE_ALARMS        = 3
+   integer, parameter :: NUM_TIMES      = 8
+   integer, parameter :: TIME_TO_RUN  = 1
+
+   type T_FVDYCORE_STATE
 !!!    private
-    type (T_FVDYCORE_VARS)               :: VARS
-    type (T_FVDYCORE_GRID )              :: GRID
+      type (T_FVDYCORE_VARS)               :: VARS
+      type (T_FVDYCORE_GRID )              :: GRID
 #if defined( MAPL_MODE )
-    type (ESMF_Clock), pointer           :: CLOCK
-    type (ESMF_Alarm)                    :: ALARMS(NUM_FVDYCORE_ALARMS)
-
+      type (ESMF_Clock), pointer           :: CLOCK
+      type (ESMF_Alarm)                    :: ALARMS(NUM_FVDYCORE_ALARMS)
 #endif
-    integer(kind=8)                      :: RUN_TIMES(4,NUM_TIMES)
-    logical                              :: DOTIME, DODYN
-    real(REAL8)                          :: DT          ! Large time step
-    integer                              :: KSPLIT
-    integer                              :: NSPLIT
-    integer                              :: NUM_CALLS
-  end type T_FVDYCORE_STATE
+      integer(kind=8)                      :: RUN_TIMES(4,NUM_TIMES)
+      logical                              :: DOTIME, DODYN
+      real(REAL8)                          :: DT          ! Large time step
+      integer                              :: KSPLIT
+      integer                              :: NSPLIT
+      integer                              :: NUM_CALLS
+   end type T_FVDYCORE_STATE
 
-! Constants used by fvcore
-    real(REAL8)                             :: pi
-    real(REAL8)                             :: omega    ! angular velocity of earth's rotation
-    real(FVPRC)                             :: cp       ! heat capacity of air at constant pressure
-    real(REAL8)                             :: radius   ! radius of the earth (m)
-    real(REAL8)                             :: rgas     ! Gas constant of the air
-    real(REAL8)                             :: rvap     ! Gas constant of vapor
-    real(FVPRC)                             :: kappa    ! kappa
-    real(REAL8)                             :: grav     ! Gravity
-    real(REAL8)                             :: hlv      ! latent heat of evaporation
-    real(FVPRC)                             :: zvir     ! RWV/RAIR-1
+   ! Constants used by fvcore
+   real(REAL8)                             :: pi
+   real(REAL8)                             :: omega    ! angular velocity of earth's rotation
+   real(FVPRC)                             :: cp       ! heat capacity of air at constant pressure
+   real(REAL8)                             :: radius   ! radius of the earth (m)
+   real(REAL8)                             :: rgas     ! Gas constant of the air
+   real(REAL8)                             :: rvap     ! Gas constant of vapor
+   real(FVPRC)                             :: kappa    ! kappa
+   real(REAL8)                             :: grav     ! Gravity
+   real(REAL8)                             :: hlv      ! latent heat of evaporation
+   real(FVPRC)                             :: zvir     ! RWV/RAIR-1
 
-  real(kind=4), pointer :: phis(:,:), varflt(:,:)
+   real(kind=4), pointer :: phis(:,:), varflt(:,:)
 
-  logical :: fv_first_run = .true.
+   logical :: fv_first_run = .true.
 
-  integer :: ntracers=11
+   integer :: ntracers=11
 
-  type (ESMF_Alarm)                    :: MASSALARM
-  type (ESMF_TimeInterval)             :: MassAlarmInt
-  logical :: first_mass_fix = .true.
+   type (ESMF_Alarm)                    :: MASSALARM
+   type (ESMF_TimeInterval)             :: MassAlarmInt
+   logical :: first_mass_fix = .true.
 
-!
-! !DESCRIPTION:
-!
-!      This module provides variables which are specific to the Lin-Rood
-!      dynamical core.  Most of them were previously SAVE variables in
-!      different routines and were set with an "if (first)" statement.
-!
-!      \begin{tabular}{|l|l|} \hline \hline
-!        lr\_init    &  Initialize the Lin-Rood variables  \\ \hline
-!        lr\_clean   &  Deallocate all internal data structures \\ \hline
-!                                \hline
-!      \end{tabular}
-!
-! !REVISION HISTORY:
-!   2007.07.17   Putman     Created from lat-lon core
-!
-!EOP
-!-----------------------------------------------------------------------
+   !DESCRIPTION:
+   !      This module provides variables which are specific to the Lin-Rood
+   !      dynamical core.  Most of them were previously SAVE variables in
+   !      different routines and were set with an "if (first)" statement.
+   !
+   !      \begin{tabular}{|l|l|} \hline \hline
+   !        lr\_init    &  Initialize the Lin-Rood variables  \\ \hline
+   !        lr\_clean   &  Deallocate all internal data structures \\ \hline
+   !                                \hline
+   !      \end{tabular}
+
+   !REVISION HISTORY:
+   !   2007.07.17   Putman     Created from lat-lon core
+
+   !EOP
+
    real(REAL8), parameter ::  D0_0                    =   0.0
    real(REAL8), parameter ::  D0_5                    =   0.5
    real(REAL8), parameter ::  D1_0                    =   1.0
@@ -272,126 +258,98 @@ private
 
 contains
 
-!-----------------------------------------------------------------------
-!
-! !INTERFACE:
- subroutine FV_RESET_CONSTANTS(FV_PI, FV_OMEGA, FV_CP, FV_RADIUS, FV_RGAS, &
-                               FV_RVAP, FV_KAPPA, FV_GRAV, FV_HLV, FV_ZVIR)
-   real (REAL8), optional, intent(IN) :: FV_PI
-   real (REAL8), optional, intent(IN) :: FV_OMEGA
-   real (REAL8), optional, intent(IN) :: FV_CP
-   real (REAL8), optional, intent(IN) :: FV_RADIUS
-   real (REAL8), optional, intent(IN) :: FV_RGAS
-   real (REAL8), optional, intent(IN) :: FV_RVAP
-   real (REAL8), optional, intent(IN) :: FV_KAPPA
-   real (REAL8), optional, intent(IN) :: FV_GRAV
-   real (REAL8), optional, intent(IN) :: FV_HLV
-   real (REAL8), optional, intent(IN) :: FV_ZVIR
+   !INTERFACE:
+   subroutine FV_RESET_CONSTANTS( &
+        FV_PI, FV_OMEGA, FV_CP, FV_RADIUS, FV_RGAS, &
+        FV_RVAP, FV_KAPPA, FV_GRAV, FV_HLV, FV_ZVIR)
+      real (REAL8), optional, intent(IN) :: FV_PI
+      real (REAL8), optional, intent(IN) :: FV_OMEGA
+      real (REAL8), optional, intent(IN) :: FV_CP
+      real (REAL8), optional, intent(IN) :: FV_RADIUS
+      real (REAL8), optional, intent(IN) :: FV_RGAS
+      real (REAL8), optional, intent(IN) :: FV_RVAP
+      real (REAL8), optional, intent(IN) :: FV_KAPPA
+      real (REAL8), optional, intent(IN) :: FV_GRAV
+      real (REAL8), optional, intent(IN) :: FV_HLV
+      real (REAL8), optional, intent(IN) :: FV_ZVIR
 
-   if (present(FV_PI)) then
-      pi = FV_PI
-   endif
-   if (present(FV_OMEGA)) then
-      omega = FV_OMEGA
-   endif
-   if (present(FV_CP)) then
-      cp = FV_CP
-   endif
-   if (present(FV_RADIUS)) then
-      radius = FV_RADIUS
-   endif
-   if (present(FV_RGAS)) then
-      rgas = FV_RGAS
-   endif
-   if (present(FV_RVAP)) then
-      rvap = FV_RVAP
-   endif
-   if (present(FV_KAPPA)) then
-      kappa = FV_KAPPA
-   endif
-   if (present(FV_GRAV)) then
-      grav   = FV_GRAV
-   endif
-   if (present(FV_HLV)) then
-      hlv = FV_HLV
-   endif
-   if (present(FV_ZVIR)) then
-      zvir = FV_ZVIR
-   endif
+      if (present(FV_PI)) then
+         pi = FV_PI
+      endif
+      if (present(FV_OMEGA)) then
+         omega = FV_OMEGA
+      endif
+      if (present(FV_CP)) then
+         cp = FV_CP
+      endif
+      if (present(FV_RADIUS)) then
+         radius = FV_RADIUS
+      endif
+      if (present(FV_RGAS)) then
+         rgas = FV_RGAS
+      endif
+      if (present(FV_RVAP)) then
+         rvap = FV_RVAP
+      endif
+      if (present(FV_KAPPA)) then
+         kappa = FV_KAPPA
+      endif
+      if (present(FV_GRAV)) then
+         grav   = FV_GRAV
+      endif
+      if (present(FV_HLV)) then
+         hlv = FV_HLV
+      endif
+      if (present(FV_ZVIR)) then
+         zvir = FV_ZVIR
+      endif
+   end subroutine FV_RESET_CONSTANTS
 
- end subroutine FV_RESET_CONSTANTS
-!
-!-----------------------------------------------------------------------
- subroutine FV_Setup(GC,LAYOUT_FILE, RC)
+   subroutine FV_Setup(gc, layout_file, rc)
+      use test_cases_mod, only : test_case
+      type(ESMF_GridComp), intent(inout) :: gc
+      character(len=*), intent(in) :: layout_file
+      integer, optional, intent(OUT) :: rc
 
-  use test_cases_mod, only : test_case
+      ! Local
+      type(ESMF_VM) :: vm
+      character(len=ESMF_MAXSTR) :: Iam='FV_StateMod::FV_Setup'
+      character(len=:), allocatable :: DYCORE
 
-  type (ESMF_GridComp)         , intent(INOUT) :: GC
-  character(LEN=*)             , intent(IN   ) :: LAYOUT_FILE
-  integer, optional            , intent(OUT  ) :: RC
-! Local
-   character(len=ESMF_MAXSTR)       :: IAm='FV_StateMod:FV_Setup'
-! Local variables
-   character(len=ESMF_MAXSTR)       :: DYCORE
+      real(FVPRC) :: DT
+      real :: temp_real
+      integer :: comm, ndt, nx, ny, status, p_split=1
 
-  type (ESMF_Config)           :: cf
-  type (ESMF_VM)               :: VM
-  integer              :: status
-  real(FVPRC) :: DT
+      call ESMF_VMGetCurrent(vm, _RC)
+      call MAPL_MemUtilsWrite(vm, trim(Iam), _RC)
 
-  integer   :: ndt,nx,ny
+      ! ! Retrieve the pointer to the state
+      ! call MAPL_GetObjectFromGC(gc, MAPL, _RC)
 
-  type (MAPL_MetaComp),          pointer :: MAPL  => NULL()
+      ! call MAPL_TimerOn(MAPL,"--FMS_INIT")
+      call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+      call fms_init(comm)
+      ! call MAPL_TimerOff(MAPL, "--FMS_INIT")
+      call MAPL_MemUtilsWrite(vm, 'FV_StateMod::fms_init', _RC)
 
-  integer :: comm
-  integer :: p_split=1
+      ! Start up FV
+      ! call MAPL_TimerOn(MAPL,"--FV_INIT")
+      call fv_init1(FV_Atm, DT, grids_on_this_pe, p_split)
+      ! call MAPL_TimerOff(MAPL,"--FV_INIT")
+      call MAPL_MemUtilsWrite(vm, 'FV_StateMod::fv_init1', _RC)
 
-  real :: temp_real
-
-! BEGIN
-
-  call ESMF_VMGetCurrent(VM, rc=STATUS)
-  VERIFY_(STATUS)
-
-    call MAPL_MemUtilsWrite(VM, trim(IAm), RC=STATUS )
-    VERIFY_(STATUS)
-
-! Retrieve the pointer to the state
-! ---------------------------------
-
-  call MAPL_GetObjectFromGC (GC, MAPL,  RC=STATUS )
-  VERIFY_(STATUS)
-
-    call MAPL_TimerOn(MAPL,"--FMS_INIT")
-    call ESMF_VMGet(VM,mpiCommunicator=comm,rc=status)
-    VERIFY_(STATUS)
-    call fms_init(comm)
-    call MAPL_TimerOff(MAPL,"--FMS_INIT")
-    call MAPL_MemUtilsWrite(VM, 'FV_StateMod: FMS_INIT', RC=STATUS )
-    VERIFY_(STATUS)
-! Start up FV
-    call MAPL_TimerOn(MAPL,"--FV_INIT")
-    call fv_init1(FV_Atm, DT, grids_on_this_pe, p_split)
-    call MAPL_TimerOff(MAPL,"--FV_INIT")
-    call MAPL_MemUtilsWrite(VM, 'FV_StateMod: FV_INIT', RC=STATUS )
-    VERIFY_(STATUS)
-
-! FV grid dimensions setup from MAPL
-      call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%npx, 'AGCM_IM:', default= 32, RC=STATUS )
-      VERIFY_(STATUS)
-      call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%npy, 'AGCM_JM:', default=192, RC=STATUS )
-      VERIFY_(STATUS)
-      call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%npz, 'AGCM_LM:', default= 72, RC=STATUS )
-      VERIFY_(STATUS)
+      ! FV grid dimensions setup from MAPL
+      call MAPL_GridCompGetResource(gc, "AGCM_IM", FV_Atm(1)%flagstruct%npx, default= 32, _RC)
+      call MAPL_GridCompGetResource(gc, "AGCM_JM", FV_Atm(1)%flagstruct%npy, default=192, _RC)
+      call MAPL_GridCompGetResource(gc, "AGCM_LM", FV_Atm(1)%flagstruct%npz, default= 72, _RC)
       if (FV_Atm(1)%flagstruct%npz == 1) SW_DYNAMICS = .true.
       ! stretch_fac is kind(R_GRID) in FV, so to prevent a MAPL failure on RC check, we pull
       ! AGCM.STRETCH_FACTOR: as a REAL32 and then cast it to REAL64. This is because
       ! FV_Atm(1)%flagstruct%stretch_fac is R_GRID => REAL64, and the MAPL_GetResource call
       ! is getting a REAL32
-      call MAPL_GetResource( MAPL, temp_real, 'AGCM.STRETCH_FACTOR:', default=1.0, RC=STATUS )
-      VERIFY_(STATUS)
+      call MAPL_GridCompGetResource(gc, "AGCM.STRETCH_FACTOR", temp_real, default=1.0, _RC)
       FV_Atm(1)%flagstruct%stretch_fac = temp_real
-! FV likes npx;npy in terms of cell vertices
+      ! FV likes npx;npy in terms of cell vertices
       if (FV_Atm(1)%flagstruct%npy == 6*FV_Atm(1)%flagstruct%npx) then
          FV_Atm(1)%flagstruct%ntiles = 6
          FV_Atm(1)%flagstruct%npy    = FV_Atm(1)%flagstruct%npx+1
@@ -401,386 +359,357 @@ contains
          FV_Atm(1)%flagstruct%npy    = FV_Atm(1)%flagstruct%npy+1
          FV_Atm(1)%flagstruct%npx    = FV_Atm(1)%flagstruct%npx+1
       endif
-! Check for Doubly Periodic Domain Info
-      call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%deglat, label='FIXED_LATS:', default=FV_Atm(1)%flagstruct%deglat, rc=status )
-      VERIFY_(STATUS)
-! MPI decomp setup
-      call MAPL_GetResource( MAPL, nx, 'NX:', default=0, RC=STATUS )
-      VERIFY_(STATUS)
+      ! Check for Doubly Periodic Domain Info
+      call MAPL_GridCompGetResource(gc, "FIXED_LATS", FV_Atm(1)%flagstruct%deglat, default=FV_Atm(1)%flagstruct%deglat, _RC)
+      ! MPI decomp setup
+      call MAPL_GridCompGetResource(gc, "NX", nx, default=0, _RC)
       FV_Atm(1)%layout(1) = nx
-      call MAPL_GetResource( MAPL, ny, 'NY:', default=0, RC=STATUS )
-      VERIFY_(STATUS)
+      call MAPL_GridCompGetResource(gc, "NY", ny, default=0, _RC)
       if (FV_Atm(1)%flagstruct%grid_type == 4) then
          FV_Atm(1)%layout(2) = ny
       else
          FV_Atm(1)%layout(2) = ny / 6
       end if
 
-! Get other scalars
-! -----------------
+      ! Get other scalars
+      call MAPL_GridCompGetResource(gc, "RUN_DT", ndt, default=0, _RC)
+      DT = ndt
+      call MAPL_GridCompGetResource(gc, "DYCORE", DYCORE, default="", _RC)
 
-  call MAPL_GetResource( MAPL, ndt, 'RUN_DT:', default=0, RC=STATUS )
-  VERIFY_(STATUS)
-  DT = ndt
+      if(adjustl(DYCORE)=="FV3") then
+         AdvCore_Advection = 0
+      endif
+      if(adjustl(DYCORE)=="FV3+ADV") then
+         AdvCore_Advection = 1
+      endif
 
-  call MAPL_GetResource(MAPL, DYCORE, 'DYCORE:', default="", RC=STATUS )
-  VERIFY_(STATUS)
+      ! Advect tracers within DynCore(AdvCore_Advection=.false.)
+      !             or within AdvCore(AdvCore_Advection=.true.)
+      call MAPL_GridCompGetResource(gc, "AdvCore_Advection", AdvCore_Advection, default=AdvCore_Advection, _RC)
 
-  if(adjustl(DYCORE)=="FV3") then
-       AdvCore_Advection = 0
-  endif
-  if(adjustl(DYCORE)=="FV3+ADV") then
-       AdvCore_Advection = 1
-  endif
+      call MAPL_GridCompGetResource(gc, "FV3_QSPLIT", FV3_QSPLIT, default=FV3_QSPLIT, _RC)
+      call MAPL_GridCompGetResource(gc, "ADJUST_DT", ADJUST_DT, default=ADJUST_DT, _RC)
+      call MAPL_GridCompGetResource(gc, "fix_mass", INT_fix_mass, default=INT_fix_mass, _RC)
+      call MAPL_GridCompGetResource(gc, "check_mass", INT_check_mass, default=INT_check_mass, _RC)
+      call MAPL_GridCompGetResource(gc, "ADIABATIC", INT_ADIABATIC, default=INT_adiabatic, _RC)
+      call MAPL_GridCompGetResource(gc, "FV_OFF", INT_FV_OFF, default=INT_FV_OFF, _RC)
 
-! Advect tracers within DynCore(AdvCore_Advection=.false.)
-!             or within AdvCore(AdvCore_Advection=.true.)
-  call MAPL_GetResource( MAPL, AdvCore_Advection, label='AdvCore_Advection:', default=AdvCore_Advection, rc=status )
-  VERIFY_(STATUS)
-
-  call MAPL_GetResource( MAPL, FV3_QSPLIT, label='FV3_QSPLIT:', default=FV3_QSPLIT, rc=status )
-  VERIFY_(STATUS)
-  call MAPL_GetResource( MAPL, ADJUST_DT,       label='ADJUST_DT:'   , default=ADJUST_DT, rc=status )
-  VERIFY_(STATUS)
-  call MAPL_GetResource( MAPL, INT_fix_mass,    label='fix_mass:'    , default=INT_fix_mass, rc=status )
-  VERIFY_(STATUS)
-  call MAPL_GetResource( MAPL, INT_check_mass,  label='check_mass:'  , default=INT_check_mass, rc=status )
-  VERIFY_(STATUS)
-  call MAPL_GetResource( MAPL, INT_ADIABATIC,   label='ADIABATIC:'   , default=INT_adiabatic, rc=status )
-  VERIFY_(STATUS)
-  call MAPL_GetResource( MAPL, INT_FV_OFF,      label='FV_OFF:'      , default=INT_FV_OFF, rc=status )
-  VERIFY_(STATUS)
-
-  ! MAT The Fortran Standard, and thus gfortran, *does not allow* the use
-  !     of if (integer). So, we must convert integer resources to logicals
-
-  if (INT_fix_mass == 0) then
-     fix_mass = .FALSE.
-  else
-     fix_mass = .TRUE.
-  end if
-
-  if (INT_check_mass == 0) then
-     check_mass = .FALSE.
-  else
-     check_mass = .TRUE.
-  end if
-
-  if (INT_ADIABATIC == 0) then
-     ADIABATIC = .FALSE.
-  else
-     ADIABATIC = .TRUE.
-  end if
-
-  if (INT_FV_OFF == 0) then
-     FV_OFF = .FALSE.
-  else
-     FV_OFF = .TRUE.
-  end if
-
-! Constants
-!
-    pi     = MAPL_PI_R8
-    omega  = MAPL_OMEGA    ! angular velocity of earth's rotation
-    cp     = MAPL_CP       ! heat capacity of air at constant pressure
-    radius = MAPL_RADIUS   ! radius of the earth (m)
-    rgas   = MAPL_RGAS     ! Gas constant of the air
-    rvap   = MAPL_RVAP     ! Gas constant of vapor
-    kappa  = MAPL_KAPPA    ! kappa
-    grav   = MAPL_GRAV     ! Gravity
-    hlv    = MAPL_ALHL     ! latent heat of evaporation
-    zvir   = MAPL_RVAP/MAPL_RGAS - 1.   ! RWV/RAIR-1
-
-   ! option to enable different configurations for FV3
-    call MAPL_GetResource( MAPL, FV3_CONFIG, label='FV3_CONFIG:', default='STOCK', rc=status )
-    VERIFY_(STATUS)
-
-!
-! Create some resolution dependent defaults for FV3 in GEOS...
-!    These can be overrided in fv_core_nml in fvcore_layout.rc linked to input.nml
-!-------------------------------------------------------------
-  ! Number of water species for FV3 determined later
-  ! when reading the tracer bundle in fv_first_run
-   FV_Atm(1)%flagstruct%nwat = 0
-  ! Trigger to enable autoconversion/cloud processes on the fv_mapz step
-   FV_Atm(1)%flagstruct%do_sat_adj = .false. ! only valid when nwat >= 6
-  ! Veritical resolution dependencies
-   FV_Atm(1)%flagstruct%external_eta = .true.
-   if (FV_Atm(1)%flagstruct%npz >= 70) then
-     FV_Atm(1)%flagstruct%n_zfilter = 17 ! ~5mb
-   endif
-   if (FV_Atm(1)%flagstruct%npz >= 72) then
-     FV_Atm(1)%flagstruct%n_zfilter = 21 ! ~5mb
-   endif
-   if (FV_Atm(1)%flagstruct%npz >= 90) then
-     FV_Atm(1)%flagstruct%n_zfilter = 17 ! ~5mb
-   endif
-   if (FV_Atm(1)%flagstruct%npz >= 126) then
-     FV_Atm(1)%flagstruct%n_zfilter = 19 ! ~5mb
-   endif
-   if (FV_Atm(1)%flagstruct%npz >= 132) then
-     FV_Atm(1)%flagstruct%n_zfilter = 23 ! ~5mb
-   endif
-   if (FV_Atm(1)%flagstruct%npz >= 136) then
-     FV_Atm(1)%flagstruct%n_zfilter = 23 ! ~5mb
-   endif
-   if (FV_Atm(1)%flagstruct%npz >= 180) then
-     FV_Atm(1)%flagstruct%n_zfilter = 32 ! ~5mb
-   endif
-  ! Vertical remap options
-   FV_Atm(1)%flagstruct%remap_option = 0 ! Remap T in LogP
-   FV_Atm(1)%flagstruct%gmao_remap = 0   ! (0 for GFDL Schemes) (3 for GMAO Cubic)
-   FV_Atm(1)%flagstruct%gmao_top_bc = .true.
-   FV_Atm(1)%flagstruct%gmao_bot_bc = .true.
-   FV_Atm(1)%flagstruct%kord_tm =  9
-   FV_Atm(1)%flagstruct%kord_mt =  9
-   FV_Atm(1)%flagstruct%kord_wz =  9
-   FV_Atm(1)%flagstruct%kord_tr =  9
-  ! Some default horizontal flags
-   FV_Atm(1)%flagstruct%z_tracer = .true.
-   FV_Atm(1)%flagstruct%adjust_dry_mass = fix_mass
-   FV_Atm(1)%flagstruct%consv_am = .false.
-   FV_Atm(1)%flagstruct%fill = .true.
-   FV_Atm(1)%flagstruct%dwind_2d = .false.
-   FV_Atm(1)%flagstruct%delt_max = 0.002
-   FV_Atm(1)%flagstruct%ke_bg = 0.0
-  ! Some default time-splitting options
-   FV_Atm(1)%flagstruct%k_split = 1
-   FV_Atm(1)%flagstruct%n_split = 0
-  ! Cubed-Sphere Global Resolution Specific adjustments
-   FV_Atm(1)%flagstruct%compute_coords_locally = .TRUE.
-   FV_Atm(1)%flagstruct%hydrostatic = .true.
-   ! Rayleigh Damping
-   FV_Atm(1)%flagstruct%rf_cutoff = 0.50e2
-   FV_Atm(1)%flagstruct%tau = 5.0
-   FV_Atm(1)%flagstruct%RF_fast = .false.
-   if (FV_Atm(1)%flagstruct%ntiles == 6) then
-     ! Cubed-sphere grid resolution and DT dependence
-     !              based on ideal remapping DT
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 12) then
-         FV_Atm(1)%flagstruct%hydrostatic = .true.
-         FV_Atm(1)%flagstruct%k_split = CEILING(DT/3600.0  )
-         FV_Atm(1)%flagstruct%tau = 5.0
-         FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 24) then
-         FV_Atm(1)%flagstruct%hydrostatic = .true.
-         FV_Atm(1)%flagstruct%k_split = CEILING(DT/1800.0  )
-         FV_Atm(1)%flagstruct%tau = 5.0
-         FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 48) then
-         FV_Atm(1)%flagstruct%hydrostatic = .true.
-         FV_Atm(1)%flagstruct%k_split = CEILING(DT/1200.0  )
-         FV_Atm(1)%flagstruct%tau = 5.0
-         FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 90) then
-         FV_Atm(1)%flagstruct%hydrostatic = .true.
-         FV_Atm(1)%flagstruct%k_split = CEILING(DT/ 600.0   )
-         FV_Atm(1)%flagstruct%tau = 5.0
-         FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 180) then
-         FV_Atm(1)%flagstruct%hydrostatic = .true.
-         FV_Atm(1)%flagstruct%k_split = CEILING(DT/ 300.0   )
-         FV_Atm(1)%flagstruct%tau = 5.0
-         FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 360) then
-         FV_Atm(1)%flagstruct%hydrostatic = .false.
-         FV_Atm(1)%flagstruct%k_split = CEILING(DT/ 150.0   )
-         FV_Atm(1)%flagstruct%tau = 4.0
-         FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 720) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/  75.0 )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/ 120.0 )
-          FV_Atm(1)%flagstruct%tau = 3.0
-          FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 1120) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/  60.0 )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/  90.0 )
-          FV_Atm(1)%flagstruct%tau = 2.5
-          FV_Atm(1)%flagstruct%RF_fast = .false.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 1440) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/  37.5 )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/  60.0 )
-          FV_Atm(1)%flagstruct%tau = 2.0
-          FV_Atm(1)%flagstruct%RF_fast = .true.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 2880) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/  18.75 )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/  30.0  )
-          FV_Atm(1)%flagstruct%tau = 1.5
-          FV_Atm(1)%flagstruct%RF_fast = .true.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 4320) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/  15.0  )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/  15.0  )
-          FV_Atm(1)%flagstruct%tau = 1.0
-          FV_Atm(1)%flagstruct%RF_fast = .true.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 5760) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/   9.375 )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/   7.5   )
-          FV_Atm(1)%flagstruct%tau = 1.0
-          FV_Atm(1)%flagstruct%RF_fast = .true.
-      endif
-      if (FV_Atm(1)%flagstruct%npx*CEILING(FV_Atm(1)%flagstruct%stretch_fac) >= 10800) then
-          FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
-                                                    FV_Atm(1)%flagstruct%k_split = CEILING(DT/  4.6875 )
-          if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = CEILING(DT/  3.25   )
-          FV_Atm(1)%flagstruct%tau = 1.0
-          FV_Atm(1)%flagstruct%RF_fast = .true.
-      endif
-      FV_Atm(1)%flagstruct%k_split = MAX(FV_Atm(1)%flagstruct%k_split,1)
-     ! Divergence Damping
-     ! 6th order divergence default damping options
-      FV_Atm(1)%flagstruct%nord = 2
-      FV_Atm(1)%flagstruct%dddmp = 0.2  ! Smagorinsky damping coef
-      FV_Atm(1)%flagstruct%d4_bg_top = 0.12 ! High-order Divg Damping coef
-      FV_Atm(1)%flagstruct%d4_bg_bot = 0.12 ! High-order Divg Damping coef
-      FV_Atm(1)%flagstruct%d2_bg = 0.0  ! 2nd order Divg Damping coef
-      FV_Atm(1)%flagstruct%d_ext = 0.0  ! External damping
-     ! Local Richardson-number turbulent mixing 
-      FV_Atm(1)%flagstruct%fv_sg_adj = DT*4
-     ! Sponge layer
-      FV_Atm(1)%flagstruct%n_sponge = 9
-      FV_Atm(1)%flagstruct%d2_bg_k1 = 0.2
-      FV_Atm(1)%flagstruct%d2_bg_k2 = 0.1
-      FV_Atm(1)%flagstruct%consv_te = 1.0
-     ! default NonHydrostatic settings (irrelavent to Hydrostatic)
-     ! a_imp > 0.5 for semi-implicit scheme [1 fully backward]
-     ! if (a_imp > 0.5) beta + a_imp must = 1.0
-      FV_Atm(1)%flagstruct%beta = 0.0
-      FV_Atm(1)%flagstruct%a_imp = 1.0
-     ! dz_min is a NH delta-z limiter increasing may improve stability
-      FV_Atm(1)%flagstruct%dz_min = 2.0
-     ! p_fac is a NH pressure fraction limiter near model top (0:0.25) 
-      FV_Atm(1)%flagstruct%p_fac = 0.05
-     ! General defaults
-      FV_Atm(1)%flagstruct%make_nh = .false.
-     ! This is the best/fastest option for tracers
-      FV_Atm(1)%flagstruct%hord_tr =  8
-      if (index(FV3_CONFIG,"MONOTONIC") > 0) then
-        ! Monotonic advection schemes
-         FV_Atm(1)%flagstruct%hord_mt =  10
-         FV_Atm(1)%flagstruct%hord_vt =  10
-         FV_Atm(1)%flagstruct%hord_tm =  10
-         FV_Atm(1)%flagstruct%hord_dp =  10
-        ! disable hyperdiffusion (vorticity damping)
-         FV_Atm(1)%flagstruct%vtdm4 = 0.0
-         FV_Atm(1)%flagstruct%do_vort_damp = .false.
-         FV_Atm(1)%flagstruct%d_con = 0.
+      ! MAT The Fortran Standard, and thus gfortran, *does not allow* the use
+      !     of if (integer). So, we must convert integer resources to logicals
+      if (INT_fix_mass == 0) then
+         fix_mass = .FALSE.
       else
-       ! Non-Monotonic advection schemes
-         FV_Atm(1)%flagstruct%hord_mt =  5
-         FV_Atm(1)%flagstruct%hord_vt =  6
-         FV_Atm(1)%flagstruct%hord_tm =  6
-         FV_Atm(1)%flagstruct%hord_dp = -6
-       ! Must now include hyperdiffusion (vorticity damping)
-         FV_Atm(1)%flagstruct%d_con = 1.
-         FV_Atm(1)%flagstruct%do_vort_damp = .true.
-         FV_Atm(1)%flagstruct%vtdm4 = 0.01
-       ! continue to adjust vorticity damping with
-       ! increasing resolution
-         if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 180) then
-           FV_Atm(1)%flagstruct%vtdm4 = 0.01
+         fix_mass = .TRUE.
+      end if
+      if (INT_check_mass == 0) then
+         check_mass = .FALSE.
+      else
+         check_mass = .TRUE.
+      end if
+      if (INT_ADIABATIC == 0) then
+         ADIABATIC = .FALSE.
+      else
+         ADIABATIC = .TRUE.
+      end if
+      if (INT_FV_OFF == 0) then
+         FV_OFF = .FALSE.
+      else
+         FV_OFF = .TRUE.
+      end if
+
+      ! Constants
+      pi     = MAPL_PI_R8
+      omega  = MAPL_OMEGA    ! angular velocity of earth's rotation
+      cp     = MAPL_CP       ! heat capacity of air at constant pressure
+      radius = MAPL_RADIUS   ! radius of the earth (m)
+      rgas   = MAPL_RGAS     ! Gas constant of the air
+      rvap   = MAPL_RVAP     ! Gas constant of vapor
+      kappa  = MAPL_KAPPA    ! kappa
+      grav   = MAPL_GRAV     ! Gravity
+      hlv    = MAPL_ALHL     ! latent heat of evaporation
+      zvir   = MAPL_RVAP/MAPL_RGAS - 1.   ! RWV/RAIR-1
+
+      ! option to enable different configurations for FV3
+      call MAPL_GridCompGetResource(gc, "FV3_CONFIG", FV3_CONFIG, default='STOCK', _RC)
+
+      ! Create some resolution dependent defaults for FV3 in GEOS...
+      !    These can be overrided in fv_core_nml in fvcore_layout.rc linked to input.nml
+      ! Number of water species for FV3 determined later
+      ! when reading the tracer bundle in fv_first_run
+      FV_Atm(1)%flagstruct%nwat = 0
+      ! Trigger to enable autoconversion/cloud processes on the fv_mapz step
+      FV_Atm(1)%flagstruct%do_sat_adj = .false. ! only valid when nwat >= 6
+      ! Veritical resolution dependencies
+      FV_Atm(1)%flagstruct%external_eta = .true.
+      if (FV_Atm(1)%flagstruct%npz >= 70) then
+         FV_Atm(1)%flagstruct%n_zfilter = 17 ! ~5mb
+      endif
+      if (FV_Atm(1)%flagstruct%npz >= 72) then
+         FV_Atm(1)%flagstruct%n_zfilter = 21 ! ~5mb
+      endif
+      if (FV_Atm(1)%flagstruct%npz >= 90) then
+         FV_Atm(1)%flagstruct%n_zfilter = 17 ! ~5mb
+      endif
+      if (FV_Atm(1)%flagstruct%npz >= 126) then
+         FV_Atm(1)%flagstruct%n_zfilter = 19 ! ~5mb
+      endif
+      if (FV_Atm(1)%flagstruct%npz >= 132) then
+         FV_Atm(1)%flagstruct%n_zfilter = 23 ! ~5mb
+      endif
+      if (FV_Atm(1)%flagstruct%npz >= 136) then
+         FV_Atm(1)%flagstruct%n_zfilter = 23 ! ~5mb
+      endif
+      if (FV_Atm(1)%flagstruct%npz >= 180) then
+         FV_Atm(1)%flagstruct%n_zfilter = 32 ! ~5mb
+      endif
+      ! Vertical remap options
+      FV_Atm(1)%flagstruct%remap_option = 0 ! Remap T in LogP
+      FV_Atm(1)%flagstruct%gmao_remap = 0   ! (0 for GFDL Schemes) (3 for GMAO Cubic)
+      FV_Atm(1)%flagstruct%gmao_top_bc = .true.
+      FV_Atm(1)%flagstruct%gmao_bot_bc = .true.
+      FV_Atm(1)%flagstruct%kord_tm =  9
+      FV_Atm(1)%flagstruct%kord_mt =  9
+      FV_Atm(1)%flagstruct%kord_wz =  9
+      FV_Atm(1)%flagstruct%kord_tr =  9
+      ! Some default horizontal flags
+      FV_Atm(1)%flagstruct%z_tracer = .true.
+      FV_Atm(1)%flagstruct%adjust_dry_mass = fix_mass
+      FV_Atm(1)%flagstruct%consv_am = .false.
+      FV_Atm(1)%flagstruct%fill = .true.
+      FV_Atm(1)%flagstruct%dwind_2d = .false.
+      FV_Atm(1)%flagstruct%delt_max = 0.002
+      FV_Atm(1)%flagstruct%ke_bg = 0.0
+      ! Some default time-splitting options
+      FV_Atm(1)%flagstruct%k_split = 1
+      FV_Atm(1)%flagstruct%n_split = 0
+      ! Cubed-Sphere Global Resolution Specific adjustments
+      FV_Atm(1)%flagstruct%compute_coords_locally = .TRUE.
+      FV_Atm(1)%flagstruct%hydrostatic = .true.
+      ! Rayleigh Damping
+      FV_Atm(1)%flagstruct%rf_cutoff = 0.50e2
+      FV_Atm(1)%flagstruct%tau = 5.0
+      FV_Atm(1)%flagstruct%RF_fast = .false.
+      if (FV_Atm(1)%flagstruct%ntiles == 6) then
+         ! Cubed-sphere grid resolution and DT dependence
+         !              based on ideal remapping DT
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 12) then
+            FV_Atm(1)%flagstruct%hydrostatic = .true.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/3600.0  )
+            FV_Atm(1)%flagstruct%tau = 5.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
-         if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 360) then
-           FV_Atm(1)%flagstruct%vtdm4 = 0.01
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 24) then
+            FV_Atm(1)%flagstruct%hydrostatic = .true.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/1800.0  )
+            FV_Atm(1)%flagstruct%tau = 5.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
-         if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 720) then
-           FV_Atm(1)%flagstruct%vtdm4 = 0.01
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 48) then
+            FV_Atm(1)%flagstruct%hydrostatic = .true.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/1200.0  )
+            FV_Atm(1)%flagstruct%tau = 5.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
-         if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 1440) then
-           FV_Atm(1)%flagstruct%vtdm4 = 0.02
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 90) then
+            FV_Atm(1)%flagstruct%hydrostatic = .true.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/ 600.0   )
+            FV_Atm(1)%flagstruct%tau = 5.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
-         if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 2880) then
-           FV_Atm(1)%flagstruct%vtdm4 = 0.03
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 180) then
+            FV_Atm(1)%flagstruct%hydrostatic = .true.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/ 300.0   )
+            FV_Atm(1)%flagstruct%tau = 5.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
-         if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 5760) then
-           FV_Atm(1)%flagstruct%vtdm4 = 0.04
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 360) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/ 150.0   )
+            FV_Atm(1)%flagstruct%tau = 4.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 720) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/  75.0 )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/ 120.0 )
+            FV_Atm(1)%flagstruct%tau = 3.0
+            FV_Atm(1)%flagstruct%RF_fast = .false.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 1120) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/  60.0 )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  90.0 )
+            FV_Atm(1)%flagstruct%tau = 2.5
+            FV_Atm(1)%flagstruct%RF_fast = .false.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 1440) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/  37.5 )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  60.0 )
+            FV_Atm(1)%flagstruct%tau = 2.0
+            FV_Atm(1)%flagstruct%RF_fast = .true.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 2880) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/  18.75 )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  30.0  )
+            FV_Atm(1)%flagstruct%tau = 1.5
+            FV_Atm(1)%flagstruct%RF_fast = .true.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 4320) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/  15.0  )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  15.0  )
+            FV_Atm(1)%flagstruct%tau = 1.0
+            FV_Atm(1)%flagstruct%RF_fast = .true.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 5760) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/   9.375 )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/   7.5   )
+            FV_Atm(1)%flagstruct%tau = 1.0
+            FV_Atm(1)%flagstruct%RF_fast = .true.
+         endif
+         if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 10800) then
+            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%k_split = ceiling(DT/  4.6875 )
+            if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  3.25   )
+            FV_Atm(1)%flagstruct%tau = 1.0
+            FV_Atm(1)%flagstruct%RF_fast = .true.
+         endif
+         FV_Atm(1)%flagstruct%k_split = MAX(FV_Atm(1)%flagstruct%k_split,1)
+         ! Divergence Damping
+         ! 6th order divergence default damping options
+         FV_Atm(1)%flagstruct%nord = 2
+         FV_Atm(1)%flagstruct%dddmp = 0.2  ! Smagorinsky damping coef
+         FV_Atm(1)%flagstruct%d4_bg_top = 0.12 ! High-order Divg Damping coef
+         FV_Atm(1)%flagstruct%d4_bg_bot = 0.12 ! High-order Divg Damping coef
+         FV_Atm(1)%flagstruct%d2_bg = 0.0  ! 2nd order Divg Damping coef
+         FV_Atm(1)%flagstruct%d_ext = 0.0  ! External damping
+         ! Local Richardson-number turbulent mixing 
+         FV_Atm(1)%flagstruct%fv_sg_adj = DT*4
+         ! Sponge layer
+         FV_Atm(1)%flagstruct%n_sponge = 9
+         FV_Atm(1)%flagstruct%d2_bg_k1 = 0.2
+         FV_Atm(1)%flagstruct%d2_bg_k2 = 0.1
+         FV_Atm(1)%flagstruct%consv_te = 1.0
+         ! default NonHydrostatic settings (irrelavent to Hydrostatic)
+         ! a_imp > 0.5 for semi-implicit scheme [1 fully backward]
+         ! if (a_imp > 0.5) beta + a_imp must = 1.0
+         FV_Atm(1)%flagstruct%beta = 0.0
+         FV_Atm(1)%flagstruct%a_imp = 1.0
+         ! dz_min is a NH delta-z limiter increasing may improve stability
+         FV_Atm(1)%flagstruct%dz_min = 2.0
+         ! p_fac is a NH pressure fraction limiter near model top (0:0.25) 
+         FV_Atm(1)%flagstruct%p_fac = 0.05
+         ! General defaults
+         FV_Atm(1)%flagstruct%make_nh = .false.
+         ! This is the best/fastest option for tracers
+         FV_Atm(1)%flagstruct%hord_tr =  8
+         if (index(FV3_CONFIG,"MONOTONIC") > 0) then
+            ! Monotonic advection schemes
+            FV_Atm(1)%flagstruct%hord_mt =  10
+            FV_Atm(1)%flagstruct%hord_vt =  10
+            FV_Atm(1)%flagstruct%hord_tm =  10
+            FV_Atm(1)%flagstruct%hord_dp =  10
+            ! disable hyperdiffusion (vorticity damping)
+            FV_Atm(1)%flagstruct%vtdm4 = 0.0
+            FV_Atm(1)%flagstruct%do_vort_damp = .false.
+            FV_Atm(1)%flagstruct%d_con = 0.
+         else
+            ! Non-Monotonic advection schemes
+            FV_Atm(1)%flagstruct%hord_mt =  5
+            FV_Atm(1)%flagstruct%hord_vt =  6
+            FV_Atm(1)%flagstruct%hord_tm =  6
+            FV_Atm(1)%flagstruct%hord_dp = -6
+            ! Must now include hyperdiffusion (vorticity damping)
+            FV_Atm(1)%flagstruct%d_con = 1.
+            FV_Atm(1)%flagstruct%do_vort_damp = .true.
+            FV_Atm(1)%flagstruct%vtdm4 = 0.01
+            ! continue to adjust vorticity damping with
+            ! increasing resolution
+            if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 180) then
+               FV_Atm(1)%flagstruct%vtdm4 = 0.01
+            endif
+            if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 360) then
+               FV_Atm(1)%flagstruct%vtdm4 = 0.01
+            endif
+            if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 720) then
+               FV_Atm(1)%flagstruct%vtdm4 = 0.01
+            endif
+            if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 1440) then
+               FV_Atm(1)%flagstruct%vtdm4 = 0.02
+            endif
+            if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 2880) then
+               FV_Atm(1)%flagstruct%vtdm4 = 0.03
+            endif
+            if (FV_Atm(1)%flagstruct%npx*(FV_Atm(1)%flagstruct%stretch_fac) >= 5760) then
+               FV_Atm(1)%flagstruct%vtdm4 = 0.04
+            endif
+         endif
+         if (index(FV3_CONFIG,"MERRA-2") > 0) then
+            ! Override FV3 defaults with MERRA-2 hydrostatic configuration
+            FV_Atm(1)%flagstruct%hydrostatic = .true.
+            ! disable subgrid dz adjustment
+            FV_Atm(1)%flagstruct%fv_sg_adj = -1
+            ! Monotonic advection schemes
+            FV_Atm(1)%flagstruct%hord_mt =  10
+            FV_Atm(1)%flagstruct%hord_vt =  10
+            FV_Atm(1)%flagstruct%hord_tm =  10
+            FV_Atm(1)%flagstruct%hord_dp =  10
+            ! 2nd order damping
+            FV_Atm(1)%flagstruct%nord = 0
+            FV_Atm(1)%flagstruct%dddmp = 0.2
+            FV_Atm(1)%flagstruct%d4_bg_top = 0.0
+            FV_Atm(1)%flagstruct%d4_bg_bot = 0.0
+            FV_Atm(1)%flagstruct%d2_bg = 0.0075
+            FV_Atm(1)%flagstruct%d_ext = 0.02
+            ! disable vorticity damping
+            FV_Atm(1)%flagstruct%vtdm4 = 0.0
+            FV_Atm(1)%flagstruct%do_vort_damp = .false.
+            FV_Atm(1)%flagstruct%d_con = 0.
+            ! Use GMAO cubic remapping for TE
+            FV_Atm(1)%flagstruct%remap_option = 2 ! Remap TE in LogP
+            FV_Atm(1)%flagstruct%gmao_remap = 3   ! GMAO Cubic
+            ! do TE conservation just in the GMAO cubic remap
+            FV_Atm(1)%flagstruct%consv_te = 0.0
          endif
       endif
-      if (index(FV3_CONFIG,"MERRA-2") > 0) then
-       ! Override FV3 defaults with MERRA-2 hydrostatic configuration
-        FV_Atm(1)%flagstruct%hydrostatic = .true.
-       ! disable subgrid dz adjustment
-        FV_Atm(1)%flagstruct%fv_sg_adj = -1
-       ! Monotonic advection schemes
-        FV_Atm(1)%flagstruct%hord_mt =  10
-        FV_Atm(1)%flagstruct%hord_vt =  10
-        FV_Atm(1)%flagstruct%hord_tm =  10
-        FV_Atm(1)%flagstruct%hord_dp =  10
-       ! 2nd order damping
-        FV_Atm(1)%flagstruct%nord = 0
-        FV_Atm(1)%flagstruct%dddmp = 0.2
-        FV_Atm(1)%flagstruct%d4_bg_top = 0.0
-        FV_Atm(1)%flagstruct%d4_bg_bot = 0.0
-        FV_Atm(1)%flagstruct%d2_bg = 0.0075
-        FV_Atm(1)%flagstruct%d_ext = 0.02
-       ! disable vorticity damping
-        FV_Atm(1)%flagstruct%vtdm4 = 0.0
-        FV_Atm(1)%flagstruct%do_vort_damp = .false.
-        FV_Atm(1)%flagstruct%d_con = 0.
-       ! Use GMAO cubic remapping for TE
-        FV_Atm(1)%flagstruct%remap_option = 2 ! Remap TE in LogP
-        FV_Atm(1)%flagstruct%gmao_remap = 3   ! GMAO Cubic
-       ! do TE conservation just in the GMAO cubic remap
-        FV_Atm(1)%flagstruct%consv_te = 0.0
+
+      ! Start up FV
+      ! call MAPL_TimerOn(MAPL,"--FV_INIT")
+      call fv_init2(FV_Atm, DT, grids_on_this_pe, p_split)
+      ! call MAPL_TimerOff(MAPL,"--FV_INIT")
+      call MAPL_MemUtilsWrite(VM, 'FV_StateMod::fv_init2', _RC)
+
+      ! Force compatibility of gmao_remap and n_zfilter
+      if (FV_Atm(1)%flagstruct%gmao_remap > 0) then
+         FV_Atm(1)%flagstruct%n_zfilter = 0
       endif
-   endif
 
-!! Start up FV
-    call MAPL_TimerOn(MAPL,"--FV_INIT")
-    call fv_init2(FV_Atm, DT, grids_on_this_pe, p_split)
-    call MAPL_TimerOff(MAPL,"--FV_INIT")
-    call MAPL_MemUtilsWrite(VM, 'FV_StateMod: FV_INIT', RC=STATUS )
-    VERIFY_(STATUS)
+      _ASSERT(DT > 0.0, 'DT must be greater than zero')
 
-!! Force compatibility of gmao_remap and n_zfilter
-    if (FV_Atm(1)%flagstruct%gmao_remap > 0) then
-        FV_Atm(1)%flagstruct%n_zfilter = 0
-    endif
+      call WRITE_PARALLEL("Dynamics PE Layout ")
+      call WRITE_PARALLEL(FV_Atm(1)%layout(1)    ,format='("NPES_X  : ",(   I3))')
+      call WRITE_PARALLEL(FV_Atm(1)%layout(2)    ,format='("NPES_Y  : ",(   I3))')
 
-  _ASSERT(DT > 0.0, 'DT must be greater than zero')
+      call WRITE_PARALLEL((/FV_Atm(1)%flagstruct%npx,FV_Atm(1)%flagstruct%npy,FV_Atm(1)%flagstruct%npz/)       , &
+           format='("Resolution of dynamics restart     =",3I5)'  )
+      call WRITE_PARALLEL((/FV_Atm(1)%flagstruct%stretch_fac/)       , &
+           format='("                 stretch_fac       =",F10.4)'  )
 
-  call WRITE_PARALLEL("Dynamics PE Layout ")
-  call WRITE_PARALLEL(FV_Atm(1)%layout(1)    ,format='("NPES_X  : ",(   I3))')
-  call WRITE_PARALLEL(FV_Atm(1)%layout(2)    ,format='("NPES_Y  : ",(   I3))')
+      FV_HYDROSTATIC = FV_Atm(1)%flagstruct%hydrostatic
+      DEBUG = FV_Atm(1)%flagstruct%fv_debug
+      call MAPL_GridCompGetResource(gc, "DEBUG_STATE", DEBUG, default=DEBUG, _RC)
 
-  call WRITE_PARALLEL((/FV_Atm(1)%flagstruct%npx,FV_Atm(1)%flagstruct%npy,FV_Atm(1)%flagstruct%npz/)       , &
-    format='("Resolution of dynamics restart     =",3I5)'  )
-  call WRITE_PARALLEL((/FV_Atm(1)%flagstruct%stretch_fac/)       , &
-    format='("                 stretch_fac       =",F10.4)'  )
-
-  FV_HYDROSTATIC = FV_Atm(1)%flagstruct%hydrostatic
-  DEBUG          = FV_Atm(1)%flagstruct%fv_debug
-  call MAPL_GetResource(MAPL, DEBUG, 'DEBUG_STATE:', default=DEBUG, RC=STATUS)
-
-  call MAPL_MemUtilsWrite(VM, trim(Iam), RC=STATUS )
-  VERIFY_(STATUS)
+      call MAPL_MemUtilsWrite(vm, trim(Iam), _RC)
 
 #ifdef RUN_GTFV3
-  call MAPL_GetResource(MAPL, run_gtfv3, 'RUN_GTFV3:', default=0, RC=STATUS)
-  VERIFY_(STATUS)
+      call MAPL_GridCompGetResource(gc, "RUN_GTFV3", run_gtfv3, default=0, _RC)
 #endif
 
-  RETURN_(ESMF_SUCCESS)
-
-contains
-
- end subroutine FV_Setup
+      _RETURN(_SUCCESS)
+   end subroutine FV_Setup
 
  subroutine FV_InitState (STATE, CLOCK, INTERNAL, IMPORT, GC, RC)
 

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -14,7 +14,8 @@ module FV_StateMod
    use MAPL_GenericMod, only: MAPL_MetaComp, MAPL_Get, MAPL_GetObjectFromGC, MAPL_GetResource
    use ESMFL_Mod, only: ESMFL_StateGetPointerToData
    use FileIOSharedMod, only: WRITE_PARALLEL
-   use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet
+
+   use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
    use mapl3g_Geom_API, only: MAPL_GridGet
 #endif
    use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
@@ -717,45 +718,31 @@ contains
       _RETURN(_SUCCESS)
    end subroutine FV_Setup
 
-   subroutine FV_InitState(state, clock, internal, import, gc, rc)
+   subroutine FV_InitState(state, clock, import, gc, rc)
 
       use test_cases_mod, only : test_case, init_double_periodic
 
       type(T_FVDYCORE_STATE), pointer :: state
-
       type(ESMF_Clock), target, intent(inout) :: clock
-      type(ESMF_GridComp), intent(inout) :: gc
-      type(ESMF_State), intent(inout) :: internal
       type(ESMF_State), intent(inout) :: import
+      type(ESMF_GridComp), intent(inout) :: gc
       integer, optional, intent(out) :: rc
 
       ! Local variables
 
-      real(REAL4), pointer :: LATS (:,:)
-      real(REAL4), pointer :: LONS (:,:)
+      ! real(REAL4), pointer :: lats(:,:)
+      ! real(REAL4), pointer :: lons(:,:)
 
+      type(ESMF_State) :: internal
       type(ESMF_TimeInterval) :: Time2Run
       type(ESMF_VM) :: vm
+      type(ESMF_Time) :: fv_time
       type(T_FVDYCORE_GRID), pointer :: grid
-      integer :: status
-      real(REAL8) :: DT
-      real :: rPRS
+      character(len=ESMF_MAXSTR) :: IAm='FV:FV_InitState'
       character(len=1) :: sCODE, rCODE, zCODE
 
-      integer :: is ,ie , js ,je    !  Local dims
-      integer :: isc,iec, jsc,jec   !  Local dims
-      integer :: isd,ied, jsd,jed   !  Local dims
-      integer :: k                  !  Vertical loop index
-      integer :: ng
-      integer :: ndt
-
-      integer :: i,j
-
-      type(ESMF_Time) :: fv_time
-      integer :: days, seconds
-
-      character(len=ESMF_MAXSTR) :: IAm='FV:FV_InitState'
-
+      real :: rPRS
+      real(REAL8) :: DT
       real(REAL8), dimension(:), pointer     :: AK1 => null(), AK => null()
       real(REAL8), dimension(:), pointer     :: BK1 => null(), BK => null()
       real(REAL8), dimension(:,:,:), pointer :: U => null()
@@ -772,22 +759,24 @@ contains
       real(REAL8), allocatable :: VD(:,:,:)
 
       logical :: hybrid
-      integer :: tile_in
-      integer :: gid, masterproc
+
+      integer :: is , ie, js, je    !  Local dims
+      integer :: isc, iec, jsc, jec !  Local dims
+      integer :: isd, ied, jsd, jed !  Local dims
+      integer :: ng, ndt, days, seconds, tile_in, gid, rootproc
+      integer :: i, j, k, status
 
 #ifdef RUN_GTFV3
       logical :: halting_mode(5)
       integer :: comm
 #endif
 
-      ! BEGIN
-
       call MAPL_GridCompGetResource(gc, "RUN_DT", ndt, default=0, _RC)
       DT = ndt
 
       ! state%grid%FVgenstate => MAPL
       grid => state%grid     ! For convenience
-      state%DOTIME= .TRUE.
+      state%DOTIME= .true.
       state%DT = DT
       state%KSPLIT = FV_Atm(1)%flagstruct%K_SPLIT
       state%NSPLIT = FV_Atm(1)%flagstruct%N_SPLIT
@@ -797,9 +786,9 @@ contains
       grid%NPZ = FV_Atm(1)%flagstruct%NPZ
       grid%NPZ_P1 = FV_Atm(1)%flagstruct%NPZ+1
       grid%NTILES = 6
-      grid%NQ = MAX(1,FV_Atm(1)%flagstruct%ncnst)
+      grid%NQ = max(1,FV_Atm(1)%flagstruct%ncnst)
 
-      masterproc = mpp_root_pe()
+      rootproc = mpp_root_pe()
       gid = mpp_pe()
 
       call ESMF_GridCompGet(gc, vm=vm, _RC)
@@ -810,6 +799,7 @@ contains
       call WRITE_PARALLEL(' ')
 
       ! Get pointers to internal state vars
+      call MAPL_GridCompGetInternalState(gc, internal, _RC)
       call MAPL_GetPointer(internal, ak1, "AK", _RC) ! 1-based
       call MAPL_GetPointer(internal, bk1, "BK", _RC) ! 1-based
       call MAPL_GetPointer(internal, u, "U", _RC) ! A-Grid U Wind
@@ -903,9 +893,6 @@ contains
          endif
       endif
 
-      ! Check coordinate information
-      call MAPL_GridGet(grid%grid, latitudes=lats, longitudes=lons, _RC)
-
       state%clock => clock
       call ESMF_TimeIntervalSet(Time2Run, s=nint(state%DT), _RC)
 
@@ -977,7 +964,7 @@ contains
                  FV_Atm(1)%ks, FV_Atm(1)%ptop, FV_Atm(1)%domain, tile_in, FV_Atm(1)%bd)
             ! Copy FV to internal State
             call FV_To_State(state)
-            if(gid==masterproc) write(*,*) 'Doubly Periodic IC generated LAT:', FV_Atm(1)%flagstruct%deglat
+            if(gid==rootproc) write(*,*) 'Doubly Periodic IC generated LAT:', FV_Atm(1)%flagstruct%deglat
          else
             allocate(UA(isc:iec  ,jsc:jec  ,1:FV_Atm(1)%npz))
             allocate(VA(isc:iec  ,jsc:jec  ,1:FV_Atm(1)%npz))
@@ -1015,19 +1002,19 @@ contains
 
       endif ! COLDSTART
 
-      if ( (gid==0)                              ) print *, ' '
-      if ( (gid==0) .and. (COLDSTART)            ) print *, 'COLDSTARTING FV3'
-      if ( (gid==0) .and. (ADIABATIC)            ) print *, 'FV3 being run Adiabatically'
-      if ( (gid==0) .and. (.not. FV_HYDROSTATIC) ) print *, 'FV3 being run Non-Hydrostatic'
-      if ( (gid==0) .and. (.not. FV_HYDROSTATIC) .and. (FV_Atm(1)%flagstruct%Make_NH) ) &
-           print *, 'FV3 Coldstarting Non-Hydrostatic W and DZ'
-      if ( (gid==0) .and. (FV_HYDROSTATIC)       ) print *, 'FV3 being run Hydrostatic'
-      if ( (gid==0) .and. (SW_DYNAMICS)          ) print *, 'FV3 being run as Shallow-Water Model: test_case=', test_case
-      if ( (gid==0) .and. (FV_Atm(1)%flagstruct%grid_type == 4) ) &
-           print*, 'FV3 being run as Doubly-Periodic: test_case=', test_case
-      state%vars%nwat = FV_Atm(1)%flagstruct%nwat
-      if ( (gid==0)                              ) print *, 'FV3 water species nwat=', FV_Atm(1)%flagstruct%nwat
-      if ( (gid==0)                              ) print *, ' '
+      if (gid == rootproc) then
+         print *, ' '
+         if (COLDSTART) print *, 'COLDSTARTING FV3'
+         if (ADIABATIC) print *, 'FV3 being run Adiabatically'
+         if (.not. FV_HYDROSTATIC) print *, 'FV3 being run Non-Hydrostatic'
+         if ((.not. FV_HYDROSTATIC) .and. (FV_Atm(1)%flagstruct%Make_NH)) print *, 'FV3 Coldstarting Non-Hydrostatic W and DZ'
+         if (FV_HYDROSTATIC) print *, 'FV3 being run Hydrostatic'
+         if (SW_DYNAMICS) print *, 'FV3 being run as Shallow-Water Model: test_case=', test_case
+         if (FV_Atm(1)%flagstruct%grid_type == 4) print*, 'FV3 being run as Doubly-Periodic: test_case=', test_case
+         state%vars%nwat = FV_Atm(1)%flagstruct%nwat
+         print *, 'FV3 water species nwat=', FV_Atm(1)%flagstruct%nwat
+         print *, ' '
+      end if
 
       if (DEBUG) call debug_fv_state('DEBUG_RESTART',state)
 
@@ -1063,7 +1050,7 @@ contains
 300      format(A1,A1,A1,2x,i5,2x,f10.6,2x,f8.4,2x,f10.4,3x,f8.4)
       endif
 
-      call MAPL_MemUtilsWrite(vm, 'FV_StateMod: FV Initialize', _RC)
+      call MAPL_MemUtilsWrite(vm, 'FV_StateMod::FV Initialize', _RC)
 
 #ifdef RUN_GTFV3
       if (run_gtfv3 /= 0) then

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -17,6 +17,7 @@ module FV_StateMod
 
    use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
    use mapl3g_Geom_API, only: MAPL_GridGet
+   use mapl3g_State_API, only: MAPL_StateGetPointer
 #endif
    use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
    use MAPL_ConstantsMod, only: MAPL_KAPPA, MAPL_PI_R8, MAPL_ALHL, MAPL_PSDRY, MAPL_OMEGA
@@ -800,15 +801,15 @@ contains
 
       ! Get pointers to internal state vars
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
-      call MAPL_GetPointer(internal, ak1, "AK", _RC) ! 1-based
-      call MAPL_GetPointer(internal, bk1, "BK", _RC) ! 1-based
-      call MAPL_GetPointer(internal, u, "U", _RC) ! A-Grid U Wind
-      call MAPL_GetPointer(internal, v, "V", _RC)
-      call MAPL_GetPointer(internal, pt, "PT", _RC)
-      call MAPL_GetPointer(internal, pe, "PE", _RC) ! 1-based
-      call MAPL_GetPointer(internal, pkz, "PKZ", _RC)
-      call MAPL_GetPointer(internal, dz, "DZ", _RC)
-      call MAPL_GetPointer(internal, w, "W", _RC)
+      call MAPL_StateGetPointer(internal, ak1, "AK", _RC) ! 1-based
+      call MAPL_StateGetPointer(internal, bk1, "BK", _RC) ! 1-based
+      call MAPL_StateGetPointer(internal, u, "U", _RC) ! A-Grid U Wind
+      call MAPL_StateGetPointer(internal, v, "V", _RC)
+      call MAPL_StateGetPointer(internal, pt, "PT", _RC)
+      call MAPL_StateGetPointer(internal, pe, "PE", _RC) ! 1-based
+      call MAPL_StateGetPointer(internal, pkz, "PKZ", _RC)
+      call MAPL_StateGetPointer(internal, dz, "DZ", _RC)
+      call MAPL_StateGetPointer(internal, w, "W", _RC)
       ! Ak and BK are expected to be 0-based
       block
          integer :: km
@@ -927,13 +928,13 @@ contains
            enabled=.true., &
            sticky=.false., _RC)
 
-      call MAPL_GetPointer(import, phis, 'PHIS', _RC)
+      call MAPL_StateGetPointer(import, phis, 'PHIS', _RC)
 
       ! Set FV3 surface geopotential
       FV_Atm(1)%phis(isc:iec, jsc:jec) = real(phis, kind=REAL8)
       call mpp_update_domains(FV_Atm(1)%phis, FV_Atm(1)%domain, complete=.true.)
 
-      call MAPL_GetPointer(import, varflt, 'VARFLT', _RC)
+      call MAPL_StateGetPointer(import, varflt, 'VARFLT', _RC)
       FV_Atm(1)%varflt(isc:iec,jsc:jec) = varflt
 
       FV_Atm(1)%ak = ak
@@ -1884,15 +1885,15 @@ contains
          allocate ( vdt(isc:iec,jsc:jec,npz) )
          ! go from native D-Grid tendencies to A-grid rotated exports
          call fv_getAllWinds(u_dt, v_dt, ur=udt, vr=vdt)
-         call MAPL_GetPointer(export, ptr3d, "DUDT_RAY", _RC)
+         call MAPL_StateGetPointer(export, ptr3d, "DUDT_RAY", _RC)
          if( associated(ptr3d) ) ptr3d = udt
-         call MAPL_GetPointer(export, ptr3d, "DVDT_RAY", _RC)
+         call MAPL_StateGetPointer(export, ptr3d, "DVDT_RAY", _RC)
          if( associated(ptr3d) ) ptr3d = vdt
          deallocate ( udt )
          deallocate ( vdt )
-         call MAPL_GetPointer(export, ptr3d, "DTDT_RAY", _RC)
+         call MAPL_StateGetPointer(export, ptr3d, "DTDT_RAY", _RC)
          if( associated(ptr3d) ) ptr3d = t_dt
-         call MAPL_GetPointer(export, ptr3d, "DWDT_RAY", _RC)
+         call MAPL_StateGetPointer(export, ptr3d, "DWDT_RAY", _RC)
          if( associated(ptr3d) ) ptr3d = w_dt
 
          if ( FV_Atm(1)%flagstruct%fv_sg_adj > 0 ) then
@@ -1908,13 +1909,13 @@ contains
                  FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%flagstruct%hydrostatic, &
                  FV_Atm(1)%w, FV_Atm(1)%delz, u_dt, v_dt, t_dt, w_dt, &
                  FV_Atm(1)%flagstruct%n_zfilter)
-            call MAPL_GetPointer(export, ptr3d, "DUDTSUBZ", _RC)
+            call MAPL_StateGetPointer(export, ptr3d, "DUDTSUBZ", _RC)
             if( associated(ptr3d) ) ptr3d = u_dt
-            call MAPL_GetPointer(export, ptr3d, "DVDTSUBZ", _RC)
+            call MAPL_StateGetPointer(export, ptr3d, "DVDTSUBZ", _RC)
             if( associated(ptr3d) ) ptr3d = v_dt
-            call MAPL_GetPointer(export, ptr3d, "DTDTSUBZ", _RC)
+            call MAPL_StateGetPointer(export, ptr3d, "DTDTSUBZ", _RC)
             if( associated(ptr3d) ) ptr3d = t_dt
-            call MAPL_GetPointer(export, ptr3d, "DWDTSUBZ", _RC)
+            call MAPL_StateGetPointer(export, ptr3d, "DWDTSUBZ", _RC)
             if( associated(ptr3d) ) ptr3d = w_dt
          endif
          deallocate ( u_dt )

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -1072,1205 +1072,1195 @@ contains
 
    end subroutine FV_InitState
 
-subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
+   subroutine FV_Run (state, export, clock, gc, ple0, rc)
 
-  type (T_FVDYCORE_STATE),pointer              :: STATE
-  type (ESMF_State),             intent(INOUT) :: EXPORT
-  type (ESMF_Clock), target,     intent(IN   ) :: CLOCK
-  type (ESMF_GridComp)         , intent(INOUT) :: GC
-  real(REAL8), optional        , intent(INOUT) :: PLE0(:,:,:)
-  integer, optional            , intent(OUT  ) :: RC
+      type(T_FVDYCORE_STATE), pointer :: state
+      type(ESMF_State), intent(inout) :: export
+      type(ESMF_Clock), target, intent(in) :: clock
+      type(ESMF_GridComp), intent(inout) :: gc
+      real(REAL8), optional, intent(inout) :: ple0(:,:,:)
+      integer, optional, intent(out) :: rc
 
-! Local variables
-  integer              :: status
-  character(len=ESMF_MAXSTR)       :: IAm='FV:FV_Run'
+      ! Local variables
+      integer :: status
 
-  type (ESMF_Time) :: fv_time
-  integer  :: days, seconds
-  real(FVPRC) :: time_total, massD
+      type(ESMF_Time) :: fv_time
+      type(ESMF_Grid) :: esmfgrid
 
-  integer :: i,j,k,n,nn
-  integer :: isc,iec,jsc,jec,ng
-  integer :: isd,ied,jsd,jed
-  integer :: npx,npy,npz
+      integer :: days, seconds
+      integer :: i, j, k, n, nn
+      integer :: isc, iec, jsc, jec, ng
+      integer :: isd, ied, jsd, jed
+      integer :: npx, npy, npz
 
-  real(FVPRC), allocatable :: QV(:,:,:)
+      real(FVPRC) :: time_total, massD
 
-  real(FVPRC), allocatable :: u_dt(:,:,:), udt(:,:,:)
-  real(FVPRC), allocatable :: v_dt(:,:,:), vdt(:,:,:)
-  real(FVPRC), allocatable :: t_dt(:,:,:)
-  real(FVPRC), allocatable :: w_dt(:,:,:)
-  real(FVPRC), allocatable :: q_dt(:,:,:,:)
-  real(FVPRC), allocatable :: u_srf(:,:)
-  real(FVPRC), allocatable :: v_srf(:,:)
-  real(FVPRC), allocatable :: ts(:,:)
+      real(FVPRC), allocatable :: QV(:,:,:)
+      real(FVPRC), allocatable :: u_dt(:,:,:), udt(:,:,:)
+      real(FVPRC), allocatable :: v_dt(:,:,:), vdt(:,:,:)
+      real(FVPRC), allocatable :: t_dt(:,:,:)
+      real(FVPRC), allocatable :: w_dt(:,:,:)
+      real(FVPRC), allocatable :: q_dt(:,:,:,:)
+      real(FVPRC), allocatable :: u_srf(:,:)
+      real(FVPRC), allocatable :: v_srf(:,:)
+      real(FVPRC), allocatable :: ts(:,:)
 
-  real(FVPRC), allocatable :: mass(:,:), tqtot(:,:)
-  real(REAL8), allocatable :: ratio(:)
-  real(REAL8) :: dpd
-  real(FVPRC) :: FQC
+      real(FVPRC), allocatable :: mass(:,:), tqtot(:,:)
+      real(REAL8), allocatable :: ratio(:)
+      real(REAL8) :: dpd
+      real(FVPRC) :: FQC
 
-  real(REAL4), pointer     :: PTR3D(:,:,:)
+      real(REAL4), pointer :: ptr3d(:,:,:)
 
-  real(FVPRC), allocatable :: DEBUG_ARRAY(:,:,:)
-  real(FVPRC) :: fac1    = 1.0
+      real(FVPRC), allocatable :: DEBUG_ARRAY(:,:,:)
+      real(FVPRC) :: fac1 = 1.0
 
-  real(REAL4), pointer     :: LONS(:,:), LATS(:,:)
-  real(REAL8), pointer     :: lonptr(:,:), latptr(:,:)
-  real(REAL4), allocatable :: griddiffs(:,:)
-  type (ESMF_Grid)         :: ESMFGRID
+      real(REAL4), pointer :: lons(:,:), lats(:,:)
+      real(REAL8), pointer :: lonptr(:,:), latptr(:,:)
+      real(REAL4), allocatable :: griddiffs(:,:)
 
-! Splitting for Pure Advection
-  real(FVPRC) :: myDT, lnp, rdg, pek, ak1
+      ! Splitting for Pure Advection
+      real(FVPRC) :: myDT, lnp, rdg, pek, ak1
 
-! Convience variables
-  real(FVPRC), allocatable :: cnvfrc(:,:,:)
-  integer :: nwat_tracers
-  integer :: sphu = -1
-  integer :: qliq = -1
-  integer :: qice = -1
-  integer :: qlls = -1
-  integer :: qlcn = -1
-  integer :: qils = -1
-  integer :: qicn = -1
-  integer :: clls = -1
-  integer :: clcn = -1
-  integer :: qcld = -1
-  integer :: rain = -1
-  integer :: snow = -1
-  integer :: grpl = -1
+      ! Convience variables
+      real(FVPRC), allocatable :: cnvfrc(:,:,:)
+      integer :: nwat_tracers
+      integer :: sphu = -1
+      integer :: qliq = -1
+      integer :: qice = -1
+      integer :: qlls = -1
+      integer :: qlcn = -1
+      integer :: qils = -1
+      integer :: qicn = -1
+      integer :: clls = -1
+      integer :: clcn = -1
+      integer :: qcld = -1
+      integer :: rain = -1
+      integer :: snow = -1
+      integer :: grpl = -1
 
-  type(domain2D) :: domain
+      type(domain2D) :: domain
 
-  type (MAPL_MetaComp),          pointer :: mapl  => NULL()
+      character(len=ESMF_MAXSTR) :: STRING
 
-  character(len=ESMF_MAXSTR) :: STRING
+      logical :: SPHU_FILLED = .FALSE.
+      logical :: QLIQ_FILLED = .FALSE.
+      logical :: QICE_FILLED = .FALSE.
+      logical :: RAIN_FILLED = .FALSE.
+      logical :: SNOW_FILLED = .FALSE.
+      logical :: GRPL_FILLED = .FALSE.
+      logical :: QCLD_FILLED = .FALSE.
+      logical :: QLLS_FILLED = .FALSE.
+      logical :: QLCN_FILLED = .FALSE.
+      logical :: QILS_FILLED = .FALSE.
+      logical :: QICN_FILLED = .FALSE.
+      logical :: CLLS_FILLED = .FALSE.
+      logical :: CLCN_FILLED = .FALSE.
 
-  logical :: SPHU_FILLED = .FALSE.
-  logical :: QLIQ_FILLED = .FALSE.
-  logical :: QICE_FILLED = .FALSE.
-  logical :: RAIN_FILLED = .FALSE.
-  logical :: SNOW_FILLED = .FALSE.
-  logical :: GRPL_FILLED = .FALSE.
-  logical :: QCLD_FILLED = .FALSE.
-  logical :: QLLS_FILLED = .FALSE.
-  logical :: QLCN_FILLED = .FALSE.
-  logical :: QILS_FILLED = .FALSE.
-  logical :: QICN_FILLED = .FALSE.
-  logical :: CLLS_FILLED = .FALSE.
-  logical :: CLCN_FILLED = .FALSE.
-
-  logical :: NWAT_TEST
+      logical :: NWAT_TEST
 
 #ifdef RUN_GTFV3
-  type(ESMF_VM) :: vm
-  integer :: comm, rank, mpierr
-  real :: start, finish
+      type(ESMF_VM) :: vm
+      integer :: comm, rank, mpierr
+      real :: start, finish
 #endif
-
-! Begin
 
 #ifdef RUN_GTFV3
-  call ESMF_VMGetCurrent(vm, rc=status) ! pchakrab: replace with ESMF_GridCompGet(gc, VM=VM, _RC)
-  call ESMF_VMGet(vm, mpiCommunicator=comm)
-  call MPI_Comm_rank(comm, rank, mpierr)
+      call ESMF_VMGetCurrent(vm, rc=status) ! pchakrab: replace with ESMF_GridCompGet(gc, VM=VM, _RC)
+      call ESMF_VMGet(vm, mpiCommunicator=comm)
+      call MPI_Comm_rank(comm, rank, mpierr)
 #endif
-! Retrieve the pointer to the state
-! ---------------------------------
 
-  call MAPL_GetObjectFromGC (GC, MAPL,  RC=STATUS )
-  VERIFY_(STATUS)
 
-  call ESMF_ClockGet( CLOCK, currTime=fv_time, rc=STATUS )
-  VERIFY_(STATUS)
-  call ESMF_TimeGet( fv_time, dayOfYear=days, s=seconds, rc=STATUS )
-  VERIFY_(STATUS)
+      call ESMF_ClockGet(clock, currTime=fv_time, _RC)
+      call ESMF_TimeGet(fv_time, dayOfYear=days, s=seconds, _RC)
 
-  time_total = days*86400. + seconds
+      time_total = days*86400. + seconds
 
-  isc = FV_Atm(1)%bd%isc
-  iec = FV_Atm(1)%bd%iec
-  jsc = FV_Atm(1)%bd%jsc
-  jec = FV_Atm(1)%bd%jec
-  isd = FV_Atm(1)%bd%isd
-  ied = FV_Atm(1)%bd%ied
-  jsd = FV_Atm(1)%bd%jsd
-  jed = FV_Atm(1)%bd%jed
-  npx = FV_Atm(1)%npx
-  npy = FV_Atm(1)%npy
-  npz = FV_Atm(1)%npz
-  ng  = FV_Atm(1)%ng
-  domain = FV_Atm(1)%domain
+      isc = FV_Atm(1)%bd%isc
+      iec = FV_Atm(1)%bd%iec
+      jsc = FV_Atm(1)%bd%jsc
+      jec = FV_Atm(1)%bd%jec
+      isd = FV_Atm(1)%bd%isd
+      ied = FV_Atm(1)%bd%ied
+      jsd = FV_Atm(1)%bd%jsd
+      jed = FV_Atm(1)%bd%jed
+      npx = FV_Atm(1)%npx
+      npy = FV_Atm(1)%npy
+      npz = FV_Atm(1)%npz
+      ng  = FV_Atm(1)%ng
+      domain = FV_Atm(1)%domain
 
-  ! Be sure we have the correct PHIS and number of tracers for this run
-   if (fv_first_run) then
-    ! Determine how many water species we have
-     nwat_tracers = 0
-     if (.not. ADIABATIC) then
-       do n=1,STATE%GRID%NQ
-         if (TRIM(state%vars%tracer(n)%tname) == 'Q'       ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QLCN'    ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QLLS'    ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QICN'    ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QILS'    ) nwat_tracers = nwat_tracers + 1
-       enddo
-      ! We must have these first 5 at a minimum
-       _ASSERT(nwat_tracers == 5, 'expecting 5 water species: Q QLCN QLLS QICN QILS')
-      ! Check for CLLS, CLCN, QRAIN, QSNOW, QGRAUPEL
-       do n=1,STATE%GRID%NQ
-         if (TRIM(state%vars%tracer(n)%tname) == 'CLLS'    ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'CLCN'    ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QRAIN'   ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QSNOW'   ) nwat_tracers = nwat_tracers + 1
-         if (TRIM(state%vars%tracer(n)%tname) == 'QGRAUPEL') nwat_tracers = nwat_tracers + 1
-       enddo
-       if (FV_Atm(1)%flagstruct%nwat == 0) then
-         if (nwat_tracers >=  5) FV_Atm(1)%flagstruct%nwat = 1 ! Tell FV3 about QV only
-         if (.not. FV_Atm(1)%flagstruct%hydrostatic) then
-           if (nwat_tracers >=  5) FV_Atm(1)%flagstruct%nwat = 3 ! Tell FV3 about QV, QLIQ, QICE
-         endif
-         if (nwat_tracers >= 10) FV_Atm(1)%flagstruct%nwat = 6 ! Tell FV3 about QV, QLIQ, QICE, QRAIN, QSNOW, QGRAUPEL plus QCLD
-       endif
-       STATE%VARS%nwat = FV_Atm(1)%flagstruct%nwat
-     endif
+      ! Be sure we have the correct PHIS and number of tracers for this run
+      if (fv_first_run) then
+         ! Determine how many water species we have
+         nwat_tracers = 0
+         if (.not. ADIABATIC) then
+            do n=1,state%grid%NQ
+               if (trim(state%vars%tracer(n)%tname) == 'Q'       ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QLCN'    ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QLLS'    ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QICN'    ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QILS'    ) nwat_tracers = nwat_tracers + 1
+            enddo
+            ! We must have these first 5 at a minimum
+            _ASSERT(nwat_tracers == 5, 'expecting 5 water species: Q QLCN QLLS QICN QILS')
+            ! Check for CLLS, CLCN, QRAIN, QSNOW, QGRAUPEL
+            do n=1,state%grid%NQ
+               if (trim(state%vars%tracer(n)%tname) == 'CLLS'    ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'CLCN'    ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QRAIN'   ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QSNOW'   ) nwat_tracers = nwat_tracers + 1
+               if (trim(state%vars%tracer(n)%tname) == 'QGRAUPEL') nwat_tracers = nwat_tracers + 1
+            enddo
+            if (FV_Atm(1)%flagstruct%nwat == 0) then
+               if (nwat_tracers >=  5) FV_Atm(1)%flagstruct%nwat = 1 ! Tell FV3 about QV only
+               if (.not. FV_Atm(1)%flagstruct%hydrostatic) then
+                  if (nwat_tracers >=  5) FV_Atm(1)%flagstruct%nwat = 3 ! Tell FV3 about QV, QLIQ, QICE
+               endif
+               if (nwat_tracers >= 10) FV_Atm(1)%flagstruct%nwat = 6 ! Tell FV3 about QV, QLIQ, QICE, QRAIN, QSNOW, QGRAUPEL, QCLD
+            endif
+            state%VARS%nwat = FV_Atm(1)%flagstruct%nwat
+         endif ! not adiabatic
+
 #ifdef VERIFY_GRID
-    ! Verify Grid Coordinates
-    ! ------- ESMF ------
-     allocate ( griddiffs(isc:iec,jsc:jec) )
-     call ESMF_GridCompGet( GC, grid=ESMFGRID, RC=STATUS )
-     call ESMF_GridGetCoord(ESMFGRID,localDE=0,coordDim=1,&
-                        staggerloc=ESMF_STAGGERLOC_CENTER,&
-                            farrayPtr=lonptr,rc=status)
-     griddiffs = REAL(lonptr)-REAL(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,1))
-     do j=jsc,jec
-        do i=isc,iec
-           if (ABS(griddiffs(i,j)) >= tiny_number) print*, 'LONS discprepency FV3 : ESMF ', &
-                                REAL( FV_Atm(1)%gridstruct%agrid(i,j,1)*180.0/MAPL_PI), &
-                                REAL(           lonptr(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
-        enddo
-     enddo
-     call ESMF_GridGetCoord(ESMFGRID,localDE=0,coordDim=2,&
-                        staggerloc=ESMF_STAGGERLOC_CENTER,&
-                                    farrayPtr=latptr,rc=status)
-     griddiffs = REAL(latptr)-REAL(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,2))
-     do j=jsc,jec
-        do i=isc,iec
-           if (ABS(griddiffs(i,j)) >= tiny_number) print*, 'LATS discprepency FV3 : ESMF ', &
-                                REAL( FV_Atm(1)%gridstruct%agrid(i,j,2)*180.0/MAPL_PI), &
-                                REAL(           latptr(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
-        enddo
-     enddo
-    ! ------- MAPL ------
-     call MAPL_Get(MAPL, LATS=LATS, LONS=LONS, RC=STATUS)  ! These are in radians
-     griddiffs = REAL(LONS)-REAL(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,1))
-     do j=jsc,jec
-        do i=isc,iec
-           if (ABS(griddiffs(i,j)) >= tiny_number) print*, 'LONS discprepency FV3 : MAPL ', &
-                                REAL( FV_Atm(1)%gridstruct%agrid(i,j,1)*180.0/MAPL_PI), &
-                                REAL(             LONS(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
-        enddo
-     enddo
-     griddiffs = REAL(LATS)-REAL(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,2))
-     do j=jsc,jec
-        do i=isc,iec
-           if (ABS(griddiffs(i,j)) >= tiny_number) print*, 'LATS discprepency FV3 : MAPL ', &
-                                REAL( FV_Atm(1)%gridstruct%agrid(i,j,2)*180.0/MAPL_PI), &
-                                REAL(             LATS(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
-        enddo
-     enddo
-     deallocate ( griddiffs )
+         ! Verify Grid Coordinates
+         allocate(griddiffs(isc:iec,jsc:jec))
+         call MAPL_GridCompGet(gc, grid=esmfgrid, _RC)
+
+         call ESMF_GridGetCoord(esmfgrid, localDE=0, coordDim=1, staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=lonptr, _RC)
+         griddiffs = real(lonptr) - real(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,1))
+         do j=jsc,jec
+            do i=isc,iec
+               if (ABS(griddiffs(i,j)) >= tiny_number) print *, 'LONS discprepency FV3 : ESMF ', &
+                    real(FV_Atm(1)%gridstruct%agrid(i,j,1)*180.0/MAPL_PI), &
+                    real(lonptr(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
+            enddo
+         enddo
+
+         call ESMF_GridGetCoord(esmfgrid, localDE=0, coordDim=2, staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=latptr, _RC)
+         griddiffs = real(latptr)-real(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,2))
+         do j=jsc,jec
+            do i=isc,iec
+               if (ABS(griddiffs(i,j)) >= tiny_number) print *, 'LATS discprepency FV3 : ESMF ', &
+                    real(FV_Atm(1)%gridstruct%agrid(i,j,2)*180.0/MAPL_PI), &
+                    real(latptr(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
+            enddo
+         enddo
+
+         call MAPL_GridGet(esmfgrid, latitudes=lats, longitudes=lons, _RC) ! These are in radians
+         griddiffs = real(lons) - real(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,1))
+         do j=jsc,jec
+            do i=isc,iec
+               if (ABS(griddiffs(i,j)) >= tiny_number) print*, 'LONS discprepency FV3 : MAPL ', &
+                    real(FV_Atm(1)%gridstruct%agrid(i,j,1)*180.0/MAPL_PI), &
+                    real(lons(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
+            enddo
+         enddo
+         griddiffs = real(lats) - real(FV_Atm(1)%gridstruct%agrid(isc:iec,jsc:jec,2))
+         do j=jsc,jec
+            do i=isc,iec
+               if (ABS(griddiffs(i,j)) >= tiny_number) print*, 'LATS discprepency FV3 : MAPL ', &
+                    real(FV_Atm(1)%gridstruct%agrid(i,j,2)*180.0/MAPL_PI), &
+                    real(lats(i-isc+1,j-jsc+1)*180.0/MAPL_PI)
+            enddo
+         enddo
+         deallocate ( griddiffs )
 #endif
-    ! Set FV3 surface geopotential
-     FV_Atm(1)%phis(isc:iec,jsc:jec) = real(phis,kind=FVPRC)
-     FV_Atm(1)%varflt(isc:iec,jsc:jec) = real(varflt,kind=FVPRC)
-     call mpp_update_domains(FV_Atm(1)%phis, FV_Atm(1)%domain, complete=.true.)
-    ! How many tracers do we really have?
-     ! MAT GCC cannot handle multi-line asserts. For ease of reading,
-     !     create a new variable to test
-     NWAT_TEST = ( (FV_Atm(1)%flagstruct%nwat == 0) .OR. &
-                   (FV_Atm(1)%flagstruct%nwat == 1) .OR. &
-                   (FV_Atm(1)%flagstruct%nwat == 3) .OR. &
-                   (FV_Atm(1)%flagstruct%nwat >= 6) )
-     _ASSERT( NWAT_TEST , 'NWAT must be either 0, 1, 3 or 6')
-     FV_Atm(1)%ncnst = STATE%GRID%NQ - 3 ! Remove CN species
-     if (FV_Atm(1)%flagstruct%nwat >= 3) then
-        FV_Atm(1)%ncnst = STATE%GRID%NQ - 3 ! Remove CN species
-     else
-        FV_Atm(1)%ncnst = STATE%GRID%NQ
-     endif
-     deallocate( FV_Atm(1)%q )
-     allocate  ( FV_Atm(1)%q(isd:ied  ,jsd:jed  ,npz, FV_Atm(1)%ncnst) )
-    ! Echo FV3 setup
-     call echo_fv3_setup()
-   endif
-
-   select case ( FV_Atm(1)%flagstruct%nwat )
-  ! Assign Tracer Indices for FV3
-   case (6:7)
-    sphu = 1
-    qliq = 2
-    qice = 3
-    rain = 4
-    snow = 5
-    grpl = 6
-    qcld = 7
-   case (3:4)
-    sphu = 1
-    qliq = 2
-    qice = 3
-    qcld = 4
-   case (1)
-    sphu = 1
-  ! Advect as split CN/LS species
-    qlcn = 2
-    qlls = 3
-    qicn = 4
-    qils = 5
-   end select
-
-   allocate ( cnvfrc(isc:iec,jsc:jec,npz) )
-   cnvfrc = 0.0
-
- ! Pull Tracers
-  nn = 0
-  if (.not. ADIABATIC) then
-    select case ( FV_Atm(1)%flagstruct%nwat )
-    case (0)
-       _ASSERT(FV_Atm(1)%ncnst == STATE%GRID%NQ, 'needs informative message')
-    case (1)
-       _ASSERT(FV_Atm(1)%ncnst >= 5, 'needs informative message')
-    case (3:4)
-       _ASSERT(FV_Atm(1)%ncnst >= 4, 'needs informative message')
-    case (6:7)
-       _ASSERT(FV_Atm(1)%ncnst >= 7, 'needs informative message')
-    end select
-   ! Report total number and names of advected tracers
-    if (fv_first_run .and. FV_Atm(1)%ncnst > 0) then
-       write(STRING,'(A,I5,A)') "FV3 is Advecting the following ", FV_Atm(1)%ncnst, " tracers:"
-       call WRITE_PARALLEL( trim(STRING)   )
-    endif
-    FV_Atm(1)%q(:,:,:,:) = 0.0
-    if (FV_Atm(1)%flagstruct%nwat > 0) then
-    do n=1,STATE%GRID%NQ
-       if (TRIM(state%vars%tracer(n)%tname) == 'Q') then
-         if (sphu /= -1) then ! SPHU
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           SPHU_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-       if (TRIM(state%vars%tracer(n)%tname) == 'QLCN') then
-         if (qliq /= -1) then ! QLIQ
-           if (fv_first_run) call WRITE_PARALLEL( trim('QLIQ') )
-           QLIQ_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content(:,:,:)
-           endif
-         elseif (qlcn /= -1) then
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           QLCN_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-       if (TRIM(state%vars%tracer(n)%tname) == 'QLLS') then
-         if (qliq /= -1) then ! QLIQ
-           QLIQ_FILLED = .TRUE.
-          ! nn increment already handled in QLLS
-           if (state%vars%tracer(n)%is_r4) then
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content(:,:,:)
-           endif
-         elseif (qlls /= -1) then
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           QLLS_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-       if (TRIM(state%vars%tracer(n)%tname) == 'QICN') then
-         if (qice /= -1) then ! QICE
-           if (fv_first_run) call WRITE_PARALLEL( trim('QICE') )
-           QICE_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content(:,:,:)
-           endif
-         elseif (qicn /= -1) then
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           QICN_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-       if (TRIM(state%vars%tracer(n)%tname) == 'QILS') then
-         if (qice /= -1) then ! QICE
-           QICE_FILLED = .TRUE.
-          ! nn increment already handled in QICN
-           if (state%vars%tracer(n)%is_r4) then
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content(:,:,:)
-           endif
-         elseif (qils /= -1) then
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           QILS_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-     ! Extra species for 6-phase microphysics
-       if ((rain /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QRAIN')) then
-         if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-         RAIN_FILLED = .TRUE.
-         nn = nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain) = state%vars%tracer(n)%content_r4(:,:,:)
+         ! Set FV3 surface geopotential
+         FV_Atm(1)%phis(isc:iec,jsc:jec) = real(phis,kind=FVPRC)
+         FV_Atm(1)%varflt(isc:iec,jsc:jec) = real(varflt,kind=FVPRC)
+         call mpp_update_domains(FV_Atm(1)%phis, FV_Atm(1)%domain, complete=.true.)
+         ! How many tracers do we really have?
+         ! MAT GCC cannot handle multi-line asserts. For ease of reading,
+         !     create a new variable to test
+         NWAT_TEST = &
+              ( (FV_Atm(1)%flagstruct%nwat == 0) .OR. &
+              (FV_Atm(1)%flagstruct%nwat == 1) .OR. &
+              (FV_Atm(1)%flagstruct%nwat == 3) .OR. &
+              (FV_Atm(1)%flagstruct%nwat >= 6) )
+         _ASSERT(NWAT_TEST, "NWAT must be either 0, 1, 3 or 6")
+         FV_Atm(1)%ncnst = state%grid%NQ - 3 ! Remove CN species
+         if (FV_Atm(1)%flagstruct%nwat >= 3) then
+            FV_Atm(1)%ncnst = state%grid%NQ - 3 ! Remove CN species
          else
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain) = state%vars%tracer(n)%content(:,:,:)
+            FV_Atm(1)%ncnst = state%grid%NQ
          endif
-       endif
-       if ((snow /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QSNOW')) then
-         if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-         SNOW_FILLED = .TRUE.
-         nn = nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow) = state%vars%tracer(n)%content_r4(:,:,:)
-         else
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow) = state%vars%tracer(n)%content(:,:,:)
-         endif
-       endif
-       if ((grpl /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QGRAUPEL')) then
-         if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-         GRPL_FILLED = .TRUE.
-         nn = nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl) = state%vars%tracer(n)%content_r4(:,:,:)
-         else
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl) = state%vars%tracer(n)%content(:,:,:)
-         endif
-       endif
-       if (TRIM(state%vars%tracer(n)%tname) == 'CLCN') then
-         if (qcld /= -1) then ! QCLD
-           if (fv_first_run) call WRITE_PARALLEL( trim('QCLD') )
-           QCLD_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-             cnvfrc  = state%vars%tracer(n)%content_r4(:,:,:)
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             cnvfrc  = state%vars%tracer(n)%content_r4(:,:,:)
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content(:,:,:)
-           endif
-         elseif (clcn /= -1) then
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           CLCN_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-       if (TRIM(state%vars%tracer(n)%tname) == 'CLLS') then
-         if (qcld /= -1) then ! QCLD
-           QCLD_FILLED = .TRUE.
-          ! nn increment already handled in CLCN
-           if (state%vars%tracer(n)%is_r4) then
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content_r4(:,:,:)
-           else
-             FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content(:,:,:)
-           endif
-         elseif (clls /= -1) then
-           if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-           CLLS_FILLED = .TRUE.
-           nn = nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       endif
-    enddo
-   ! Verify
-    select case (FV_Atm(1)%flagstruct%nwat)
-    case (6:7)
-      do k=1,npz
-        do j=jsc,jec
-          do i=isc,iec
-            if (FV_Atm(1)%q(i,j,k,qcld) > 0.0) &
-               cnvfrc(i,j,k) = cnvfrc(i,j,k)/FV_Atm(1)%q(i,j,k,qcld)
-          enddo
-        enddo
-      enddo
-      _ASSERT(SPHU_FILLED, 'SPHU Not Filled')
-      _ASSERT(QLIQ_FILLED, 'QLIQ Not Filled')
-      _ASSERT(QICE_FILLED, 'QICE Not Filled')
-      _ASSERT(RAIN_FILLED, 'RAIN Not Filled')
-      _ASSERT(SNOW_FILLED, 'SNOW Not Filled')
-      _ASSERT(GRPL_FILLED, 'GRPL Not Filled')
-      _ASSERT(QCLD_FILLED, 'QCLD Not Filled')
-      _ASSERT(nn == 7, 'Expecting 7 water species') ! Q, QRAIN, QSNOW, QGRAUPEL, QLIQ, QICE, QCLD
-    case (3:4)
-      do k=1,npz
-        do j=jsc,jec
-          do i=isc,iec
-            if (FV_Atm(1)%q(i,j,k,qcld) > 0.0) &
-               cnvfrc(i,j,k) = cnvfrc(i,j,k)/FV_Atm(1)%q(i,j,k,qcld)
-          enddo
-        enddo
-      enddo
-      _ASSERT(SPHU_FILLED, 'SPHU Not Filled')
-      _ASSERT(QLIQ_FILLED, 'QLIQ Not Filled')
-      _ASSERT(QICE_FILLED, 'QICE Not Filled')
-      _ASSERT(QCLD_FILLED, 'QCLD Not Filled')
-      _ASSERT(nn == 4, 'Expecting 4 water species') ! Q, QLIQ, QICE
-    case (1)
-      _ASSERT(SPHU_FILLED, 'SPHU Not Filled')
-      _ASSERT(QLCN_FILLED, 'QLCN Not Filled')
-      _ASSERT(QLLS_FILLED, 'QLLS Not Filled')
-      _ASSERT(QICN_FILLED, 'QICN Not Filled')
-      _ASSERT(QILS_FILLED, 'QILS Not Filled')
-      _ASSERT(nn == 5, 'Expecting 5 water species') ! Q, QLCN, QLLS, QICN, QILS
-    end select
-    endif !nwat > 0
-
- ! Include any additional tracers
-
-    select case (FV_Atm(1)%flagstruct%nwat)
-    case (0)
-       do n=1,STATE%GRID%NQ
-         if (fv_first_run) call WRITE_PARALLEL( trim('--'//STATE%VARS%TRACER(n)%TNAME) )
-         nn = nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
-         else
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
-         endif
-       enddo
-    case (1)
-       do n=1,STATE%GRID%NQ
-         if ( (TRIM(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QILS'    ) ) then
-           if (fv_first_run) call WRITE_PARALLEL( trim('--'//STATE%VARS%TRACER(n)%TNAME) )
-           nn=nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       enddo
-    case (3:4)
-       do n=1,STATE%GRID%NQ
-         if ( (TRIM(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'CLLS'    ) ) then
-           if (fv_first_run) call WRITE_PARALLEL( trim('--'//STATE%VARS%TRACER(n)%TNAME) )
-           nn=nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       enddo
-    case (6:7)
-       do n=1,STATE%GRID%NQ
-         if ( (TRIM(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'CLLS'    ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QRAIN'   ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QSNOW'   ) .and. &
-              (TRIM(state%vars%tracer(n)%tname) /= 'QGRAUPEL') ) then
-           if (fv_first_run) call WRITE_PARALLEL( trim('--'//STATE%VARS%TRACER(n)%TNAME) )
-           nn=nn+1
-           if (state%vars%tracer(n)%is_r4) then
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
-           else
-              FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
-           endif
-         endif
-       enddo
-    end select
-    write (STRING, "(I3.3,' /= ',I3.3)") nn, FV_Atm(1)%ncnst
-    _ASSERT(nn == FV_Atm(1)%ncnst, 'nn /= ncnst: '//trim(STRING))
-
-  else
-
-    if (fv_first_run .and. (mpp_pe()==0)) print*, 'Running In Adiabatic Mode'
-
-   ! Report total number and names of advected tracers
-      if (fv_first_run .and. STATE%GRID%NQ > 0) then
-         write(STRING,'(A,I5,A)') "FV3 is Advecting the following ", STATE%GRID%NQ, " tracers:"
-         call WRITE_PARALLEL( trim(STRING)   )
+         deallocate( FV_Atm(1)%q )
+         allocate  ( FV_Atm(1)%q(isd:ied  ,jsd:jed  ,npz, FV_Atm(1)%ncnst) )
+         call echo_fv3_setup()
       endif
-   ! Advect all tracers
-      do n=1,STATE%GRID%NQ
-         if (fv_first_run) call WRITE_PARALLEL( trim(STATE%VARS%TRACER(n)%TNAME) )
-         nn = nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
-         else
-            FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
+
+      select case ( FV_Atm(1)%flagstruct%nwat )
+         ! Assign Tracer Indices for FV3
+      case (6:7)
+         sphu = 1
+         qliq = 2
+         qice = 3
+         rain = 4
+         snow = 5
+         grpl = 6
+         qcld = 7
+      case (3:4)
+         sphu = 1
+         qliq = 2
+         qice = 3
+         qcld = 4
+      case (1)
+         sphu = 1
+         ! Advect as split CN/LS species
+         qlcn = 2
+         qlls = 3
+         qicn = 4
+         qils = 5
+      end select
+
+      allocate ( cnvfrc(isc:iec,jsc:jec,npz) )
+      cnvfrc = 0.0
+
+      ! Pull Tracers
+      nn = 0
+      if (.not. ADIABATIC) then
+         select case ( FV_Atm(1)%flagstruct%nwat )
+         case (0)
+            _ASSERT(FV_Atm(1)%ncnst == state%grid%NQ, 'needs informative message')
+         case (1)
+            _ASSERT(FV_Atm(1)%ncnst >= 5, 'needs informative message')
+         case (3:4)
+            _ASSERT(FV_Atm(1)%ncnst >= 4, 'needs informative message')
+         case (6:7)
+            _ASSERT(FV_Atm(1)%ncnst >= 7, 'needs informative message')
+         end select
+         ! Report total number and names of advected tracers
+         if (fv_first_run .and. FV_Atm(1)%ncnst > 0) then
+            write(STRING,'(A,I5,A)') "FV3 is Advecting the following ", FV_Atm(1)%ncnst, " tracers:"
+            call WRITE_PARALLEL( trim(STRING)   )
          endif
-      enddo
-      _ASSERT(nn == FV_Atm(1)%ncnst, 'needs informative message')
+         FV_Atm(1)%q(:,:,:,:) = 0.0
+         if (FV_Atm(1)%flagstruct%nwat > 0) then
+            do n=1,state%grid%NQ
+               if (trim(state%vars%tracer(n)%tname) == 'Q') then
+                  if (sphu /= -1) then ! SPHU
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     SPHU_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QLCN') then
+                  if (qliq /= -1) then ! QLIQ
+                     if (fv_first_run) call WRITE_PARALLEL( trim('QLIQ') )
+                     QLIQ_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  elseif (qlcn /= -1) then
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     QLCN_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QLLS') then
+                  if (qliq /= -1) then ! QLIQ
+                     QLIQ_FILLED = .TRUE.
+                     ! nn increment already handled in QLLS
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) + state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  elseif (qlls /= -1) then
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     QLLS_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QICN') then
+                  if (qice /= -1) then ! QICE
+                     if (fv_first_run) call WRITE_PARALLEL( trim('QICE') )
+                     QICE_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  elseif (qicn /= -1) then
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     QICN_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QILS') then
+                  if (qice /= -1) then ! QICE
+                     QICE_FILLED = .TRUE.
+                     ! nn increment already handled in QICN
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) + state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  elseif (qils /= -1) then
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     QILS_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+               ! Extra species for 6-phase microphysics
+               if ((rain /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QRAIN')) then
+                  if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                  RAIN_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain) = state%vars%tracer(n)%content_r4(:,:,:)
+                  else
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain) = state%vars%tracer(n)%content(:,:,:)
+                  endif
+               endif
+               if ((snow /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QSNOW')) then
+                  if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                  SNOW_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow) = state%vars%tracer(n)%content_r4(:,:,:)
+                  else
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow) = state%vars%tracer(n)%content(:,:,:)
+                  endif
+               endif
+               if ((grpl /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QGRAUPEL')) then
+                  if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                  GRPL_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl) = state%vars%tracer(n)%content_r4(:,:,:)
+                  else
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl) = state%vars%tracer(n)%content(:,:,:)
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'CLCN') then
+                  if (qcld /= -1) then ! QCLD
+                     if (fv_first_run) call WRITE_PARALLEL( trim('QCLD') )
+                     QCLD_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        cnvfrc  = state%vars%tracer(n)%content_r4(:,:,:)
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        cnvfrc  = state%vars%tracer(n)%content_r4(:,:,:)
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  elseif (clcn /= -1) then
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     CLCN_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'CLLS') then
+                  if (qcld /= -1) then ! QCLD
+                     QCLD_FILLED = .TRUE.
+                     ! nn increment already handled in CLCN
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) + state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  elseif (clls /= -1) then
+                     if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+                     CLLS_FILLED = .TRUE.
+                     nn = nn+1
+                     if (state%vars%tracer(n)%is_r4) then
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls) = state%vars%tracer(n)%content_r4(:,:,:)
+                     else
+                        FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls) = state%vars%tracer(n)%content(:,:,:)
+                     endif
+                  endif
+               endif
+            enddo
+            ! Verify
+            select case (FV_Atm(1)%flagstruct%nwat)
+            case (6:7)
+               do k=1,npz
+                  do j=jsc,jec
+                     do i=isc,iec
+                        if (FV_Atm(1)%q(i,j,k,qcld) > 0.0) &
+                             cnvfrc(i,j,k) = cnvfrc(i,j,k)/FV_Atm(1)%q(i,j,k,qcld)
+                     enddo
+                  enddo
+               enddo
+               _ASSERT(SPHU_FILLED, 'SPHU Not Filled')
+               _ASSERT(QLIQ_FILLED, 'QLIQ Not Filled')
+               _ASSERT(QICE_FILLED, 'QICE Not Filled')
+               _ASSERT(RAIN_FILLED, 'RAIN Not Filled')
+               _ASSERT(SNOW_FILLED, 'SNOW Not Filled')
+               _ASSERT(GRPL_FILLED, 'GRPL Not Filled')
+               _ASSERT(QCLD_FILLED, 'QCLD Not Filled')
+               _ASSERT(nn == 7, 'Expecting 7 water species') ! Q, QRAIN, QSNOW, QGRAUPEL, QLIQ, QICE, QCLD
+            case (3:4)
+               do k=1,npz
+                  do j=jsc,jec
+                     do i=isc,iec
+                        if (FV_Atm(1)%q(i,j,k,qcld) > 0.0) &
+                             cnvfrc(i,j,k) = cnvfrc(i,j,k)/FV_Atm(1)%q(i,j,k,qcld)
+                     enddo
+                  enddo
+               enddo
+               _ASSERT(SPHU_FILLED, 'SPHU Not Filled')
+               _ASSERT(QLIQ_FILLED, 'QLIQ Not Filled')
+               _ASSERT(QICE_FILLED, 'QICE Not Filled')
+               _ASSERT(QCLD_FILLED, 'QCLD Not Filled')
+               _ASSERT(nn == 4, 'Expecting 4 water species') ! Q, QLIQ, QICE
+            case (1)
+               _ASSERT(SPHU_FILLED, 'SPHU Not Filled')
+               _ASSERT(QLCN_FILLED, 'QLCN Not Filled')
+               _ASSERT(QLLS_FILLED, 'QLLS Not Filled')
+               _ASSERT(QICN_FILLED, 'QICN Not Filled')
+               _ASSERT(QILS_FILLED, 'QILS Not Filled')
+               _ASSERT(nn == 5, 'Expecting 5 water species') ! Q, QLCN, QLLS, QICN, QILS
+            end select
+         endif !nwat > 0
 
-  endif
+         ! Include any additional tracers
 
-    myDT = state%dt
+         select case (FV_Atm(1)%flagstruct%nwat)
+         case (0)
+            do n=1,state%grid%NQ
+               if (fv_first_run) call WRITE_PARALLEL( trim('--'//state%VARS%TRACER(n)%TNAME) )
+               nn = nn+1
+               if (state%vars%tracer(n)%is_r4) then
+                  FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
+               else
+                  FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
+               endif
+            enddo
+         case (1)
+            do n=1,state%grid%NQ
+               if ( (trim(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QILS'    ) ) then
+                  if (fv_first_run) call WRITE_PARALLEL( trim('--'//state%VARS%TRACER(n)%TNAME) )
+                  nn=nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
+                  else
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
+                  endif
+               endif
+            enddo
+         case (3:4)
+            do n=1,state%grid%NQ
+               if ( (trim(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLLS'    ) ) then
+                  if (fv_first_run) call WRITE_PARALLEL( trim('--'//state%VARS%TRACER(n)%TNAME) )
+                  nn=nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
+                  else
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
+                  endif
+               endif
+            enddo
+         case (6:7)
+            do n=1,state%grid%NQ
+               if ( (trim(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QRAIN'   ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QSNOW'   ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QGRAUPEL') ) then
+                  if (fv_first_run) call WRITE_PARALLEL( trim('--'//state%VARS%TRACER(n)%TNAME) )
+                  nn=nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
+                  else
+                     FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
+                  endif
+               endif
+            enddo
+         end select
+         write (STRING, "(I3.3,' /= ',I3.3)") nn, FV_Atm(1)%ncnst
+         _ASSERT(nn == FV_Atm(1)%ncnst, 'nn /= ncnst: '//trim(STRING))
+         
+      else
 
-    elapsed_time = elapsed_time + myDT
+         if (fv_first_run .and. (mpp_pe()==0)) print*, 'Running In Adiabatic Mode'
+         
+         ! Report total number and names of advected tracers
+         if (fv_first_run .and. state%grid%NQ > 0) then
+            write(STRING,'(A,I5,A)') "FV3 is Advecting the following ", state%grid%NQ, " tracers:"
+            call WRITE_PARALLEL( trim(STRING)   )
+         endif
+         ! Advect all tracers
+         do n=1,state%grid%NQ
+            if (fv_first_run) call WRITE_PARALLEL( trim(state%VARS%TRACER(n)%TNAME) )
+            nn = nn+1
+            if (state%vars%tracer(n)%is_r4) then
+               FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content_r4(:,:,:)
+            else
+               FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn) = state%vars%tracer(n)%content(:,:,:)
+            endif
+         enddo
+         _ASSERT(nn == FV_Atm(1)%ncnst, 'needs informative message')
 
-    if (DEBUG) call debug_fv_state('Before Dynamics Execution',STATE)
+      endif ! not adiabatic
 
-! Update FV with Internal State
-    call State_To_FV( STATE )
+      myDT = state%dt
 
-    ! Query for PSDRY from AGCM.rc and set to MAPL_PSDRY if not found
-    call MAPL_GetResource( MAPL, massD0, 'PSDRY:', default=MAPL_PSDRY, RC=STATUS )
-    VERIFY_(STATUS)
-    FV_Atm(1)%flagstruct%dry_mass = massD0
+      elapsed_time = elapsed_time + myDT
 
-    if (fv_first_run) then
-     ! Make_NH
-      if ( .not. FV_Atm(1)%flagstruct%hydrostatic ) then
-        if (all(FV_Atm(1)%w(isc:iec,jsc:jec,:) == 0.0)) FV_Atm(1)%flagstruct%Make_NH = .true.
-        if ( FV_Atm(1)%flagstruct%Make_NH ) then
-          if (FV_Atm(1)%flagstruct%na_init == 0) FV_Atm(1)%flagstruct%na_init = max(1,CEILING(900/myDT))
-          if (mpp_pe()==0) print*, 'fv_first_run: FV3 is making Non-Hydrostatic W and DZ'
-          if (mpp_pe()==0) print*, '              FV3 will run fwd-bck restart for NH spinup'
-          FV_Atm(1)%w = 0.0
-          call p_var(FV_Atm(1)%npz,         isc,         iec,       jsc,     jec,  FV_Atm(1)%ptop,     ptop_min,  &
-                     FV_Atm(1)%delp, FV_Atm(1)%delz, FV_Atm(1)%pt, FV_Atm(1)%ps, FV_Atm(1)%pe,  FV_Atm(1)%peln,   &
-                     FV_Atm(1)%pk,   FV_Atm(1)%pkz, kappa, FV_Atm(1)%q, FV_Atm(1)%ng, &
-                     FV_Atm(1)%ncnst, FV_Atm(1)%gridstruct%area_64, FV_Atm(1)%flagstruct%dry_mass,  &
-                     FV_Atm(1)%flagstruct%adjust_dry_mass,  FV_Atm(1)%flagstruct%mountain, &
-                     FV_Atm(1)%flagstruct%moist_phys,  FV_Atm(1)%flagstruct%hydrostatic, &
-                     FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%domain, FV_Atm(1)%flagstruct%make_nh)
-          FV_Atm(1)%flagstruct%Make_NH=.false.
-        endif
-      endif
-     ! Mark FV setup complete
-      fv_first_run = .false.
-    endif
+      if (DEBUG) call debug_fv_state('Before Dynamics Execution',state)
 
-! Check Dry Mass (Apply fixer is option is enabled)
-   if ( check_mass .OR. fix_mass ) then
-      ! call MAPL_TimerOn(MAPL,"--MASS_FIX")
+      ! Update FV with Internal State
+      call State_To_FV( state )
 
-      if ( FV_Atm(1)%flagstruct%adjust_dry_mass .AND. &
-            ((.not. FV_Atm(1)%flagstruct%hydrostatic) .OR. FV_Atm(1)%flagstruct%nwat>=6)  ) then
+      ! Query for PSDRY from AGCM.rc and set to MAPL_PSDRY if not found
+      call MAPL_GridCompGetResource(gc, "PSDRY", massD0, default=MAPL_PSDRY, _RC)
+      FV_Atm(1)%flagstruct%dry_mass = massD0
 
-         call p_var(FV_Atm(1)%npz,         isc,         iec,       jsc,     jec,  FV_Atm(1)%ptop,     ptop_min,  &
-                    FV_Atm(1)%delp, FV_Atm(1)%delz, FV_Atm(1)%pt, FV_Atm(1)%ps, FV_Atm(1)%pe,  FV_Atm(1)%peln,   &
+      if (fv_first_run) then
+         ! Make_NH
+         if ( .not. FV_Atm(1)%flagstruct%hydrostatic ) then
+            if (all(FV_Atm(1)%w(isc:iec,jsc:jec,:) == 0.0)) FV_Atm(1)%flagstruct%Make_NH = .true.
+            if ( FV_Atm(1)%flagstruct%Make_NH ) then
+               if (FV_Atm(1)%flagstruct%na_init == 0) FV_Atm(1)%flagstruct%na_init = max(1,CEILING(900/myDT))
+               if (mpp_pe()==0) print*, 'fv_first_run: FV3 is making Non-Hydrostatic W and DZ'
+               if (mpp_pe()==0) print*, '              FV3 will run fwd-bck restart for NH spinup'
+               FV_Atm(1)%w = 0.0
+               call p_var( &
+                    FV_Atm(1)%npz,         isc,         iec,       jsc,     jec,  FV_Atm(1)%ptop,     ptop_min, &
+                    FV_Atm(1)%delp, FV_Atm(1)%delz, FV_Atm(1)%pt, FV_Atm(1)%ps, FV_Atm(1)%pe,  FV_Atm(1)%peln, &
                     FV_Atm(1)%pk,   FV_Atm(1)%pkz, kappa, FV_Atm(1)%q, FV_Atm(1)%ng, &
                     FV_Atm(1)%ncnst, FV_Atm(1)%gridstruct%area_64, FV_Atm(1)%flagstruct%dry_mass,  &
                     FV_Atm(1)%flagstruct%adjust_dry_mass,  FV_Atm(1)%flagstruct%mountain, &
                     FV_Atm(1)%flagstruct%moist_phys,  FV_Atm(1)%flagstruct%hydrostatic, &
                     FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%domain, FV_Atm(1)%flagstruct%make_nh)
-
-      else
-
-      allocate ( mass(isc:iec,jsc:jec))
-      allocate (tqtot(isc:iec,jsc:jec))
-      do j=jsc,jec
-         do i=isc,iec
-            mass(i,j) = FV_Atm(1)%pe(i,npz+1,j)
-         enddo
-      enddo
-      tqtot = 0.0
-      if ( (.not. ADIABATIC) .AND. (FV_Atm(1)%flagstruct%nwat /= 0) ) then
-       if (FV_Atm(1)%flagstruct%nwat >= 6) then
-         do k=1,npz
-            tqtot(:,:) = tqtot(:,:) + ( &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qice) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,rain) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,snow) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,grpl) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
-         enddo
-       elseif (FV_Atm(1)%flagstruct%nwat == 3) then
-         do k=1,npz
-            tqtot(:,:) = tqtot(:,:) + ( &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qice) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
-         enddo
-       else
-         do k=1,npz
-            tqtot(:,:) = tqtot(:,:) + ( &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qlcn) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qlls) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qicn) + &
-            FV_Atm(1)%q(isc:iec,jsc:jec,k,qils) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
-         enddo
-       endif
+               FV_Atm(1)%flagstruct%Make_NH=.false.
+            endif
+         endif
+         ! Mark FV setup complete
+         fv_first_run = .false.
       endif
 
-      massD = g_sum(FV_Atm(1)%domain, mass-tqtot, isc, iec, jsc, jec, state%grid%ng, &
-                    fv_atm(1)%gridstruct%area_64, 1, reproduce=FV_Atm(1)%flagstruct%exact_sum)
+      ! Check Dry Mass (Apply fixer is option is enabled)
+      if ( check_mass .OR. fix_mass ) then
+         ! call MAPL_TimerOn(MAPL,"--MASS_FIX")
 
-      ! If PSDRY is negative, set to use the incoming drymass.
-      ! NOTE: THIS WILL NOT TIME REGRESS
-      if (massD0 < 0.0d0) then
-         massD0 = massD
-      end if
+         if ( FV_Atm(1)%flagstruct%adjust_dry_mass .AND. &
+              ((.not. FV_Atm(1)%flagstruct%hydrostatic) .OR. FV_Atm(1)%flagstruct%nwat>=6)  ) then
+            call p_var( &
+                 FV_Atm(1)%npz, isc, iec, jsc, jec, FV_Atm(1)%ptop, ptop_min, &
+                 FV_Atm(1)%delp, FV_Atm(1)%delz, FV_Atm(1)%pt, FV_Atm(1)%ps, FV_Atm(1)%pe, FV_Atm(1)%peln, &
+                 FV_Atm(1)%pk, FV_Atm(1)%pkz, kappa, FV_Atm(1)%q, FV_Atm(1)%ng, &
+                 FV_Atm(1)%ncnst, FV_Atm(1)%gridstruct%area_64, FV_Atm(1)%flagstruct%dry_mass,  &
+                 FV_Atm(1)%flagstruct%adjust_dry_mass, FV_Atm(1)%flagstruct%mountain, &
+                 FV_Atm(1)%flagstruct%moist_phys, FV_Atm(1)%flagstruct%hydrostatic, &
+                 FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%domain, FV_Atm(1)%flagstruct%make_nh)
 
-      if(ESMF_AlarmIsRinging(MASSALARM) .AND. check_mass) then
-         if (ABS((massD-massD0)/massD0) >= epsilon(1.0_REAL4)) then
-            if (mpp_pe()==mpp_root_pe()) then
-               write(6,126)
-               write(6,127) massD0
-               write(6,128) massD
-               write(6,129) massD0/massD, (massD-massD0)/massD0
-               126 format('Dry Mass Difference of > epsilon relative found!')
-               127 format('Dry Mass Expected:'2x,g21.14)
-               128 format('Dry Mass Calculated in FV3:'2x,g21.14)
-               129 format('Dry Mass Scaling Factor and Relative Difference'2x,g21.14,2x,g21.14)
-            end if
-         end if
-      end if
+         else
 
-      ! Apply the fixer if asked for
-      if (fix_mass) then
-
-         if (ABS((massD-massD0)/massD0) >= epsilon(1.0_REAL4)) then
-            if (mpp_pe()==mpp_root_pe()) then
-               write(6,119) massD0, massD, massD0/massD, (massD-massD0)/massD0
-               119 format('Dry Mass Violation (epsilon relative)!'2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14)
-            end if
-         end if
-
-         ! Accumulate added dry mass from the fixer
-         massADDED = massADDED + (massD-massD0)/massD0
-
-         ! -----------------------------------------------
-         ! Fix Dry Mass after increments have been applied
-         ! -----------------------------------------------
-         FV_Atm(1)%pe = FV_Atm(1)%pe*massD0/massD
-         if (present(PLE0)) then
-            do k=1,npz
-               PLE0(:,:,k) = FV_Atm(1)%pe(isc:iec,k,jsc:jec)
+            allocate ( mass(isc:iec,jsc:jec))
+            allocate (tqtot(isc:iec,jsc:jec))
+            do j=jsc,jec
+               do i=isc,iec
+                  mass(i,j) = FV_Atm(1)%pe(i,npz+1,j)
+               enddo
             enddo
+            tqtot = 0.0
+            if ( (.not. ADIABATIC) .AND. (FV_Atm(1)%flagstruct%nwat /= 0) ) then
+               if (FV_Atm(1)%flagstruct%nwat >= 6) then
+                  do k=1,npz
+                     tqtot(:,:) = tqtot(:,:) + ( &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qice) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,rain) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,snow) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,grpl) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
+                  enddo
+               elseif (FV_Atm(1)%flagstruct%nwat == 3) then
+                  do k=1,npz
+                     tqtot(:,:) = tqtot(:,:) + ( &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qliq) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qice) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
+                  enddo
+               else
+                  do k=1,npz
+                     tqtot(:,:) = tqtot(:,:) + ( &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,sphu) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qlcn) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qlls) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qicn) + &
+                          FV_Atm(1)%q(isc:iec,jsc:jec,k,qils) ) * FV_Atm(1)%delp(isc:iec,jsc:jec,k)
+                  enddo
+               endif
+            endif
+
+            massD = g_sum(FV_Atm(1)%domain, mass-tqtot, isc, iec, jsc, jec, state%grid%ng, &
+                 fv_atm(1)%gridstruct%area_64, 1, reproduce=FV_Atm(1)%flagstruct%exact_sum)
+
+            ! If PSDRY is negative, set to use the incoming drymass.
+            ! NOTE: THIS WILL NOT TIME REGRESS
+            if (massD0 < 0.0d0) then
+               massD0 = massD
+            end if
+
+            if(ESMF_AlarmIsRinging(MASSALARM) .AND. check_mass) then
+               if (ABS((massD-massD0)/massD0) >= epsilon(1.0_REAL4)) then
+                  if (mpp_pe()==mpp_root_pe()) then
+                     write(6,126)
+                     write(6,127) massD0
+                     write(6,128) massD
+                     write(6,129) massD0/massD, (massD-massD0)/massD0
+126                  format('Dry Mass Difference of > epsilon relative found!')
+127                  format('Dry Mass Expected:'2x,g21.14)
+128                  format('Dry Mass Calculated in FV3:'2x,g21.14)
+129                  format('Dry Mass Scaling Factor and Relative Difference'2x,g21.14,2x,g21.14)
+                  end if
+               end if
+            end if
+
+            ! Apply the fixer if asked for
+            if (fix_mass) then
+
+               if (ABS((massD-massD0)/massD0) >= epsilon(1.0_REAL4)) then
+                  if (mpp_pe()==mpp_root_pe()) then
+                     write(6,119) massD0, massD, massD0/massD, (massD-massD0)/massD0
+119                  format('Dry Mass Violation (epsilon relative)!'2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14)
+                  end if
+               end if
+
+               ! Accumulate added dry mass from the fixer
+               massADDED = massADDED + (massD-massD0)/massD0
+
+               ! -----------------------------------------------
+               ! Fix Dry Mass after increments have been applied
+               ! -----------------------------------------------
+               FV_Atm(1)%pe = FV_Atm(1)%pe*massD0/massD
+               if (present(ple0)) then
+                  do k=1,npz
+                     ple0(:,:,k) = FV_Atm(1)%pe(isc:iec,k,jsc:jec)
+                  enddo
+               endif
+
+               if(ESMF_AlarmIsRinging(MASSALARM) .AND. check_mass) then
+                  if (mpp_pe()==mpp_root_pe()) then
+                     write(6,109) massD0, massD, massD0/massD, (massD-massD0)/massD0, massADDED
+109                  format('Dry Mass Fixer'2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14)
+                  end if
+               end if
+            else
+               ! Check Dry Mass Conservation and write to log
+               if(ESMF_AlarmIsRinging(MASSALARM) .AND. mpp_pe()==mpp_root_pe()) then
+                  write(6,110) massD0, massD, massD0/massD, (massD-massD0)/massD0
+               end if
+110            format('Dry Mass Check'2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14)
+            endif
+
+            deallocate (mass)
+            deallocate (tqtot)
+
          endif
 
-         if(ESMF_AlarmIsRinging(MASSALARM) .AND. check_mass) then
-            if (mpp_pe()==mpp_root_pe()) then
-               write(6,109) massD0, massD, massD0/massD, (massD-massD0)/massD0, massADDED
-               109    format('Dry Mass Fixer'2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14)
-            end if
-         end if
-      else
-         ! Check Dry Mass Conservation and write to log
-         if(ESMF_AlarmIsRinging(MASSALARM) .AND. mpp_pe()==mpp_root_pe()) write(6,110) massD0, massD, massD0/massD, (massD-massD0)/massD0
-         110    format('Dry Mass Check'2x,g21.14,2x,g21.14,2x,g21.14,2x,g21.14)
+         ! call MAPL_TimerOff(MAPL,"--MASS_FIX")
       endif
 
-      deallocate (mass)
-      deallocate (tqtot)
-
+      ! call MAPL_TimerOn(MAPL,"--NH_ADIABATIC_INIT")
+      if ((.not. FV_Atm(1)%flagstruct%hydrostatic) .and. (FV_Atm(1)%flagstruct%na_init>0)) then
+         allocate( DEBUG_ARRAY(isc:iec,jsc:jec,NPZ) )
+         call nullify_domain ( )
+         DEBUG_ARRAY(:,:,1:npz) = FV_Atm(1)%w(isc:iec,jsc:jec,:)
+         call prt_maxmin('Before adiabatic_init W: ', DEBUG_ARRAY, isc, iec, jsc, jec, 0, npz, fac1   )
+         call adiabatic_init(myDT,DEBUG_ARRAY,fac1)
+         DEBUG_ARRAY(:,:,1:npz) = FV_Atm(1)%w(isc:iec,jsc:jec,:)
+         call prt_maxmin('After adiabatic_init W: ', DEBUG_ARRAY, isc, iec, jsc, jec, 0, npz, fac1   )
+         deallocate( DEBUG_ARRAY )
+         FV_Atm(1)%flagstruct%na_init=0
       endif
+      ! call MAPL_TimerOff(MAPL,"--NH_ADIABATIC_INIT")
 
-      ! call MAPL_TimerOff(MAPL,"--MASS_FIX")
-   endif
-
-    ! call MAPL_TimerOn(MAPL,"--NH_ADIABATIC_INIT")
-       if ((.not. FV_Atm(1)%flagstruct%hydrostatic) .and. (FV_Atm(1)%flagstruct%na_init>0)) then
-          allocate( DEBUG_ARRAY(isc:iec,jsc:jec,NPZ) )
-          call nullify_domain ( )
-          DEBUG_ARRAY(:,:,1:npz) = FV_Atm(1)%w(isc:iec,jsc:jec,:)
-          call prt_maxmin('Before adiabatic_init W: ', DEBUG_ARRAY, isc, iec, jsc, jec, 0, npz, fac1   )
-          call adiabatic_init(myDT,DEBUG_ARRAY,fac1)
-          DEBUG_ARRAY(:,:,1:npz) = FV_Atm(1)%w(isc:iec,jsc:jec,:)
-          call prt_maxmin('After adiabatic_init W: ', DEBUG_ARRAY, isc, iec, jsc, jec, 0, npz, fac1   )
-          deallocate( DEBUG_ARRAY )
-          FV_Atm(1)%flagstruct%na_init=0
-       endif
-    ! call MAPL_TimerOff(MAPL,"--NH_ADIABATIC_INIT")
-
-    ! call MAPL_TimerOn(MAPL,"--FV_DYNAMICS")
-    if (.not. FV_OFF) then
-    call set_domain(FV_Atm(1)%domain)  ! needed for diagnostic output done in fv_dynamics
-    allocate ( u_dt(isc:iec,jsc:jec,npz) )
-    allocate ( v_dt(isc:iec,jsc:jec,npz) )
-    allocate ( t_dt(isc:iec,jsc:jec,npz) )
-    allocate ( w_dt(isc:iec,jsc:jec,npz) )
-    u_dt(:,:,:) = 0.0
-    v_dt(:,:,:) = 0.0
-    t_dt(:,:,:) = 0.0
-    w_dt(:,:,:) = 0.0
-
-#ifdef RUN_GTFV3
-    if (run_gtfv3 == 0) then
-       call cpu_time(start)
-#endif
-       if (FV3_QSPLIT == 0) FV3_QSPLIT = FV_Atm(1)%flagstruct%q_split
-       call fv_dynamics( &
-            FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%ncnst, FV_Atm(1)%ng, myDT, &
-            FV_Atm(1)%flagstruct%consv_te, FV_Atm(1)%flagstruct%fill, &
-            kappa, cp, zvir, &
-            FV_Atm(1)%ptop, FV_Atm(1)%ks, FV_Atm(1)%flagstruct%ncnst, &
-            state%ksplit, state%nsplit, FV3_QSPLIT, &
-            FV_Atm(1)%u, FV_Atm(1)%v, FV_Atm(1)%w, FV_Atm(1)%delz, &
-            FV_Atm(1)%flagstruct%hydrostatic, &
-            FV_Atm(1)%pt, FV_Atm(1)%delp, FV_Atm(1)%q, &
-            FV_Atm(1)%ps, FV_Atm(1)%pe, FV_Atm(1)%pk, FV_Atm(1)%peln, FV_Atm(1)%pkz, &
-            FV_Atm(1)%phis, FV_Atm(1)%varflt, FV_Atm(1)%q_con, FV_Atm(1)%omga, &
-            FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%uc, FV_Atm(1)%vc, &
-            FV_Atm(1)%ak, FV_Atm(1)%bk, &
-            FV_Atm(1)%mfx, FV_Atm(1)%mfy, FV_Atm(1)%cx, FV_Atm(1)%cy, &
-            FV_Atm(1)%ze0, FV_Atm(1)%flagstruct%hybrid_z, FV_Atm(1)%gridstruct, FV_Atm(1)%flagstruct, &
-            FV_Atm(1)%neststruct, FV_Atm(1)%idiag, FV_Atm(1)%bd, FV_Atm(1)%parent_grid, FV_Atm(1)%domain, &
-            FV_Atm(1)%diss_est, u_dt, v_dt, w_dt, t_dt, &
-            time_total)
-#ifdef RUN_GTFV3
-       call cpu_time(finish)
-       if (rank == 0) print *, '0: fv_dynamics: time taken = ', finish - start, 's'
-    else
-       call cpu_time(start)
-       call geos_gtfv3_interface_f( &
-            comm, &
-            FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%flagstruct%ntiles, &
-            FV_Atm(1)%bd%is, FV_Atm(1)%bd%ie, FV_Atm(1)%bd%js, FV_Atm(1)%bd%je, &
-            isd, ied, jsd, jed, &
-            myDT, 7, FV_Atm(1)%ng, FV_Atm(1)%ptop, FV_Atm(1)%ks, &
-            FV_Atm(1)%layout(1), FV_Atm(1)%layout(2), adiabatic, &
-            ! input/output
-            FV_Atm(1)%u, FV_Atm(1)%v, FV_Atm(1)%w, FV_Atm(1)%delz, &
-            FV_Atm(1)%pt, FV_Atm(1)%delp, FV_Atm(1)%q(:,:,:,1:7), &
-            FV_Atm(1)%ps, FV_Atm(1)%pe, FV_Atm(1)%pk, FV_Atm(1)%peln, FV_Atm(1)%pkz, &
-            FV_Atm(1)%phis, FV_Atm(1)%q_con, FV_Atm(1)%omga, &
-            FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%uc, FV_Atm(1)%vc, &
-            ! input
-            FV_Atm(1)%ak, FV_Atm(1)%bk, &
-            ! input/output
-            FV_Atm(1)%mfx, FV_Atm(1)%mfy, FV_Atm(1)%cx, FV_Atm(1)%cy, FV_Atm(1)%diss_est)
-       call cpu_time(finish)
-       print *, rank, ', geos_gtfv3_interface_f: time taken = ', finish - start, 's'
-    end if
-#endif
-
-    allocate ( udt(isc:iec,jsc:jec,npz) )
-    allocate ( vdt(isc:iec,jsc:jec,npz) )
-    ! go from native D-Grid tendencies to A-grid rotated exports
-    call fv_getAllWinds(u_dt, v_dt, ur=udt, vr=vdt)
-    call MAPL_GetPointer ( export, PTR3D, 'DUDT_RAY', rc=status ); VERIFY_(STATUS)
-    if( associated(PTR3D) ) PTR3D = udt
-    call MAPL_GetPointer ( export, PTR3D, 'DVDT_RAY', rc=status ); VERIFY_(STATUS)
-    if( associated(PTR3D) ) PTR3D = vdt
-    deallocate ( udt )
-    deallocate ( vdt )
-    call MAPL_GetPointer ( export, PTR3D, 'DTDT_RAY', rc=status ); VERIFY_(STATUS)
-    if( associated(PTR3D) ) PTR3D = t_dt
-    call MAPL_GetPointer ( export, PTR3D, 'DWDT_RAY', rc=status ); VERIFY_(STATUS)
-    if( associated(PTR3D) ) PTR3D = w_dt
-
-    if ( FV_Atm(1)%flagstruct%fv_sg_adj > 0 ) then
+      ! call MAPL_TimerOn(MAPL,"--FV_DYNAMICS")
+      if (.not. FV_OFF) then
+         call set_domain(FV_Atm(1)%domain)  ! needed for diagnostic output done in fv_dynamics
+         allocate ( u_dt(isc:iec,jsc:jec,npz) )
+         allocate ( v_dt(isc:iec,jsc:jec,npz) )
+         allocate ( t_dt(isc:iec,jsc:jec,npz) )
+         allocate ( w_dt(isc:iec,jsc:jec,npz) )
          u_dt(:,:,:) = 0.0
          v_dt(:,:,:) = 0.0
          t_dt(:,:,:) = 0.0
          w_dt(:,:,:) = 0.0
-         call fv_subgrid_z(isd, ied, jsd, jed, isc, iec, jsc, jec, FV_Atm(1)%npz, &
-                           FV_Atm(1)%ncnst, myDT, FV_Atm(1)%flagstruct%fv_sg_adj,      &
-                           FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%delp, FV_Atm(1)%pe,     &
-                           FV_Atm(1)%peln, FV_Atm(1)%pkz, FV_Atm(1)%pt, FV_Atm(1)%q,       &
-                           FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%flagstruct%hydrostatic,&
-                           FV_Atm(1)%w, FV_Atm(1)%delz, u_dt, v_dt, t_dt, w_dt,          &
-                           FV_Atm(1)%flagstruct%n_zfilter)
-        call MAPL_GetPointer ( export, PTR3D, 'DUDTSUBZ', rc=status ); VERIFY_(STATUS)
-        if( associated(PTR3D) ) PTR3D = u_dt
-        call MAPL_GetPointer ( export, PTR3D, 'DVDTSUBZ', rc=status ); VERIFY_(STATUS)
-        if( associated(PTR3D) ) PTR3D = v_dt
-        call MAPL_GetPointer ( export, PTR3D, 'DTDTSUBZ', rc=status ); VERIFY_(STATUS)
-        if( associated(PTR3D) ) PTR3D = t_dt
-        call MAPL_GetPointer ( export, PTR3D, 'DWDTSUBZ', rc=status ); VERIFY_(STATUS)
-        if( associated(PTR3D) ) PTR3D = w_dt
-    endif
-    deallocate ( u_dt )
-    deallocate ( v_dt )
-    deallocate ( t_dt )
-    deallocate ( w_dt )
 
-    call nullify_domain()
-
-    endif
-    ! call MAPL_TimerOff(MAPL,"--FV_DYNAMICS")
-
-  SPHU_FILLED = .FALSE.
-  QLIQ_FILLED = .FALSE.
-  QICE_FILLED = .FALSE.
-  RAIN_FILLED = .FALSE.
-  SNOW_FILLED = .FALSE.
-  GRPL_FILLED = .FALSE.
-  QCLD_FILLED = .FALSE.
-  QLLS_FILLED = .FALSE.
-  QLCN_FILLED = .FALSE.
-  QILS_FILLED = .FALSE.
-  QICN_FILLED = .FALSE.
-  CLLS_FILLED = .FALSE.
-  CLCN_FILLED = .FALSE.
-
- ! Push Tracers
-  nn = 0
-  if (.not. ADIABATIC) then
-
-     do n=1,STATE%GRID%NQ
-
-       if ((sphu /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'Q')) then
-          SPHU_FILLED = .TRUE.
-          nn = nn+1
-          if (state%vars%tracer(n)%is_r4) then
-             state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu)
-          else
-             state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu)
-          endif
-       endif
-    ! QLIQ
-       if (qliq /= -1) then
-         if (TRIM(state%vars%tracer(n)%tname) == 'QLCN') then
-            QLCN_FILLED = .TRUE.
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * cnvfrc
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * cnvfrc
-            endif
-         endif
-         if (TRIM(state%vars%tracer(n)%tname) == 'QLLS') then
-            QLLS_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * (1.0-cnvfrc)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * (1.0-cnvfrc)
-            endif
-         endif
-       else
-         if ((qlcn /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QLCN')) then
-            QLCN_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn)
-            endif
-         endif
-         if ((qlls /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QLLS')) then
-            QLLS_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls)
-            endif
-          endif
-       endif
-    ! QICE
-       if (qice /= -1) then
-         if (TRIM(state%vars%tracer(n)%tname) == 'QICN') then
-            QICN_FILLED = .TRUE.
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * cnvfrc
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * cnvfrc
-            endif
-       endif
-         if (TRIM(state%vars%tracer(n)%tname) == 'QILS') then
-            QILS_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * (1.0-cnvfrc)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * (1.0-cnvfrc)
-            endif
-         endif
-       else
-         if (TRIM(state%vars%tracer(n)%tname) == 'QICN') then
-            QICN_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn)
-            endif
-         endif
-         if (TRIM(state%vars%tracer(n)%tname) == 'QILS') then
-            QILS_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils)
-            endif
-         endif
-       endif
-    ! QCLD
-       if (qcld /= -1) then
-         if (TRIM(state%vars%tracer(n)%tname) == 'CLCN') then
-            CLCN_FILLED = .TRUE.
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * cnvfrc
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * cnvfrc
-            endif
-         endif
-         if (TRIM(state%vars%tracer(n)%tname) == 'CLLS') then
-            CLLS_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * (1.0-cnvfrc)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * (1.0-cnvfrc)
-            endif
-         endif
-       else
-         if ((clcn /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'CLCN')) then
-            CLCN_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn)
-            endif
-         endif
-         if ((clls /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'CLLS')) then
-            CLLS_FILLED = .TRUE.
-            nn = nn+1
-            if (state%vars%tracer(n)%is_r4) then
-               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls)
-            else
-                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls)
-            endif
-         endif
-       endif
-    ! RAIN
-       if ((rain /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QRAIN')) then
-          RAIN_FILLED = .TRUE.
-          nn = nn+1
-          if (state%vars%tracer(n)%is_r4) then
-             state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain)
-          else
-                state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain)
-          endif
-       endif
-    ! SNOW
-       if ((snow /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QSNOW')) then
-          SNOW_FILLED = .TRUE.
-          nn = nn+1
-          if (state%vars%tracer(n)%is_r4) then
-             state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow)
-          else
-                state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow)
-          endif
-       endif
-     ! GRPL
-       if ((grpl /= -1) .and. (TRIM(state%vars%tracer(n)%tname) == 'QGRAUPEL')) then
-          GRPL_FILLED = .TRUE.
-          nn = nn+1
-          if (state%vars%tracer(n)%is_r4) then
-             state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl)
-          else
-                state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl)
-          endif
-       endif
-
-     enddo
-
-   ! Verify
-    deallocate ( cnvfrc )
-    select case (FV_Atm(1)%flagstruct%nwat)
-    case (6:7)
-       _ASSERT(SPHU_FILLED, 'SPHU Not Filled Out')
-       _ASSERT(RAIN_FILLED, 'RAIN Not Filled Out')
-       _ASSERT(SNOW_FILLED, 'SNOW Not Filled Out')
-       _ASSERT(GRPL_FILLED, 'GRPL Not Filled Out')
-       _ASSERT(QLCN_FILLED, 'QLCN Not Filled Out')
-       _ASSERT(QLLS_FILLED, 'QLLS Not Filled Out')
-       _ASSERT(QICN_FILLED, 'QICN Not Filled Out')
-       _ASSERT(QILS_FILLED, 'QILS Not Filled Out')
-       _ASSERT(CLCN_FILLED, 'CLCN Not Filled Out')
-       _ASSERT(CLLS_FILLED, 'CLLS Not Filled Out')
-       _ASSERT(nn == 7, 'Expecting 7 water species Out') ! Q, QLIQ, QICE, QCLD, QRAIN, QSNOW, QGRAUPEL
-     case (3:4)
-       _ASSERT(SPHU_FILLED, 'SPHU Not Filled Out')
-       _ASSERT(QLCN_FILLED, 'QLCN Not Filled Out')
-       _ASSERT(QLLS_FILLED, 'QLLS Not Filled Out')
-       _ASSERT(QICN_FILLED, 'QICN Not Filled Out')
-       _ASSERT(QILS_FILLED, 'QILS Not Filled Out')
-       _ASSERT(CLCN_FILLED, 'CLCN Not Filled Out')
-       _ASSERT(CLLS_FILLED, 'CLLS Not Filled Out')
-       _ASSERT(nn == 4, 'Expecting 4 water species Out') ! Q, QLIQ, QICE
-    case (1)
-      _ASSERT(SPHU_FILLED, 'SPHU Not Filled Out')
-      _ASSERT(QLCN_FILLED, 'QLCN Not Filled Out')
-      _ASSERT(QLLS_FILLED, 'QLLS Not Filled Out')
-      _ASSERT(QICN_FILLED, 'QICN Not Filled Out')
-      _ASSERT(QILS_FILLED, 'QILS Not Filled Out')
-      _ASSERT(nn == 5, 'Expecting 5 water species Out') ! Q, QLCN, QLLS, QICN, QILS
-    end select
-
-! Include additional tracers
-
-    select case(FV_Atm(1)%flagstruct%nwat)
-      case (0)
-       do n=1,STATE%GRID%NQ
-         nn=nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+#ifdef RUN_GTFV3
+         if (run_gtfv3 == 0) then
+            call cpu_time(start)
+#endif
+            if (FV3_QSPLIT == 0) FV3_QSPLIT = FV_Atm(1)%flagstruct%q_split
+            call fv_dynamics( &
+                 FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%ncnst, FV_Atm(1)%ng, myDT, &
+                 FV_Atm(1)%flagstruct%consv_te, FV_Atm(1)%flagstruct%fill, &
+                 kappa, cp, zvir, &
+                 FV_Atm(1)%ptop, FV_Atm(1)%ks, FV_Atm(1)%flagstruct%ncnst, &
+                 state%ksplit, state%nsplit, FV3_QSPLIT, &
+                 FV_Atm(1)%u, FV_Atm(1)%v, FV_Atm(1)%w, FV_Atm(1)%delz, &
+                 FV_Atm(1)%flagstruct%hydrostatic, &
+                 FV_Atm(1)%pt, FV_Atm(1)%delp, FV_Atm(1)%q, &
+                 FV_Atm(1)%ps, FV_Atm(1)%pe, FV_Atm(1)%pk, FV_Atm(1)%peln, FV_Atm(1)%pkz, &
+                 FV_Atm(1)%phis, FV_Atm(1)%varflt, FV_Atm(1)%q_con, FV_Atm(1)%omga, &
+                 FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%uc, FV_Atm(1)%vc, &
+                 FV_Atm(1)%ak, FV_Atm(1)%bk, &
+                 FV_Atm(1)%mfx, FV_Atm(1)%mfy, FV_Atm(1)%cx, FV_Atm(1)%cy, &
+                 FV_Atm(1)%ze0, FV_Atm(1)%flagstruct%hybrid_z, FV_Atm(1)%gridstruct, FV_Atm(1)%flagstruct, &
+                 FV_Atm(1)%neststruct, FV_Atm(1)%idiag, FV_Atm(1)%bd, FV_Atm(1)%parent_grid, FV_Atm(1)%domain, &
+                 FV_Atm(1)%diss_est, u_dt, v_dt, w_dt, t_dt, &
+                 time_total)
+#ifdef RUN_GTFV3
+            call cpu_time(finish)
+            if (rank == 0) print *, '0: fv_dynamics: time taken = ', finish - start, 's'
          else
-            state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+            call cpu_time(start)
+            call geos_gtfv3_interface_f( &
+                 comm, &
+                 FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%flagstruct%ntiles, &
+                 FV_Atm(1)%bd%is, FV_Atm(1)%bd%ie, FV_Atm(1)%bd%js, FV_Atm(1)%bd%je, &
+                 isd, ied, jsd, jed, &
+                 myDT, 7, FV_Atm(1)%ng, FV_Atm(1)%ptop, FV_Atm(1)%ks, &
+                 FV_Atm(1)%layout(1), FV_Atm(1)%layout(2), adiabatic, &
+                 ! input/output
+                 FV_Atm(1)%u, FV_Atm(1)%v, FV_Atm(1)%w, FV_Atm(1)%delz, &
+                 FV_Atm(1)%pt, FV_Atm(1)%delp, FV_Atm(1)%q(:,:,:,1:7), &
+                 FV_Atm(1)%ps, FV_Atm(1)%pe, FV_Atm(1)%pk, FV_Atm(1)%peln, FV_Atm(1)%pkz, &
+                 FV_Atm(1)%phis, FV_Atm(1)%q_con, FV_Atm(1)%omga, &
+                 FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%uc, FV_Atm(1)%vc, &
+                 ! input
+                 FV_Atm(1)%ak, FV_Atm(1)%bk, &
+                 ! input/output
+                 FV_Atm(1)%mfx, FV_Atm(1)%mfy, FV_Atm(1)%cx, FV_Atm(1)%cy, FV_Atm(1)%diss_est)
+            call cpu_time(finish)
+            print *, rank, ', geos_gtfv3_interface_f: time taken = ', finish - start, 's'
+         end if
+#endif
+
+         allocate ( udt(isc:iec,jsc:jec,npz) )
+         allocate ( vdt(isc:iec,jsc:jec,npz) )
+         ! go from native D-Grid tendencies to A-grid rotated exports
+         call fv_getAllWinds(u_dt, v_dt, ur=udt, vr=vdt)
+         call MAPL_GetPointer(export, ptr3d, "DUDT_RAY", _RC)
+         if( associated(ptr3d) ) ptr3d = udt
+         call MAPL_GetPointer(export, ptr3d, "DVDT_RAY", _RC)
+         if( associated(ptr3d) ) ptr3d = vdt
+         deallocate ( udt )
+         deallocate ( vdt )
+         call MAPL_GetPointer(export, ptr3d, "DTDT_RAY", _RC)
+         if( associated(ptr3d) ) ptr3d = t_dt
+         call MAPL_GetPointer(export, ptr3d, "DWDT_RAY", _RC)
+         if( associated(ptr3d) ) ptr3d = w_dt
+
+         if ( FV_Atm(1)%flagstruct%fv_sg_adj > 0 ) then
+            u_dt(:,:,:) = 0.0
+            v_dt(:,:,:) = 0.0
+            t_dt(:,:,:) = 0.0
+            w_dt(:,:,:) = 0.0
+            call fv_subgrid_z( &
+                 isd, ied, jsd, jed, isc, iec, jsc, jec, FV_Atm(1)%npz, &
+                 FV_Atm(1)%ncnst, myDT, FV_Atm(1)%flagstruct%fv_sg_adj, &
+                 FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%delp, FV_Atm(1)%pe, &
+                 FV_Atm(1)%peln, FV_Atm(1)%pkz, FV_Atm(1)%pt, FV_Atm(1)%q, &
+                 FV_Atm(1)%ua, FV_Atm(1)%va, FV_Atm(1)%flagstruct%hydrostatic, &
+                 FV_Atm(1)%w, FV_Atm(1)%delz, u_dt, v_dt, t_dt, w_dt, &
+                 FV_Atm(1)%flagstruct%n_zfilter)
+            call MAPL_GetPointer(export, ptr3d, "DUDTSUBZ", _RC)
+            if( associated(ptr3d) ) ptr3d = u_dt
+            call MAPL_GetPointer(export, ptr3d, "DVDTSUBZ", _RC)
+            if( associated(ptr3d) ) ptr3d = v_dt
+            call MAPL_GetPointer(export, ptr3d, "DTDTSUBZ", _RC)
+            if( associated(ptr3d) ) ptr3d = t_dt
+            call MAPL_GetPointer(export, ptr3d, "DWDTSUBZ", _RC)
+            if( associated(ptr3d) ) ptr3d = w_dt
          endif
-       enddo
-      case (1)
-       do n=1,STATE%GRID%NQ
-        if ((TRIM(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QILS'    ) ) then
-         nn=nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         else
-            state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         endif
-        endif
-       enddo
-      case (3:4)
-       do n=1,STATE%GRID%NQ
-        if ((TRIM(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'CLLS'    ) ) then
-         nn=nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         else
-            state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         endif
-        endif
-       enddo
-      case (6:7)
-       do n=1,STATE%GRID%NQ
-        if ((TRIM(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'CLLS'    ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QRAIN'   ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QSNOW'   ) .and. &
-            (TRIM(state%vars%tracer(n)%tname) /= 'QGRAUPEL') ) then
-         nn=nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         else
-            state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         endif
-        endif
-       enddo
-      end select
-      write (STRING, "(I3.3,' /= ',I3.3)") nn, FV_Atm(1)%ncnst
-      _ASSERT(nn == FV_Atm(1)%ncnst, 'nn /= ncnst: '//trim(STRING))
+         deallocate ( u_dt )
+         deallocate ( v_dt )
+         deallocate ( t_dt )
+         deallocate ( w_dt )
 
-  else
+         call nullify_domain()
 
-    ! Include all tracers
-      do n=1,STATE%GRID%NQ
-         nn=nn+1
-         if (state%vars%tracer(n)%is_r4) then
-            state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         else
-            state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
-         endif
-      enddo
-      _ASSERT(nn == FV_Atm(1)%ncnst, 'needs informative message')
+      endif
+      ! call MAPL_TimerOff(MAPL,"--FV_DYNAMICS")
 
-  endif
+      SPHU_FILLED = .FALSE.
+      QLIQ_FILLED = .FALSE.
+      QICE_FILLED = .FALSE.
+      RAIN_FILLED = .FALSE.
+      SNOW_FILLED = .FALSE.
+      GRPL_FILLED = .FALSE.
+      QCLD_FILLED = .FALSE.
+      QLLS_FILLED = .FALSE.
+      QLCN_FILLED = .FALSE.
+      QILS_FILLED = .FALSE.
+      QICN_FILLED = .FALSE.
+      CLLS_FILLED = .FALSE.
+      CLCN_FILLED = .FALSE.
 
- ! Clean negative tracers and check
-  if (DEBUG_ADV) then
-    prt_minmax     = DEBUG_ADV
-    if (mpp_pe()==0) print*,''
-    if (mpp_pe()==0) print*,'-------------- FV3 Tracer Debug After DYN --------------'
-    allocate( DEBUG_ARRAY(isc:iec,jsc:jec,npz) )
-    do n=1,STATE%GRID%NQ
-       if (state%vars%tracer(n)%is_r4) then
-          DEBUG_ARRAY(:,:,1:npz) = state%vars%tracer(n)%content_r4
-       else
-          DEBUG_ARRAY(:,:,1:npz) = state%vars%tracer(n)%content
-       endif
-       call prt_maxmin(TRIM(state%vars%tracer(n)%tname), DEBUG_ARRAY, isc, iec, jsc, jec, 0, npz, fac1)
-    enddo
-    deallocate ( DEBUG_ARRAY )
-    if (mpp_pe()==0) print*,'-------------- FV3 Tracer Debug After DYN --------------'
-    if (mpp_pe()==0) print*,''
-    prt_minmax     = .false.
-  endif
+      ! Push Tracers
+      nn = 0
+      if (.not. ADIABATIC) then
 
-! Copy FV to internal State
-   call FV_To_State ( STATE )
+         do n=1,state%grid%NQ
 
-    if (DEBUG) call debug_fv_state('After Dynamics Execution',STATE)
+            if ((sphu /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'Q')) then
+               SPHU_FILLED = .TRUE.
+               nn = nn+1
+               if (state%vars%tracer(n)%is_r4) then
+                  state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu)
+               else
+                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,sphu)
+               endif
+            endif
+            ! QLIQ
+            if (qliq /= -1) then
+               if (trim(state%vars%tracer(n)%tname) == 'QLCN') then
+                  QLCN_FILLED = .TRUE.
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * cnvfrc
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * cnvfrc
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QLLS') then
+                  QLLS_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * (1.0-cnvfrc)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qliq) * (1.0-cnvfrc)
+                  endif
+               endif
+            else
+               if ((qlcn /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QLCN')) then
+                  QLCN_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlcn)
+                  endif
+               endif
+               if ((qlls /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QLLS')) then
+                  QLLS_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qlls)
+                  endif
+               endif
+            endif
+            ! QICE
+            if (qice /= -1) then
+               if (trim(state%vars%tracer(n)%tname) == 'QICN') then
+                  QICN_FILLED = .TRUE.
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * cnvfrc
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * cnvfrc
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QILS') then
+                  QILS_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * (1.0-cnvfrc)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qice) * (1.0-cnvfrc)
+                  endif
+               endif
+            else
+               if (trim(state%vars%tracer(n)%tname) == 'QICN') then
+                  QICN_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qicn)
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'QILS') then
+                  QILS_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qils)
+                  endif
+               endif
+            endif
+            ! QCLD
+            if (qcld /= -1) then
+               if (trim(state%vars%tracer(n)%tname) == 'CLCN') then
+                  CLCN_FILLED = .TRUE.
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * cnvfrc
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * cnvfrc
+                  endif
+               endif
+               if (trim(state%vars%tracer(n)%tname) == 'CLLS') then
+                  CLLS_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * (1.0-cnvfrc)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,qcld) * (1.0-cnvfrc)
+                  endif
+               endif
+            else
+               if ((clcn /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'CLCN')) then
+                  CLCN_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clcn)
+                  endif
+               endif
+               if ((clls /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'CLLS')) then
+                  CLLS_FILLED = .TRUE.
+                  nn = nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,clls)
+                  endif
+               endif
+            endif
+            ! RAIN
+            if ((rain /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QRAIN')) then
+               RAIN_FILLED = .TRUE.
+               nn = nn+1
+               if (state%vars%tracer(n)%is_r4) then
+                  state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain)
+               else
+                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,rain)
+               endif
+            endif
+            ! SNOW
+            if ((snow /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QSNOW')) then
+               SNOW_FILLED = .TRUE.
+               nn = nn+1
+               if (state%vars%tracer(n)%is_r4) then
+                  state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow)
+               else
+                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,snow)
+               endif
+            endif
+            ! GRPL
+            if ((grpl /= -1) .and. (trim(state%vars%tracer(n)%tname) == 'QGRAUPEL')) then
+               GRPL_FILLED = .TRUE.
+               nn = nn+1
+               if (state%vars%tracer(n)%is_r4) then
+                  state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl)
+               else
+                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,grpl)
+               endif
+            endif
+            
+         enddo
 
-    RETURN_(ESMF_SUCCESS)
+         ! Verify
+         deallocate ( cnvfrc )
+         select case (FV_Atm(1)%flagstruct%nwat)
+         case (6:7)
+            _ASSERT(SPHU_FILLED, 'SPHU Not Filled Out')
+            _ASSERT(RAIN_FILLED, 'RAIN Not Filled Out')
+            _ASSERT(SNOW_FILLED, 'SNOW Not Filled Out')
+            _ASSERT(GRPL_FILLED, 'GRPL Not Filled Out')
+            _ASSERT(QLCN_FILLED, 'QLCN Not Filled Out')
+            _ASSERT(QLLS_FILLED, 'QLLS Not Filled Out')
+            _ASSERT(QICN_FILLED, 'QICN Not Filled Out')
+            _ASSERT(QILS_FILLED, 'QILS Not Filled Out')
+            _ASSERT(CLCN_FILLED, 'CLCN Not Filled Out')
+            _ASSERT(CLLS_FILLED, 'CLLS Not Filled Out')
+            _ASSERT(nn == 7, 'Expecting 7 water species Out') ! Q, QLIQ, QICE, QCLD, QRAIN, QSNOW, QGRAUPEL
+         case (3:4)
+            _ASSERT(SPHU_FILLED, 'SPHU Not Filled Out')
+            _ASSERT(QLCN_FILLED, 'QLCN Not Filled Out')
+            _ASSERT(QLLS_FILLED, 'QLLS Not Filled Out')
+            _ASSERT(QICN_FILLED, 'QICN Not Filled Out')
+            _ASSERT(QILS_FILLED, 'QILS Not Filled Out')
+            _ASSERT(CLCN_FILLED, 'CLCN Not Filled Out')
+            _ASSERT(CLLS_FILLED, 'CLLS Not Filled Out')
+            _ASSERT(nn == 4, 'Expecting 4 water species Out') ! Q, QLIQ, QICE
+         case (1)
+            _ASSERT(SPHU_FILLED, 'SPHU Not Filled Out')
+            _ASSERT(QLCN_FILLED, 'QLCN Not Filled Out')
+            _ASSERT(QLLS_FILLED, 'QLLS Not Filled Out')
+            _ASSERT(QICN_FILLED, 'QICN Not Filled Out')
+            _ASSERT(QILS_FILLED, 'QILS Not Filled Out')
+            _ASSERT(nn == 5, 'Expecting 5 water species Out') ! Q, QLCN, QLLS, QICN, QILS
+         end select
+         
+         ! Include additional tracers
 
-end subroutine FV_Run
+         select case(FV_Atm(1)%flagstruct%nwat)
+         case (0)
+            do n=1,state%grid%NQ
+               nn=nn+1
+               if (state%vars%tracer(n)%is_r4) then
+                  state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+               else
+                  state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+               endif
+            enddo
+         case (1)
+            do n=1,state%grid%NQ
+               if ( (trim(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QILS'    ) ) then
+                  nn=nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+                  endif
+               endif
+            enddo
+         case (3:4)
+            do n=1,state%grid%NQ
+               if ( (trim(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLLS'    ) ) then
+                  nn=nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+                  endif
+               endif
+            enddo
+         case (6:7)
+            do n=1,state%grid%NQ
+               if ( (trim(state%vars%tracer(n)%tname) /= 'Q'       ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QICN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QILS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLCN'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'CLLS'    ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QRAIN'   ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QSNOW'   ) .and. &
+                    (trim(state%vars%tracer(n)%tname) /= 'QGRAUPEL') ) then
+                  nn=nn+1
+                  if (state%vars%tracer(n)%is_r4) then
+                     state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+                  else
+                     state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+                  endif
+               endif
+            enddo
+         end select
+         write (STRING, "(I3.3,' /= ',I3.3)") nn, FV_Atm(1)%ncnst
+         _ASSERT(nn == FV_Atm(1)%ncnst, 'nn /= ncnst: '//trim(STRING))
 
- subroutine FV_DA_Incs (LONS,LATS,IM,JM,KM,&
+      else
+
+         ! Include all tracers
+         do n=1,state%grid%NQ
+            nn=nn+1
+            if (state%vars%tracer(n)%is_r4) then
+               state%vars%tracer(n)%content_r4(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+            else
+               state%vars%tracer(n)%content(:,:,:) = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,nn)
+            endif
+         enddo
+         _ASSERT(nn == FV_Atm(1)%ncnst, 'needs informative message')
+
+      endif
+
+      ! Clean negative tracers and check
+      if (DEBUG_ADV) then
+         prt_minmax     = DEBUG_ADV
+         if (mpp_pe()==0) print*,''
+         if (mpp_pe()==0) print*,'-------------- FV3 Tracer Debug After DYN --------------'
+         allocate( DEBUG_ARRAY(isc:iec,jsc:jec,npz) )
+         do n=1,state%grid%NQ
+            if (state%vars%tracer(n)%is_r4) then
+               DEBUG_ARRAY(:,:,1:npz) = state%vars%tracer(n)%content_r4
+            else
+               DEBUG_ARRAY(:,:,1:npz) = state%vars%tracer(n)%content
+            endif
+            call prt_maxmin(trim(state%vars%tracer(n)%tname), DEBUG_ARRAY, isc, iec, jsc, jec, 0, npz, fac1)
+         enddo
+         deallocate ( DEBUG_ARRAY )
+         if (mpp_pe()==0) print*,'-------------- FV3 Tracer Debug After DYN --------------'
+         if (mpp_pe()==0) print*,''
+         prt_minmax     = .false.
+      endif
+
+      ! Copy FV to internal State
+      call FV_To_State ( state )
+
+      if (DEBUG) call debug_fv_state('After Dynamics Execution',state)
+
+      _RETURN(_SUCCESS)
+
+   end subroutine FV_Run
+
+ subroutine FV_DA_Incs (lons,lats,IM,JM,KM,&
                         u_amb, v_amb, t_amb, dp_amb, q_amb, o3_amb, &
                         u_inc, v_inc, t_inc, dp_inc, q_inc, o3_inc)
  use fv_treat_da_inc_mod, only : geos_get_da_increments
 ! The ANA Lat-Lon Grid
  integer, intent(in) :: IM,JM,KM
- real, intent(inout) :: LONS(IM), LATS(JM)
+ real, intent(inout) :: lons(IM), lats(JM)
 ! ANA-BKG fields on the ANA Lat-Lon Grid
  real, dimension(IM,JM,KM), intent(inout) :: u_amb, v_amb, t_amb, dp_amb, q_amb, o3_amb
 ! increments are returned on Cubed A-Grid with Native Cubed-Sphere Wind Incs on the D-Grid
@@ -2578,11 +2568,11 @@ subroutine fv_getQ(Q, qNAME)
   jsc = FV_Atm(1)%bd%jsc
   jec = FV_Atm(1)%bd%jec
   npz = FV_Atm(1)%npz
-  if (TRIM(qNAME) == 'Q'   ) Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,1)
-  if (TRIM(qNAME) == 'QLCN') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,2)
-  if (TRIM(qNAME) == 'QLLS') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,3)
-  if (TRIM(qNAME) == 'QICN') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,4)
-  if (TRIM(qNAME) == 'QILS') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,5)
+  if (trim(qNAME) == 'Q'   ) Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,1)
+  if (trim(qNAME) == 'QLCN') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,2)
+  if (trim(qNAME) == 'QLLS') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,3)
+  if (trim(qNAME) == 'QICN') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,4)
+  if (trim(qNAME) == 'QILS') Q = FV_Atm(1)%q(isc:iec,jsc:jec,1:npz,5)
 
 return
 end subroutine fv_getQ
@@ -4509,7 +4499,7 @@ end subroutine fv_getAllWinds_2D
   prt_minmax     = DEBUG
   allocate( DEBUG_ARRAY(ISC:IEC,JSC:JEC,NPZ+1) )
   if (mpp_pe()==0) print*,''
-  if (mpp_pe()==0) print*,'--------------', TRIM(debug_txt), '--------------'
+  if (mpp_pe()==0) print*,'--------------', trim(debug_txt), '--------------'
   DEBUG_ARRAY(:,:,1) = FV_Atm(1)%phis(isc:iec,jsc:jec)
   call prt_maxmin('PHIS', DEBUG_ARRAY  , isc, iec  , jsc, jec  , 0,   1, fac1   )
   DEBUG_ARRAY(:,:,1) = FV_Atm(1)%varflt(isc:iec,jsc:jec)
@@ -4538,7 +4528,7 @@ end subroutine fv_getAllWinds_2D
       call prt_maxmin('DZ  ', DEBUG_ARRAY  , isc, iec, jsc, jec, 0, npz, fac1   )
   endif
   endif
-  if (mpp_pe()==0) print*,'--------------', TRIM(debug_txt), '--------------'
+  if (mpp_pe()==0) print*,'--------------', trim(debug_txt), '--------------'
   if (mpp_pe()==0) print*,''
   prt_minmax     = .false.
   deallocate( DEBUG_ARRAY)

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -7,11 +7,18 @@ module FV_StateMod
    !USES:
 #if defined( MAPL_MODE )
    use ESMF                ! ESMF base class
-   use MAPL                ! MAPL base class
+   ! use MAPL              ! MAPL base class
+   use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY, MAPL_RTRN
+   use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
+   use MAPL_BaseMod, only: MAPL_UNDEF
+   use MAPL_GenericMod, only: MAPL_MetaComp, MAPL_Get, MAPL_GetObjectFromGC, MAPL_GetResource
+   use ESMFL_Mod, only: ESMFL_StateGetPointerToData
+   use FileIOSharedMod, only: WRITE_PARALLEL
+   use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet
+   use mapl3g_Geom_API, only: MAPL_GridGet
 #endif
    use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
-   use MAPL_ConstantsMod, only: MAPL_KAPPA, MAPL_PI_R8, MAPL_ALHL, MAPL_PSDRY
-   use mapl3g_generic, only: MAPL_GridCompGetResource
+   use MAPL_ConstantsMod, only: MAPL_KAPPA, MAPL_PI_R8, MAPL_ALHL, MAPL_PSDRY, MAPL_OMEGA
 
    use fv_mp_mod, only: start_group_halo_update, complete_group_halo_update, group_halo_update_type
 
@@ -145,45 +152,44 @@ module FV_StateMod
 
    type T_FVDYCORE_GRID
 #if defined( MAPL_MODE )
-      type (MAPL_MetaComp),   pointer :: FVgenstate
-      type (ESMF_Grid)                :: GRID           ! The 'horizontal' grid (2D decomp only)
+      ! type (MAPL_MetaComp),   pointer :: FVgenstate
+      type(ESMF_Grid) :: grid ! The 'horizontal' grid (2D decomp only)
 #endif
 
-      integer                         :: NG               ! Ghosting
+      integer :: NG ! Ghosting
 
-      integer                         :: IS               ! Start X-index (exclusive, unghosted)
-      integer                         :: IE               ! End X-index (exclusive, unghosted)
-      integer                         :: JS               ! Start Y-index (exclusive, unghosted)
-      integer                         :: JE               ! End Y-index (exclusive, unghosted)
+      integer :: IS ! Start X-index (exclusive, unghosted)
+      integer :: IE ! End X-index (exclusive, unghosted)
+      integer :: JS ! Start Y-index (exclusive, unghosted)
+      integer :: JE ! End Y-index (exclusive, unghosted)
 
-      integer                         :: ISD              ! Start X-index (exclusive, ghosted)
-      integer                         :: IED              ! End X-index (exclusive, ghosted)
-      integer                         :: JSD              ! Start Y-index (exclusive, ghosted)
-      integer                         :: JED              ! End Y-index (exclusive, ghosted)
+      integer :: ISD ! Start X-index (exclusive, ghosted)
+      integer :: IED ! End X-index (exclusive, ghosted)
+      integer :: JSD ! Start Y-index (exclusive, ghosted)
+      integer :: JED ! End Y-index (exclusive, ghosted)
 
-      integer                         :: NPX             ! Full X- dim
-      integer                         :: NPY             ! Full Y- dim
-      integer                         :: NPZ             ! Numer of levels
-      integer                         :: NPZ_P1          ! NPZ+1 (?)
+      integer :: NPX ! Full X- dim
+      integer :: NPY ! Full Y- dim
+      integer :: NPZ ! Numer of levels
+      integer :: NPZ_P1 ! NPZ+1 (?)
 
-      integer                         :: NTILES          ! log-rectangular tiles in grid: 1 for lat/lon, 6 for cubed-sphere
+      integer :: NTILES ! log-rectangular tiles in grid: 1 for lat/lon, 6 for cubed-sphere
 
-      real(REAL8), allocatable           :: DXC(:,:)     ! local C-Grid DeltaX
-      real(REAL8), allocatable           :: DYC(:,:)     ! local C-Grid DeltaY
+      real(REAL8), allocatable :: DXC(:,:) ! local C-Grid DeltaX
+      real(REAL8), allocatable :: DYC(:,:) ! local C-Grid DeltaY
 
-      real(REAL8), allocatable           :: AREA(:,:)    ! local cell area
-      real(REAL8)                        :: GLOBALAREA   ! global area
+      real(REAL8), allocatable :: AREA(:,:) ! local cell area
+      real(REAL8) :: GLOBALAREA ! global area
 
-      integer                         :: KS              ! Number of true pressure levels (out of NPZ+1)
-      real(REAL8)                        :: PTOP            ! pressure at top (ak(1))
-      real(REAL8)                        :: PINT            ! initial pressure (ak(npz+1))
-      real(REAL8), dimension(:), pointer :: AK => NULL()    ! Sigma mapping
-      real(REAL8), dimension(:), pointer :: BK => NULL()    ! Sigma mapping
-      real(REAL8)                        :: f_coriolis_angle = 0
-      !
+      integer :: KS ! Number of true pressure levels (out of NPZ+1)
+      real(REAL8) :: PTOP ! pressure at top (ak(1))
+      real(REAL8) :: PINT ! initial pressure (ak(npz+1))
+      real(REAL8) :: f_coriolis_angle = 0
+      real(REAL8), dimension(:), pointer :: AK => null() ! Sigma mapping
+      real(REAL8), dimension(:), pointer :: BK => null() ! Sigma mapping
+
       ! Tracers
-      !
-      integer                         :: NQ              ! Number of advected tracers
+      integer :: NQ ! Number of advected tracers
    end type T_FVDYCORE_GRID
 
    integer, parameter :: NUM_FVDYCORE_ALARMS        = 3
@@ -536,42 +542,42 @@ contains
             FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
          if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 1120) then
-            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
             FV_Atm(1)%flagstruct%k_split = ceiling(DT/  60.0 )
             if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  90.0 )
             FV_Atm(1)%flagstruct%tau = 2.5
             FV_Atm(1)%flagstruct%RF_fast = .false.
          endif
          if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 1440) then
-            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
             FV_Atm(1)%flagstruct%k_split = ceiling(DT/  37.5 )
             if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  60.0 )
             FV_Atm(1)%flagstruct%tau = 2.0
             FV_Atm(1)%flagstruct%RF_fast = .true.
          endif
          if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 2880) then
-            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
             FV_Atm(1)%flagstruct%k_split = ceiling(DT/  18.75 )
             if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  30.0  )
             FV_Atm(1)%flagstruct%tau = 1.5
             FV_Atm(1)%flagstruct%RF_fast = .true.
          endif
          if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 4320) then
-            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
             FV_Atm(1)%flagstruct%k_split = ceiling(DT/  15.0  )
             if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  15.0  )
             FV_Atm(1)%flagstruct%tau = 1.0
             FV_Atm(1)%flagstruct%RF_fast = .true.
          endif
          if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 5760) then
-            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
             FV_Atm(1)%flagstruct%k_split = ceiling(DT/   9.375 )
             if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/   7.5   )
             FV_Atm(1)%flagstruct%tau = 1.0
             FV_Atm(1)%flagstruct%RF_fast = .true.
          endif
          if (FV_Atm(1)%flagstruct%npx*ceiling(FV_Atm(1)%flagstruct%stretch_fac) >= 10800) then
-            FV_Atm(1)%flagstruct%hydrostatic = .false.                                            
+            FV_Atm(1)%flagstruct%hydrostatic = .false.
             FV_Atm(1)%flagstruct%k_split = ceiling(DT/  4.6875 )
             if (FV_Atm(1)%flagstruct%stretch_fac > 1) FV_Atm(1)%flagstruct%k_split = ceiling(DT/  3.25   )
             FV_Atm(1)%flagstruct%tau = 1.0
@@ -586,7 +592,7 @@ contains
          FV_Atm(1)%flagstruct%d4_bg_bot = 0.12 ! High-order Divg Damping coef
          FV_Atm(1)%flagstruct%d2_bg = 0.0  ! 2nd order Divg Damping coef
          FV_Atm(1)%flagstruct%d_ext = 0.0  ! External damping
-         ! Local Richardson-number turbulent mixing 
+         ! Local Richardson-number turbulent mixing
          FV_Atm(1)%flagstruct%fv_sg_adj = DT*4
          ! Sponge layer
          FV_Atm(1)%flagstruct%n_sponge = 9
@@ -600,7 +606,7 @@ contains
          FV_Atm(1)%flagstruct%a_imp = 1.0
          ! dz_min is a NH delta-z limiter increasing may improve stability
          FV_Atm(1)%flagstruct%dz_min = 2.0
-         ! p_fac is a NH pressure fraction limiter near model top (0:0.25) 
+         ! p_fac is a NH pressure fraction limiter near model top (0:0.25)
          FV_Atm(1)%flagstruct%p_fac = 0.05
          ! General defaults
          FV_Atm(1)%flagstruct%make_nh = .false.
@@ -711,395 +717,373 @@ contains
       _RETURN(_SUCCESS)
    end subroutine FV_Setup
 
- subroutine FV_InitState (STATE, CLOCK, INTERNAL, IMPORT, GC, RC)
+   subroutine FV_InitState(state, clock, internal, import, gc, rc)
 
-  use test_cases_mod, only : test_case, init_double_periodic
+      use test_cases_mod, only : test_case, init_double_periodic
 
-  type (T_FVDYCORE_STATE),pointer              :: STATE
+      type(T_FVDYCORE_STATE), pointer :: state
 
-  type (ESMF_Clock), target,     intent(INOUT) :: CLOCK
-  type (ESMF_GridComp)         , intent(INOUT) :: GC
-  type (ESMF_State)            , intent(INOUT) :: INTERNAL
-  type (ESMF_State)            , intent(INOUT) :: IMPORT
-  integer, optional            , intent(OUT  ) :: RC
+      type(ESMF_Clock), target, intent(inout) :: clock
+      type(ESMF_GridComp), intent(inout) :: gc
+      type(ESMF_State), intent(inout) :: internal
+      type(ESMF_State), intent(inout) :: import
+      integer, optional, intent(out) :: rc
 
-! Local variables
+      ! Local variables
 
-! Pointers to geography info in the MAPL MetaComp
+      real(REAL4), pointer :: LATS (:,:)
+      real(REAL4), pointer :: LONS (:,:)
 
-  real(REAL4),                 pointer :: LATS (:,:)
-  real(REAL4),                 pointer :: LONS (:,:)
+      type(ESMF_TimeInterval) :: Time2Run
+      type(ESMF_VM) :: vm
+      type(T_FVDYCORE_GRID), pointer :: grid
+      integer :: status
+      real(REAL8) :: DT
+      real :: rPRS
+      character(len=1) :: sCODE, rCODE, zCODE
 
-  type (ESMF_TimeInterval)     :: Time2Run
-  type (ESMF_VM)               :: VM
-  type (T_FVDYCORE_GRID) , pointer :: GRID
-  integer              :: status
-  real(REAL8) :: DT
-  real        :: rPRS
-  character(len=1) :: sCODE, rCODE, zCODE
+      integer :: is ,ie , js ,je    !  Local dims
+      integer :: isc,iec, jsc,jec   !  Local dims
+      integer :: isd,ied, jsd,jed   !  Local dims
+      integer :: k                  !  Vertical loop index
+      integer :: ng
+      integer :: ndt
 
-  integer   :: is ,ie , js ,je    !  Local dims
-  integer   :: isc,iec, jsc,jec   !  Local dims
-  integer   :: isd,ied, jsd,jed   !  Local dims
-  integer   :: k                  !  Vertical loop index
-  integer   :: ng
-  integer   :: ndt
+      integer :: i,j
 
-  integer   :: i,j
+      type(ESMF_Time) :: fv_time
+      integer :: days, seconds
 
-  type (ESMF_Time) :: fv_time
-  integer :: days, seconds
+      character(len=ESMF_MAXSTR) :: IAm='FV:FV_InitState'
 
-  character(len=ESMF_MAXSTR)       :: IAm='FV:FV_InitState'
+      real(REAL8), dimension(:), pointer     :: AK1 => null(), AK => null()
+      real(REAL8), dimension(:), pointer     :: BK1 => null(), BK => null()
+      real(REAL8), dimension(:,:,:), pointer :: U => null()
+      real(REAL8), dimension(:,:,:), pointer :: V => null()
+      real(REAL8), dimension(:,:,:), pointer :: PT => null()
+      real(REAL8), dimension(:,:,:), pointer :: PE1 => null(), PE => null()
+      real(REAL8), dimension(:,:,:), pointer :: PKZ => null()
+      real(REAL8), dimension(:,:,:), pointer :: DZ => null()
+      real(REAL8), dimension(:,:,:), pointer :: W => null()
 
-  real(REAL8), pointer                   :: AK(:) => NULL()
-  real(REAL8), pointer                   :: BK(:) => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: U     => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: V     => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: PT    => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: PE    => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: PKZ   => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: DZ    => NULL()
-  real(REAL8), dimension(:,:,:), pointer :: W     => NULL()
-  type (MAPL_MetaComp),          pointer :: mapl  => NULL()
+      real(REAL8), allocatable :: UA(:,:,:)
+      real(REAL8), allocatable :: VA(:,:,:)
+      real(REAL8), allocatable :: UD(:,:,:)
+      real(REAL8), allocatable :: VD(:,:,:)
 
-  real(REAL8), ALLOCATABLE :: UA(:,:,:)
-  real(REAL8), ALLOCATABLE :: VA(:,:,:)
-  real(REAL8), ALLOCATABLE :: UD(:,:,:)
-  real(REAL8), ALLOCATABLE :: VD(:,:,:)
-
-  logical    :: hybrid
-  integer    :: tile_in
-  integer    :: gid, masterproc
+      logical :: hybrid
+      integer :: tile_in
+      integer :: gid, masterproc
 
 #ifdef RUN_GTFV3
-  logical :: halting_mode(5)
-  integer :: comm
+      logical :: halting_mode(5)
+      integer :: comm
 #endif
 
-! BEGIN
+      ! BEGIN
 
-! Retrieve the pointer to the state
-! ---------------------------------
+      call MAPL_GridCompGetResource(gc, "RUN_DT", ndt, default=0, _RC)
+      DT = ndt
 
-  call MAPL_GetObjectFromGC (GC, MAPL,  RC=STATUS )
-  VERIFY_(STATUS)
+      ! state%grid%FVgenstate => MAPL
+      grid => state%grid     ! For convenience
+      state%DOTIME= .TRUE.
+      state%DT = DT
+      state%KSPLIT = FV_Atm(1)%flagstruct%K_SPLIT
+      state%NSPLIT = FV_Atm(1)%flagstruct%N_SPLIT
+      grid%NG = 3 ; ng = 3
+      grid%NPX = FV_Atm(1)%flagstruct%NPX-1
+      grid%NPY = FV_Atm(1)%flagstruct%NPY-1
+      grid%NPZ = FV_Atm(1)%flagstruct%NPZ
+      grid%NPZ_P1 = FV_Atm(1)%flagstruct%NPZ+1
+      grid%NTILES = 6
+      grid%NQ = MAX(1,FV_Atm(1)%flagstruct%ncnst)
 
-  call MAPL_GetResource( MAPL, ndt, 'RUN_DT:', default=0, RC=STATUS )
-  VERIFY_(STATUS)
-  DT = ndt
+      masterproc = mpp_root_pe()
+      gid = mpp_pe()
 
-  STATE%GRID%FVgenstate => MAPL
-  GRID => STATE%GRID     ! For convenience
-  STATE%DOTIME= .TRUE.
-  STATE%DT        = DT
-  STATE%KSPLIT    = FV_Atm(1)%flagstruct%K_SPLIT
-  STATE%NSPLIT    = FV_Atm(1)%flagstruct%N_SPLIT
-  GRID%NG     = 3 ; ng = 3
-  GRID%NPX    = FV_Atm(1)%flagstruct%NPX-1
-  GRID%NPY    = FV_Atm(1)%flagstruct%NPY-1
-  GRID%NPZ    = FV_Atm(1)%flagstruct%NPZ
-  GRID%NPZ_P1 = FV_Atm(1)%flagstruct%NPZ+1
-  GRID%NTILES = 6
-  GRID%NQ     = MAX(1,FV_Atm(1)%flagstruct%ncnst)
+      call ESMF_GridCompGet(gc, vm=vm, _RC)
+      call MAPL_GridCompGet(gc, grid=grid%grid, _RC)
 
-  masterproc = mpp_root_pe()
-  gid = mpp_pe()
+      call WRITE_PARALLEL(' ')
+      call WRITE_PARALLEL(state%DT,format='("Dynamics time step : ",(F10.4))')
+      call WRITE_PARALLEL(' ')
 
-  call ESMF_GridCompGet(gc, grid=GRID%GRID, VM=VM, rc=STATUS)
-    VERIFY_(STATUS)
+      ! Get pointers to internal state vars
+      call MAPL_GetPointer(internal, ak1, "AK", _RC) ! 1-based
+      call MAPL_GetPointer(internal, bk1, "BK", _RC) ! 1-based
+      call MAPL_GetPointer(internal, u, "U", _RC) ! A-Grid U Wind
+      call MAPL_GetPointer(internal, v, "V", _RC)
+      call MAPL_GetPointer(internal, pt, "PT", _RC)
+      call MAPL_GetPointer(internal, pe1, "PE", _RC) ! 1-based
+      call MAPL_GetPointer(internal, pkz, "PKZ", _RC)
+      call MAPL_GetPointer(internal, dz, "DZ", _RC)
+      call MAPL_GetPointer(internal, w, "W", _RC)
+      block
+         integer :: is, ie, js, je, ks, ke, km
+         is = lbound(u,1); ie = ubound(u,1)
+         js = lbound(u,2); je = ubound(u,2)
+         ks = lbound(u,3); ke = ubound(u,3)
+         km = ke-ks+1
+         ak(0:km) => ak1(1:km+1)
+         bk(0:km) => bk1(1:km+1)
+         pe(is:ie, js:je, 0:km) => pe1(is:ie, js:je, 1:km+1)
+      end block
 
-  call WRITE_PARALLEL(' ')
-  call WRITE_PARALLEL(STATE%DT,format='("Dynamics time step : ",(F10.4))')
-  call WRITE_PARALLEL(' ')
+      call CREATE_VARS( &
+           FV_Atm(1)%bd%isc, FV_Atm(1)%bd%iec, FV_Atm(1)%bd%jsc, FV_Atm(1)%bd%jec, &
+           1, FV_Atm(1)%flagstruct%npz, FV_Atm(1)%flagstruct%npz+1, &
+           U, V, PT, PE, PKZ, DZ, W, state%vars)
+      call MAPL_MemUtilsWrite(vm, 'FV_StateMod: CREATE_VARS', _RC)
 
-! Get pointers to internal state vars
-  call MAPL_GetPointer(internal, ak, "AK",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, bk, "BK",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, u, "U",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, v, "V",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, pt, "PT",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, pe, "PE",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, pkz, "PKZ",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, dz, "DZ",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_GetPointer(internal, w, "W",rc=status)
-  VERIFY_(STATUS)
+      grid%IS = FV_Atm(1)%bd%isc
+      grid%IE = FV_Atm(1)%bd%iec
+      grid%JS = FV_Atm(1)%bd%jsc
+      grid%JE = FV_Atm(1)%bd%jec
+      grid%isd = FV_Atm(1)%bd%isd
+      grid%ied = FV_Atm(1)%bd%ied
+      grid%jsd = FV_Atm(1)%bd%jsd
+      grid%jed = FV_Atm(1)%bd%jed
+      if(.not.associated(grid%AK)) allocate(grid%AK(size(ak)))
+      if(.not.associated(grid%BK)) allocate(grid%BK(size(bk)))
+      grid%AK = ak
+      grid%BK = bk
 
-  call CREATE_VARS ( FV_Atm(1)%bd%isc, FV_Atm(1)%bd%iec, FV_Atm(1)%bd%jsc, FV_Atm(1)%bd%jec,     &
-                     1, FV_Atm(1)%flagstruct%npz, FV_Atm(1)%flagstruct%npz+1,            &
-                     U, V, PT, PE, PKZ, DZ, W, &
-                     STATE%VARS )
-  call MAPL_MemUtilsWrite(VM, 'FV_StateMod: CREATE_VARS', RC=STATUS )
-  VERIFY_(STATUS)
+      FV_Atm(1)%ks = count(bk == 0.0) - 1
+      _ASSERT(FV_Atm(1)%ks <= FV_Atm(1)%flagstruct%NPZ+1, "ks must be smaller than NPZ+1")
+      call WRITE_PARALLEL(FV_Atm(1)%ks, format='("Number of true pressure levels =", I5)')
 
-  GRID%IS     = FV_Atm(1)%bd%isc
-  GRID%IE     = FV_Atm(1)%bd%iec
-  GRID%JS     = FV_Atm(1)%bd%jsc
-  GRID%JE     = FV_Atm(1)%bd%jec
-  GRID%isd    = FV_Atm(1)%bd%isd
-  GRID%ied    = FV_Atm(1)%bd%ied
-  GRID%jsd    = FV_Atm(1)%bd%jsd
-  GRID%jed    = FV_Atm(1)%bd%jed
-  if(.not.associated(GRID%AK)) allocate(GRID%AK(size(ak)))
-  if(.not.associated(GRID%BK)) allocate(GRID%BK(size(bk)))
-  GRID%AK     = ak
-  GRID%BK     = bk
+      ! Local Copy of dimensions
+      IS  = FV_Atm(1)%bd%isc
+      IE  = FV_Atm(1)%bd%iec
+      JS  = FV_Atm(1)%bd%jsc
+      JE  = FV_Atm(1)%bd%jec
+      ISC = FV_Atm(1)%bd%isc
+      IEC = FV_Atm(1)%bd%iec
+      JSC = FV_Atm(1)%bd%jsc
+      JEC = FV_Atm(1)%bd%jec
+      ISD = FV_Atm(1)%bd%isd
+      IED = FV_Atm(1)%bd%ied
+      JSD = FV_Atm(1)%bd%jsd
+      JED = FV_Atm(1)%bd%jed
 
-  FV_Atm(1)%ks = count(bk == 0.0) - 1
-  _ASSERT(FV_Atm(1)%ks <= FV_Atm(1)%flagstruct%NPZ+1,'ks must be smaller than NPZ+1')
-  call WRITE_PARALLEL(FV_Atm(1)%ks, format='("Number of true pressure levels =", I5)'   )
+      allocate(grid%DXC(IS:IE,JS:JE))
+      grid%DXC = fv_atm(1)%gridstruct%dxc(IS:IE,JS:JE)
 
-! Local Copy of dimensions
+      allocate(grid%DYC(IS:IE,JS:JE) )
+      grid%DYC = fv_atm(1)%gridstruct%dyc(IS:IE,JS:JE)
 
-  IS     = FV_Atm(1)%bd%isc
-  IE     = FV_Atm(1)%bd%iec
-  JS     = FV_Atm(1)%bd%jsc
-  JE     = FV_Atm(1)%bd%jec
-  ISC    = FV_Atm(1)%bd%isc
-  IEC    = FV_Atm(1)%bd%iec
-  JSC    = FV_Atm(1)%bd%jsc
-  JEC    = FV_Atm(1)%bd%jec
-  ISD    = FV_Atm(1)%bd%isd
-  IED    = FV_Atm(1)%bd%ied
-  JSD    = FV_Atm(1)%bd%jsd
-  JED    = FV_Atm(1)%bd%jed
+      allocate(grid%AREA(IS:IE,JS:JE) )
+      grid%AREA = fv_atm(1)%gridstruct%area(IS:IE,JS:JE)
+      grid%GLOBALAREA = fv_atm(1)%gridstruct%globalarea
 
-  allocate( GRID%DXC(IS:IE,JS:JE) )
-  GRID%DXC = fv_atm(1)%gridstruct%dxc(IS:IE,JS:JE)
+      if (FV_Atm(1)%flagstruct%grid_type == 4) then
+         fv_atm(1)%gridstruct%fC(:,:) = 2.*MAPL_OMEGA*sin(FV_Atm(1)%flagstruct%deglat/180.*MAPL_PI_R8)
+         fv_atm(1)%gridstruct%f0(:,:) = 2.*MAPL_OMEGA*sin(FV_Atm(1)%flagstruct%deglat/180.*MAPL_PI_R8)
+      else
+         if (grid%f_coriolis_angle == -999) then
+            fv_atm(1)%gridstruct%fC(:,:) = 0.0
+            fv_atm(1)%gridstruct%f0(:,:) = 0.0
+         else
+            do j=jsd,jed+1
+               do i=isd,ied+1
+                  fv_atm(1)%gridstruct%fC(i,j) = 2.*MAPL_OMEGA*( &
+                       - cos(FV_Atm(1)%gridstruct%grid(i,j,1))*cos(FV_Atm(1)%gridstruct%grid(i,j,2))*sin(grid%f_coriolis_angle) &
+                       + sin(FV_Atm(1)%gridstruct%grid(i,j,2))*cos(grid%f_coriolis_angle) &
+                       )
+               enddo
+            enddo
+            do j=jsd,jed
+               do i=isd,ied
+                  fv_atm(1)%gridstruct%f0(i,j) = 2.*MAPL_OMEGA*( &
+                       - cos(FV_Atm(1)%gridstruct%agrid(i,j,1))*cos(FV_Atm(1)%gridstruct%agrid(i,j,2))*sin(grid%f_coriolis_angle) &
+                       + sin(FV_Atm(1)%gridstruct%agrid(i,j,2))*cos(grid%f_coriolis_angle) )
+               enddo
+            enddo
+         endif
+      endif
 
-  allocate( GRID%DYC(IS:IE,JS:JE) )
-  GRID%DYC = fv_atm(1)%gridstruct%dyc(IS:IE,JS:JE)
+      ! Check coordinate information
+      call MAPL_GridGet(grid%grid, latitudes=lats, longitudes=lons, _RC)
 
-  allocate( GRID%AREA(IS:IE,JS:JE) )
-  GRID%AREA = fv_atm(1)%gridstruct%area(IS:IE,JS:JE)
-  GRID%GLOBALAREA = fv_atm(1)%gridstruct%globalarea
+      state%clock => clock
+      call ESMF_TimeIntervalSet(Time2Run, s=nint(state%DT), _RC)
 
-  if (FV_Atm(1)%flagstruct%grid_type == 4) then
-     fv_atm(1)%gridstruct%fC(:,:) = 2.*MAPL_OMEGA*sin(FV_Atm(1)%flagstruct%deglat/180.*MAPL_PI_R8)
-     fv_atm(1)%gridstruct%f0(:,:) = 2.*MAPL_OMEGA*sin(FV_Atm(1)%flagstruct%deglat/180.*MAPL_PI_R8)
-  else
-   if (GRID%f_coriolis_angle == -999) then
-     fv_atm(1)%gridstruct%fC(:,:) = 0.0
-     fv_atm(1)%gridstruct%f0(:,:) = 0.0
-   else
-     do j=jsd,jed+1
-        do i=isd,ied+1
-           fv_atm(1)%gridstruct%fC(i,j) = 2.*MAPL_OMEGA*( -COS(FV_Atm(1)%gridstruct%grid(i,j,1))*COS(FV_Atm(1)%gridstruct%grid(i,j,2))*SIN(GRID%f_coriolis_angle) + &
-                                      SIN(FV_Atm(1)%gridstruct%grid(i,j,2))*COS(GRID%f_coriolis_angle) )
-        enddo
-     enddo
-     do j=jsd,jed
-        do i=isd,ied
-           fv_atm(1)%gridstruct%f0(i,j) = 2.*MAPL_OMEGA*( -COS(FV_Atm(1)%gridstruct%agrid(i,j,1))*COS(FV_Atm(1)%gridstruct%agrid(i,j,2))*SIN(GRID%f_coriolis_angle) + &
-                                      SIN(FV_Atm(1)%gridstruct%agrid(i,j,2))*COS(GRID%f_coriolis_angle) )
-        enddo
-     enddo
-   endif
-  endif
+      state%ALARMS(TIME_TO_RUN) = ESMF_AlarmCreate( &
+           name="Time2Run", &
+           clock=clock, &
+           ringInterval=Time2Run, &
+           enabled=.true., _RC)
+      call ESMF_AlarmEnable(state%ALARMS(TIME_TO_RUN), _RC)
+      call ESMF_AlarmRingerOn(state%ALARMS(TIME_TO_RUN), _RC)
 
-! Check coordinate information from MAPL_MetaComp
-!--------------------------------------------
-    call MAPL_Get(MAPL,                &
-       LATS          = LATS,           & ! These are in radians
-       LONS          = LONS,           & ! These are in radians
-       INTERNAL_ESMF_STATE=INTERNAL,   &
-                             RC=STATUS )
-    VERIFY_(STATUS)
+      call WRITE_PARALLEL(' ')
+      call WRITE_PARALLEL(state%DT, format='("INITIALIZED ALARM: DYN_TIME_TO_RUN EVERY ",F9.1," secs.")')
 
-  STATE%CLOCK => CLOCK
-  call ESMF_TimeIntervalSet(Time2Run, &
-                            S=nint(STATE%DT), rc=status)
-  VERIFY_(status)
+      !  Clear wall clock time clocks and global budgets
+      state%RUN_TIMES = 0
+      state%NUM_CALLS = 0
 
-  STATE%ALARMS(TIME_TO_RUN) = ESMF_AlarmCreate(name="Time2Run", clock=clock, &
-                              ringInterval=Time2Run, &
-                              Enabled=.TRUE., rc=status) ; VERIFY_(status)
-  call ESMF_AlarmEnable(STATE%ALARMS(TIME_TO_RUN), rc=status); VERIFY_(status)
-  call ESMF_AlarmRingerOn(STATE%ALARMS(TIME_TO_RUN), rc=status); VERIFY_(status)
+      call ESMF_ClockGet(clock, currTime=fv_time, _RC)
+      call ESMF_TimeGet(fv_time, dayOfYear=days, s=seconds, _RC)
 
-  call WRITE_PARALLEL(' ')
-  call WRITE_PARALLEL(STATE%DT, &
-    format='("INITIALIZED ALARM: DYN_TIME_TO_RUN EVERY ",F9.1," secs.")')
+      ! Create alarm for dry mass fix reporting
 
-!  Clear wall clock time clocks and global budgets
+      ! Set an interval for printing. Currently hard-coded to
+      ! six hours, but could be a MAPL_GetResource value
+      call ESMF_TimeIntervalSet(MassAlarmInt, h=6, _RC)
 
-  STATE%RUN_TIMES = 0
-  STATE%NUM_CALLS = 0
+      ! Create the alarm with the above interval
+      MASSALARM = ESMF_AlarmCreate( &
+           clock=clock, &
+           name=trim(Iam)//"_MassAlarm", &
+           ringInterval=MassAlarmInt, &
+           ringTime=fv_time, &
+           refTime=fv_time, &
+           enabled=.true., &
+           sticky=.false., _RC)
 
-  call ESMF_ClockGet( CLOCK, currTime=fv_time, rc=STATUS )
-  VERIFY_(STATUS)
-  call ESMF_TimeGet( fv_time, dayOfYear=days, s=seconds, rc=STATUS )
-  VERIFY_(STATUS)
+      call MAPL_GetPointer(import, phis, 'PHIS', _RC)
 
-  ! ---------------------------------------
-  ! Create alarm for dry mass fix reporting
-  ! ---------------------------------------
+      ! Set FV3 surface geopotential
+      FV_Atm(1)%phis(isc:iec, jsc:jec) = real(phis, kind=REAL8)
+      call mpp_update_domains(FV_Atm(1)%phis, FV_Atm(1)%domain, complete=.true.)
 
-  ! Set an interval for printing. Currently hard-coded to
-  ! six hours, but could be a MAPL_GetResource value
-  call ESMF_TimeIntervalSet(MassAlarmInt, H=6, rc=STATUS)
-  VERIFY_(STATUS)
+      call MAPL_GetPointer(import, varflt, 'VARFLT', _RC)
+      FV_Atm(1)%varflt(isc:iec,jsc:jec) = varflt
 
-  ! Create the alarm with the above interval
-  MASSALARM = ESMF_AlarmCreate(CLOCK = CLOCK, &
-     name         = trim(Iam)//"_MassAlarm",  &
-     RingInterval = MassAlarmInt,             &
-     RingTime     = fv_time,                  &
-     RefTime      = fv_time,                  &
-     Enabled      = .true.,                   &
-     sticky       = .false.,                  &
-     RC           = STATUS                    )
-  VERIFY_(STATUS)
+      FV_Atm(1)%ak = ak
+      FV_Atm(1)%bk = bk
+      FV_Atm(1)%ptop = ak(0)
+      FV_Atm(1)%q(:,:,:,:) = 0.0 ! We Don't Have QV from the Import yet
 
-  call MAPL_GetPointer ( import, phis, 'PHIS', RC=STATUS )
-  VERIFY_(STATUS)
+      if (COLDSTART) then
 
- ! Set FV3 surface geopotential
-  FV_Atm(1)%phis(isc:iec,jsc:jec) = real(phis,kind=REAL8)
-  call mpp_update_domains(FV_Atm(1)%phis, FV_Atm(1)%domain, complete=.true.)
+         if (FV_Atm(1)%flagstruct%grid_type == 4) then
+            if ( FV_Atm(1)%flagstruct%make_hybrid_z ) then
+               hybrid = .false.
+            else
+               hybrid = FV_Atm(1)%flagstruct%hybrid_z
+            endif
+            call init_double_periodic( &
+                 FV_Atm(1)%u,FV_Atm(1)%v,FV_Atm(1)%w,FV_Atm(1)%pt,FV_Atm(1)%delp,FV_Atm(1)%q,FV_Atm(1)%phis, &
+                 FV_Atm(1)%ps,FV_Atm(1)%pe, FV_Atm(1)%peln, &
+                 FV_Atm(1)%pk,FV_Atm(1)%pkz, FV_Atm(1)%uc,FV_Atm(1)%vc, FV_Atm(1)%ua,FV_Atm(1)%va, &
+                 FV_Atm(1)%ak, FV_Atm(1)%bk, FV_Atm(1)%gridstruct,FV_Atm(1)%flagstruct, &
+                 FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%ng, &
+                 FV_Atm(1)%flagstruct%ncnst, FV_Atm(1)%flagstruct%nwat, FV_Atm(1)%flagstruct%ndims, &
+                 FV_Atm(1)%flagstruct%ntiles, FV_Atm(1)%flagstruct%dry_mass, FV_Atm(1)%flagstruct%mountain, &
+                 FV_Atm(1)%flagstruct%moist_phys, FV_Atm(1)%flagstruct%hydrostatic, hybrid, FV_Atm(1)%delz, FV_Atm(1)%ze0, &
+                 FV_Atm(1)%ks, FV_Atm(1)%ptop, FV_Atm(1)%domain, tile_in, FV_Atm(1)%bd)
+            ! Copy FV to internal State
+            call FV_To_State(state)
+            if(gid==masterproc) write(*,*) 'Doubly Periodic IC generated LAT:', FV_Atm(1)%flagstruct%deglat
+         else
+            allocate(UA(isc:iec  ,jsc:jec  ,1:FV_Atm(1)%npz))
+            allocate(VA(isc:iec  ,jsc:jec  ,1:FV_Atm(1)%npz))
+            allocate(UD(isc:iec  ,jsc:jec+1,1:FV_Atm(1)%npz))
+            allocate(VD(isc:iec+1,jsc:jec  ,1:FV_Atm(1)%npz))
+            UA(isc:iec,jsc:jec,:) = state%vars%U(isc:iec,jsc:jec,:)
+            VA(isc:iec,jsc:jec,:) = state%vars%V(isc:iec,jsc:jec,:)
+            call INTERP_AGRID_TO_DGRID(UA, VA, UD, VD)
+            state%vars%U(isc:iec,jsc:jec,:) = UD(isc:iec,jsc:jec,:)
+            state%vars%V(isc:iec,jsc:jec,:) = VD(isc:iec,jsc:jec,:)
+            deallocate(UA)
+            deallocate(VA)
+            deallocate(UD)
+            deallocate(VD)
+            if (.not. FV_HYDROSTATIC) then
+               FV_Atm(1)%w = 0.0
+               W   = 0.0
+               PT = PT*PKZ
+               call fv_getDELZ(DZ,PT,PE)
+               PT = PT/PKZ
+            endif
+            call State_To_FV(state)
+         endif ! doubly-periodic
 
-  call MAPL_GetPointer ( import, varflt, 'VARFLT', RC=STATUS )
-  VERIFY_(STATUS)
-  FV_Atm(1)%varflt(isc:iec,jsc:jec) = varflt
+      else ! COLDSTART
 
-  FV_Atm(1)%ak = ak
-  FV_Atm(1)%bk = bk
-  FV_Atm(1)%ptop = ak(0)
-  FV_Atm(1)%q(:,:,:,:) = 0.0 ! We Don't Have QV from the Import yet
+         !if ( (.not. FV_HYDROSTATIC) .and. (FV_Atm(1)%flagstruct%Make_NH) ) then
+         !   FV_Atm(1)%w = 0.0
+         !   W   = 0.0
+         !   PT = PT*PKZ
+         !   call fv_getDELZ(DZ,PT,PE)
+         !   PT = PT/PKZ
+         !endif
+         call State_To_FV( state )
 
-  if (COLDSTART) then
+      endif ! COLDSTART
 
-   if (FV_Atm(1)%flagstruct%grid_type == 4) then
-       if ( FV_Atm(1)%flagstruct%make_hybrid_z ) then
-         hybrid = .false.
-       else
-         hybrid = FV_Atm(1)%flagstruct%hybrid_z
-       endif
-       call init_double_periodic(FV_Atm(1)%u,FV_Atm(1)%v,FV_Atm(1)%w,FV_Atm(1)%pt,FV_Atm(1)%delp,FV_Atm(1)%q,FV_Atm(1)%phis, &
-                                 FV_Atm(1)%ps,FV_Atm(1)%pe, FV_Atm(1)%peln, &
-                                 FV_Atm(1)%pk,FV_Atm(1)%pkz, FV_Atm(1)%uc,FV_Atm(1)%vc, FV_Atm(1)%ua,FV_Atm(1)%va,        &
-                                 FV_Atm(1)%ak, FV_Atm(1)%bk, FV_Atm(1)%gridstruct,FV_Atm(1)%flagstruct, &
-                                 FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%ng, FV_Atm(1)%flagstruct%ncnst, FV_Atm(1)%flagstruct%nwat,  &
-                                 FV_Atm(1)%flagstruct%ndims, FV_Atm(1)%flagstruct%ntiles, FV_Atm(1)%flagstruct%dry_mass, FV_Atm(1)%flagstruct%mountain, &
-                                 FV_Atm(1)%flagstruct%moist_phys, FV_Atm(1)%flagstruct%hydrostatic, hybrid, FV_Atm(1)%delz, FV_Atm(1)%ze0, &
-                                 FV_Atm(1)%ks, FV_Atm(1)%ptop, FV_Atm(1)%domain, tile_in, FV_Atm(1)%bd)
-     ! Copy FV to internal State
-       call FV_To_State ( STATE )
-       if( gid==masterproc ) write(*,*) 'Doubly Periodic IC generated LAT:', FV_Atm(1)%flagstruct%deglat
-   else
-     ALLOCATE( UA(isc:iec  ,jsc:jec  ,1:FV_Atm(1)%npz) )
-     ALLOCATE( VA(isc:iec  ,jsc:jec  ,1:FV_Atm(1)%npz) )
-     ALLOCATE( UD(isc:iec  ,jsc:jec+1,1:FV_Atm(1)%npz) )
-     ALLOCATE( VD(isc:iec+1,jsc:jec  ,1:FV_Atm(1)%npz) )
-     UA(isc:iec,jsc:jec,:) = STATE%VARS%U(isc:iec,jsc:jec,:)
-     VA(isc:iec,jsc:jec,:) = STATE%VARS%V(isc:iec,jsc:jec,:)
-     call INTERP_AGRID_TO_DGRID( UA, VA, UD, VD )
-     STATE%VARS%U(isc:iec,jsc:jec,:) = UD(isc:iec,jsc:jec,:)
-     STATE%VARS%V(isc:iec,jsc:jec,:) = VD(isc:iec,jsc:jec,:)
-     DEALLOCATE ( UA )
-     DEALLOCATE ( VA )
-     DEALLOCATE ( UD )
-     DEALLOCATE ( VD )
-     if ( .not. FV_HYDROSTATIC) then
-        FV_Atm(1)%w = 0.0
-        W   = 0.0
-        PT = PT*PKZ
-        call fv_getDELZ(DZ,PT,PE)
-        PT = PT/PKZ
-     endif
-     call State_To_FV( STATE )
-   endif ! doubly-periodic
+      if ( (gid==0)                              ) print *, ' '
+      if ( (gid==0) .and. (COLDSTART)            ) print *, 'COLDSTARTING FV3'
+      if ( (gid==0) .and. (ADIABATIC)            ) print *, 'FV3 being run Adiabatically'
+      if ( (gid==0) .and. (.not. FV_HYDROSTATIC) ) print *, 'FV3 being run Non-Hydrostatic'
+      if ( (gid==0) .and. (.not. FV_HYDROSTATIC) .and. (FV_Atm(1)%flagstruct%Make_NH) ) &
+           print *, 'FV3 Coldstarting Non-Hydrostatic W and DZ'
+      if ( (gid==0) .and. (FV_HYDROSTATIC)       ) print *, 'FV3 being run Hydrostatic'
+      if ( (gid==0) .and. (SW_DYNAMICS)          ) print *, 'FV3 being run as Shallow-Water Model: test_case=', test_case
+      if ( (gid==0) .and. (FV_Atm(1)%flagstruct%grid_type == 4) ) &
+           print*, 'FV3 being run as Doubly-Periodic: test_case=', test_case
+      state%vars%nwat = FV_Atm(1)%flagstruct%nwat
+      if ( (gid==0)                              ) print *, 'FV3 water species nwat=', FV_Atm(1)%flagstruct%nwat
+      if ( (gid==0)                              ) print *, ' '
 
-  else ! COLDSTART
+      if (DEBUG) call debug_fv_state('DEBUG_RESTART',state)
 
-    !if ( (.not. FV_HYDROSTATIC) .and. (FV_Atm(1)%flagstruct%Make_NH) ) then
-    !   FV_Atm(1)%w = 0.0
-    !   W   = 0.0
-    !   PT = PT*PKZ
-    !   call fv_getDELZ(DZ,PT,PE)
-    !   PT = PT/PKZ
-    !endif
-     call State_To_FV( STATE )
-
-  endif
-
-  if ( (gid==0)                              ) print*, ' '
-  if ( (gid==0) .and. (COLDSTART)            ) print*, 'COLDSTARTING FV3'
-  if ( (gid==0) .and. (ADIABATIC)            ) print*, 'FV3 being run Adiabatically'
-  if ( (gid==0) .and. (.not. FV_HYDROSTATIC) ) print*, 'FV3 being run Non-Hydrostatic'
-  if ( (gid==0) .and. (.not. FV_HYDROSTATIC) .and. (FV_Atm(1)%flagstruct%Make_NH) ) print*, 'FV3 Coldstarting Non-Hydrostatic W and DZ'
-  if ( (gid==0) .and. (FV_HYDROSTATIC)       ) print*, 'FV3 being run Hydrostatic'
-  if ( (gid==0) .and. (SW_DYNAMICS)          ) print*, 'FV3 being run as Shallow-Water Model: test_case=', test_case
-  if ( (gid==0) .and. (FV_Atm(1)%flagstruct%grid_type == 4) ) print*, 'FV3 being run as Doubly-Periodic: test_case=', test_case
-  STATE%VARS%nwat = FV_Atm(1)%flagstruct%nwat
-  if ( (gid==0)                              ) print*, 'FV3 water species nwat=', FV_Atm(1)%flagstruct%nwat
-  if ( (gid==0)                              ) print*, ' '
-
-  if (DEBUG) call debug_fv_state('DEBUG_RESTART',STATE)
-!
-! Write the vertical coordinate to STDOUT
-!
-  if( gid.eq.0 .and. .not. SW_DYNAMICS) then
-        print *
-        write(6,*) ' x denotes a layer within the "Sponge layer"                of the dynamics'
-        write(6,*) ' + denotes a layer within the "Rayleigh Damping"            of the dynamics'
-        write(6,*) ' o denotes a layer within the "Richardson Number dz-filter" of the dynamics'
-        write(6,100)
-100     format(5x,'  k  ',2x,'   A(k)   ',2x,'   B(k)   ',2x,'   Pref   ',2x,'   DelP   ',/, &
-               5x,'-----',2x,'----------',2x,'----------',2x,'----------',2x,'----------' )
-          do k=0,ubound(ak,1)
+      ! Write the vertical coordinate to STDOUT
+      if( gid.eq.0 .and. .not. SW_DYNAMICS) then
+         print *
+         write(6,*) ' x denotes a layer within the "Sponge layer"                of the dynamics'
+         write(6,*) ' + denotes a layer within the "Rayleigh Damping"            of the dynamics'
+         write(6,*) ' o denotes a layer within the "Richardson Number dz-filter" of the dynamics'
+         write(6,100)
+100      format(5x,'  k  ',2x,'   A(k)   ',2x,'   B(k)   ',2x,'   Pref   ',2x,'   DelP   ',/, &
+              5x,'-----',2x,'----------',2x,'----------',2x,'----------',2x,'----------' )
+         do k=0,ubound(ak,1)
             rPRS=ak(k)*0.01 + 1000.0*bk(k)
             zCODE = ' '
             if ((FV_Atm(1)%flagstruct%fv_sg_adj > 0.0) .AND. (k   <=FV_Atm(1)%flagstruct%n_zfilter))  &
-               zCODE = 'o'
+                 zCODE = 'o'
             rCODE = ' '
             if ((FV_Atm(1)%flagstruct%tau       > 0.0) .AND. (rPRS<=0.01*FV_Atm(1)%flagstruct%rf_cutoff))  &
-               rCODE = '+'
+                 rCODE = '+'
             sCODE = ' '
             if (k<=FV_Atm(1)%flagstruct%n_sponge) &
-               sCODE = 'x'
+                 sCODE = 'x'
             if (k == 0) then
-              write(6,200) sCODE,rCODE,zCODE,k+1,ak(k)*0.01, bk(k), ak(k)*0.01 + 1000.0*bk(k)
+               write(6,200) sCODE,rCODE,zCODE,k+1,ak(k)*0.01, bk(k), ak(k)*0.01 + 1000.0*bk(k)
             else
-              write(6,300) sCODE,rCODE,zCODE,k+1,ak(k)*0.01, bk(k), ak(k)*0.01 + 1000.0*bk(k), &
-                              (ak(k)-ak(k-1))*0.01 + 1000.0*(bk(k)-bk(k-1))
+               write(6,300) sCODE,rCODE,zCODE,k+1,ak(k)*0.01, bk(k), ak(k)*0.01 + 1000.0*bk(k), &
+                    (ak(k)-ak(k-1))*0.01 + 1000.0*(bk(k)-bk(k-1))
             endif
-          enddo
-        print *
-200     format(A1,A1,A1,2x,i5,2x,f10.6,2x,f8.4,2x,f10.4)
-300     format(A1,A1,A1,2x,i5,2x,f10.6,2x,f8.4,2x,f10.4,3x,f8.4)
-  endif
+         enddo
+         print *
+200      format(A1,A1,A1,2x,i5,2x,f10.6,2x,f8.4,2x,f10.4)
+300      format(A1,A1,A1,2x,i5,2x,f10.6,2x,f8.4,2x,f10.4,3x,f8.4)
+      endif
 
-  call MAPL_MemUtilsWrite(VM, 'FV_StateMod: FV Initialize', RC=STATUS )
-  VERIFY_(STATUS)
+      call MAPL_MemUtilsWrite(vm, 'FV_StateMod: FV Initialize', _RC)
 
 #ifdef RUN_GTFV3
-  if (run_gtfv3 /= 0) then
-     ! call ESMF_VMGetCurrent(VM, _RC)
-     call ESMF_VMGet(VM, mpiCommunicator=comm, _RC)
-     ! A workaround to the issue of SIGFPE abort during importing of numpy, is to
-     ! disable trapping of FPEs temporarily, call the Python interface and resume trapping
-     call ieee_get_halting_mode(ieee_all, halting_mode)
-     call ieee_set_halting_mode(ieee_all, .false.)
-     call geos_gtfv3_interface_f_init( &
-          comm, &
-          FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%flagstruct%ntiles, &
-          IS, IE, JS, JE, ISD, IED, JSD, JED, real(STATE%DT), 7)
-     call ieee_set_halting_mode(ieee_all, halting_mode)
-  end if
+      if (run_gtfv3 /= 0) then
+         ! call ESMF_VMGetCurrent(vm, _RC)
+         call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+         ! A workaround to the issue of SIGFPE abort during importing of numpy, is to
+         ! disable trapping of FPEs temporarily, call the Python interface and resume trapping
+         call ieee_get_halting_mode(ieee_all, halting_mode)
+         call ieee_set_halting_mode(ieee_all, .false.)
+         call geos_gtfv3_interface_f_init( &
+              comm, &
+              FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, FV_Atm(1)%flagstruct%ntiles, &
+              IS, IE, JS, JE, ISD, IED, JSD, JED, real(state%DT), 7)
+         call ieee_set_halting_mode(ieee_all, halting_mode)
+      end if
 #endif
 
-  RETURN_(ESMF_SUCCESS)
+      _RETURN(_SUCCESS)
 
-end subroutine FV_InitState
+   end subroutine FV_InitState
 
 subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
 
@@ -1727,7 +1711,7 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
 
 ! Check Dry Mass (Apply fixer is option is enabled)
    if ( check_mass .OR. fix_mass ) then
-      call MAPL_TimerOn(MAPL,"--MASS_FIX")
+      ! call MAPL_TimerOn(MAPL,"--MASS_FIX")
 
       if ( FV_Atm(1)%flagstruct%adjust_dry_mass .AND. &
             ((.not. FV_Atm(1)%flagstruct%hydrostatic) .OR. FV_Atm(1)%flagstruct%nwat>=6)  ) then
@@ -1844,10 +1828,10 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
 
       endif
 
-      call MAPL_TimerOff(MAPL,"--MASS_FIX")
+      ! call MAPL_TimerOff(MAPL,"--MASS_FIX")
    endif
 
-    call MAPL_TimerOn(MAPL,"--NH_ADIABATIC_INIT")
+    ! call MAPL_TimerOn(MAPL,"--NH_ADIABATIC_INIT")
        if ((.not. FV_Atm(1)%flagstruct%hydrostatic) .and. (FV_Atm(1)%flagstruct%na_init>0)) then
           allocate( DEBUG_ARRAY(isc:iec,jsc:jec,NPZ) )
           call nullify_domain ( )
@@ -1859,9 +1843,9 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
           deallocate( DEBUG_ARRAY )
           FV_Atm(1)%flagstruct%na_init=0
        endif
-    call MAPL_TimerOff(MAPL,"--NH_ADIABATIC_INIT")
+    ! call MAPL_TimerOff(MAPL,"--NH_ADIABATIC_INIT")
 
-    call MAPL_TimerOn(MAPL,"--FV_DYNAMICS")
+    ! call MAPL_TimerOn(MAPL,"--FV_DYNAMICS")
     if (.not. FV_OFF) then
     call set_domain(FV_Atm(1)%domain)  ! needed for diagnostic output done in fv_dynamics
     allocate ( u_dt(isc:iec,jsc:jec,npz) )
@@ -1967,7 +1951,7 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
     call nullify_domain()
 
     endif
-    call MAPL_TimerOff(MAPL,"--FV_DYNAMICS")
+    ! call MAPL_TimerOff(MAPL,"--FV_DYNAMICS")
 
   SPHU_FILLED = .FALSE.
   QLIQ_FILLED = .FALSE.
@@ -2643,9 +2627,9 @@ subroutine fv_getPKZ_NH(pkz,temp,qv,pe,delz)
 !-------------------------------------------------------------------------
 ! Re-compute the full (nonhydrostatic) pressure due to temperature changes
 !-------------------------------------------------------------------------
-!$omp parallel do default (none) & 
+!$omp parallel do default (none) &
 !$omp shared (npz, jsc, jec, isc, iec, pkz, kappa, rdg, delp, temp, zvir, qv, delz) &
-!$omp private (k, j, i) 
+!$omp private (k, j, i)
       do k=1,npz
          do j=jsc,jec
             do i=isc,iec
@@ -2678,9 +2662,9 @@ subroutine fv_getPKZ(pkz,pe)
   peln = log(pe)
   pk   = exp( kappa*peln )
 
-!$omp parallel do default (none) & 
+!$omp parallel do default (none) &
 !$omp shared (npz, jsc, jec, isc, iec, pkz, pk, kappa, peln) &
-!$omp private (k, j, i) 
+!$omp private (k, j, i)
       do k=1,npz
          do j=jsc,jec
             do i=isc,iec
@@ -4499,8 +4483,7 @@ end subroutine fv_getAllWinds_2D
 !EOC
 !------------------------------------------------------------------------------
 
-  subroutine CREATE_VARS (I1, IN, J1, JN, K1, KN, KP, &
-       U, V, PT, PE, PKZ, DZ, W, VARS )
+  subroutine CREATE_VARS (I1, IN, J1, JN, K1, KN, KP, U, V, PT, PE, PKZ, DZ, W, VARS)
 
     integer, intent(IN   ) :: I1, IN, J1, JN, K1, KN, KP
     real(REAL8), target ::   U(I1:IN,J1:JN,K1:KN  )
@@ -4950,7 +4933,7 @@ end subroutine echo_fv3_setup
      allocate ( t0(isc:iec,jsc:jec, npz) )
      allocate (dp0(isc:iec,jsc:jec, npz) )
 
-!$omp parallel do default (none) & 
+!$omp parallel do default (none) &
 !$omp shared (npz, jsc, jec, isc, iec, n, sphum, u0, v0, t0, dp0, FV_Atm, zvir) &
 !$omp private (k, j, i)
        do k=1,npz
@@ -5014,7 +4997,7 @@ end subroutine echo_fv3_setup
             time_total)
 !Nudging back to IC
 !$omp parallel do default (none) &
-!$omp shared (npz, jsc, jec, isc, iec, n, sphum, FV_Atm, u0, v0, t0, dp0, xt, zvir) & 
+!$omp shared (npz, jsc, jec, isc, iec, n, sphum, FV_Atm, u0, v0, t0, dp0, xt, zvir) &
 !$omp private (i, j, k)
        do k=1,npz
           do j=jsc,jec+1

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -743,12 +743,12 @@ contains
 
       real :: rPRS
       real(REAL8) :: DT
-      real(REAL8), dimension(:), pointer     :: AK1 => null(), AK => null()
-      real(REAL8), dimension(:), pointer     :: BK1 => null(), BK => null()
+      real(REAL8), dimension(:), pointer :: AK1 => null(), AK => null()
+      real(REAL8), dimension(:), pointer :: BK1 => null(), BK => null()
       real(REAL8), dimension(:,:,:), pointer :: U => null()
       real(REAL8), dimension(:,:,:), pointer :: V => null()
       real(REAL8), dimension(:,:,:), pointer :: PT => null()
-      real(REAL8), dimension(:,:,:), pointer :: PE1 => null(), PE => null()
+      real(REAL8), dimension(:,:,:), pointer :: PE => null()
       real(REAL8), dimension(:,:,:), pointer :: PKZ => null()
       real(REAL8), dimension(:,:,:), pointer :: DZ => null()
       real(REAL8), dimension(:,:,:), pointer :: W => null()
@@ -805,19 +805,16 @@ contains
       call MAPL_GetPointer(internal, u, "U", _RC) ! A-Grid U Wind
       call MAPL_GetPointer(internal, v, "V", _RC)
       call MAPL_GetPointer(internal, pt, "PT", _RC)
-      call MAPL_GetPointer(internal, pe1, "PE", _RC) ! 1-based
+      call MAPL_GetPointer(internal, pe, "PE", _RC) ! 1-based
       call MAPL_GetPointer(internal, pkz, "PKZ", _RC)
       call MAPL_GetPointer(internal, dz, "DZ", _RC)
       call MAPL_GetPointer(internal, w, "W", _RC)
+      ! Ak and BK are expected to be 0-based
       block
-         integer :: is, ie, js, je, ks, ke, km
-         is = lbound(u,1); ie = ubound(u,1)
-         js = lbound(u,2); je = ubound(u,2)
-         ks = lbound(u,3); ke = ubound(u,3)
-         km = ke-ks+1
+         integer :: km
+         km = size(ak1) - 1
          ak(0:km) => ak1(1:km+1)
          bk(0:km) => bk1(1:km+1)
-         pe(is:ie, js:je, 0:km) => pe1(is:ie, js:je, 1:km+1)
       end block
 
       call CREATE_VARS( &

--- a/StandAlone_FV3_Dycore.F90
+++ b/StandAlone_FV3_Dycore.F90
@@ -5,12 +5,9 @@
 
 program StandAlone_FV3_Dycore
    use MAPL
-   use FVdycoreCubed_GridComp,      only: SetServices
+   use FVdycoreCubed_GridComp, only: SetServices
+
    implicit none
-
-!EOP
-
-!EOC
 
    character(*), parameter :: IAM = __FILE__
 
@@ -23,6 +20,3 @@ program StandAlone_FV3_Dycore
    call cap%run(_RC)
 
  end Program StandAlone_FV3_Dycore
-
-!EOC
-


### PR DESCRIPTION
A large part of DynCore has been ported to MAPL3. The port is zero-diff compared to the results of a one-day run of FV3 StandAlone (the `internal` restart).