### PR TITLE
Porting DynCore to MAPL3 - continued

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,10 +184,7 @@ ecbuild_add_executable (
 # main library above.
 if (FV_PRECISION STREQUAL R4R8)
   foreach(executable
-    StandAlone_FV3_Dycore.x
     rs_scale.x
-    StandAlone_AdvCore.x
-    StandAlone_DynAdvCore.x
     c2c.x
     interp_restarts.x
     interp_restarts_bin.x)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,10 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 
 endif ()
 
-set(dependencies MAPL MAPL.generic3g GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared esmf OpenMP::OpenMP_Fortran)
+set(dependencies
+  esmf MAPL MAPL.generic3g MAPL.utilities
+  GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared
+  OpenMP::OpenMP_Fortran)
 
 if (BUILD_GEOS_GTFV3_INTERFACE)
   esma_add_library (${this}

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -27,6 +27,7 @@ module FVdycoreCubed_GridComp
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    ! pchakrab - TODO: need MAPL3 equivalent
    ! use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
+   use MAPL_BaseMod, only: MAPL_RemapBounds
    use MAPL_GridManagerMod, only: grid_manager
    use MAPL_RegridderManagerMod, only: regridder_manager
    use MAPL_RegridMethods, only: REGRID_METHOD_BILINEAR
@@ -3583,7 +3584,10 @@ contains
          self%vars%TRACER(N)%TNAME = fieldname
          if ( self%vars%TRACER(N)%IS_R4 ) then
             call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r4, _RC)
-            self%vars%tracer(n)%content_r4(i1:in, j1:jn, 1:km) => ptr_r4
+            ! gfortran has trouble with pointer bounds remapping
+            ! (Error: Rank remapping target must be rank 1 or simply contiguous)
+            ! self%vars%tracer(n)%content_r4(i1:in, j1:jn, 1:km) => ptr_r4
+            self%vars%tracer(n)%content_r4 => MAPL_RemapBounds(ptr_r4, i1, in, j1, jn, 1, km)
             if (fieldname == QFieldName) then
                qqq%is_r4 = .true.
                qqq%content_r4 => self%vars%tracer(n)%content_r4

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -22,7 +22,7 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_VectorField ! pchakrab: TODO - need MAPL3 equivalent
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL
 
-   use ESMFL_Mod, only: ESMFL_StateGetPointerToData, ESMFL_BundleGetPointerToData, MAPL_AreaMean
+   use ESMFL_Mod, only: ESMFL_BundleGetPointerToData, MAPL_AreaMean
 
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    ! pchakrab - TODO: need MAPL3 equivalent
@@ -458,9 +458,9 @@ contains
       integer :: i, numTracers, status
 
       ! Setup FMS/FV3
-      call MAPL_GridCompTimerStart(gc, "DynSetup", _RC)
+      call MAPL_GridCompTimerStart(gc, "DYN_SETUP", _RC)
       call DynSetup(gc, _RC)
-      call MAPL_GridCompTimerStop(gc, "DynSetup", _RC)
+      call MAPL_GridCompTimerStop(gc, "DYN_SETUP", _RC)
 
       ! Get the private state
       _GET_NAMED_PRIVATE_STATE(gc, DynState, PRIVATE_STATE, self)
@@ -476,9 +476,9 @@ contains
       ! Set Private Internal State from Restart File
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
-      call MAPL_GridCompTimerStart(gc, "DynInit", _RC)
+      call MAPL_GridCompTimerStart(gc, "DYN_INIT", _RC)
       call DynInit(self, clock, import, gc, _RC)
-      call MAPL_GridCompTimerStop(gc, "DynInit", _RC)
+      call MAPL_GridCompTimerStop(gc, "DYN_INIT", _RC)
 
       ! Create PREF EXPORT Coupling (Needs to be done only once per run)
       call MAPL_StateGetPointer(internal, ak, "AK", _RC)
@@ -741,11 +741,10 @@ contains
       real(r4), allocatable ::   cubetemp3d(:,:,:)
       real(r4), allocatable ::   cubevtmp3d(:,:,:)
 
-      real(r4), pointer :: uh25(:,:)
-      real(r4), pointer :: uh03(:,:)
-      real(r4), pointer :: srh01(:,:)
-      real(r4), pointer :: srh03(:,:)
-      real(r4), pointer :: srh25(:,:)
+      real(r4), pointer :: uh25(:,:), uh03(:,:)
+      real(r4), pointer :: srh01(:,:), srh03(:,:), srh25(:,:)
+      real(r4), allocatable :: uh25tmp(:,:), uh03tmp(:,:)
+      real(r4), allocatable :: srh01tmp(:,:), srh03tmp(:,:), srh25tmp(:,:)
 
       real(r8),     allocatable ::   uatmp(:,:,:)
       real(r8),     allocatable ::   vatmp(:,:,:)
@@ -1030,7 +1029,7 @@ contains
       ! WMP Begin REPLAY/ANA section
       call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", FV3_STANDALONE, default=.false., _RC)
       if (.not. FV3_STANDALONE) then
-         ! call MAPL_TimerOn(MAPL, "-DYN_ANA")
+         call MAPL_GridCompTimerStart(gc, "DYN_ANA", _RC)
          call ESMF_ClockGetAlarm(clock, "ReplayShutOff", alarm, _RC)
          is_shutoff = ESMF_AlarmIsRinging(alarm, _RC)
       else
@@ -1681,11 +1680,11 @@ contains
          end if
 
       endif
-      ! if (.not. FV3_STANDALONE) then
-      !    call MAPL_TimerOff(MAPL,"-DYN_ANA")
-      ! endif
+      if (.not. FV3_STANDALONE) then
+         call MAPL_GridCompTimerStop(gc, "DYN_ANA", _RC)
+      endif
 
-      ! call MAPL_TimerOn(MAPL,"-DYN_PROLOGUE")
+      call MAPL_GridCompTimerStart(gc,"DYN_PROLOGUE", _RC)
       ! Create FV Thermodynamic Variables
       tempxy = vars%pt * vars%pkz      ! Compute Dry Temperature
 
@@ -1853,18 +1852,18 @@ contains
       ! Get pressures before dynamics
       pe0=vars%pe
 
-      ! call MAPL_TimerOff(MAPL, "-DYN_PROLOGUE")
+      call MAPL_GridCompTimerStop(gc, "DYN_PROLOGUE", _RC)
 
       !-------------------------------------------------------
 
-      ! call MAPL_TimerOn(MAPL, "-DYN_CORE")
+      call MAPL_GridCompTimerStart(gc, "DYN_CORE", _RC)
       t1 = MPI_Wtime(status)
       call DynRun(self, export, clock, gc, PLE0=pe0, _RC)
       t2 = MPI_Wtime(status)
       dyn_run_timer = t2-t1
-      ! call MAPL_TimerOff(MAPL, "-DYN_CORE")
+      call MAPL_GridCompTimerStop(gc, "DYN_CORE", _RC)
 
-      ! call MAPL_TimerOn(MAPL, "-DYN_EPILOGUE")
+      call MAPL_GridCompTimerStart(gc, "DYN_EPILOGUE", _RC)
       ! Computational diagnostics
       call MAPL_StateGetPointer(export, temp2d, "TIME_IN_DYN", _RC)
       if(associated(temp2d)) temp2d = dyn_run_timer
@@ -2569,19 +2568,23 @@ contains
          end if
 
          ! Updraft Helicty Exports
-         ! pchakrab: TODO - how to handle `alloc=.true.` in MAPL3??
-         call MAPL_GetPointer(export,  uh25, 'UH25', alloc=.true., _RC)
-         call MAPL_GetPointer(export,  uh03, 'UH03', alloc=.true., _RC)
-         call MAPL_GetPointer(export, srh01,'SRH01', alloc=.true., _RC)
-         call MAPL_GetPointer(export, srh03,'SRH03', alloc=.true., _RC)
-         call MAPL_GetPointer(export, srh25,'SRH25', alloc=.true., _RC)
+         call MAPL_StateGetPointer(export,  uh25, 'UH25', _RC)
+         call MAPL_StateGetPointer(export,  uh03, 'UH03', _RC)
+         call MAPL_StateGetPointer(export, srh01,'SRH01', _RC)
+         call MAPL_StateGetPointer(export, srh03,'SRH03', _RC)
+         call MAPL_StateGetPointer(export, srh25,'SRH25', _RC)
          ! Per WMP, this calculation is not useful if running hydrostatic
-         if (.not. HYDROSTATIC) then
-            if( associated( uh25) .or. associated( uh03) .or. &
-                 associated(srh01) .or. associated(srh03) .or. associated(srh25) ) then
-               call fv_getUpdraftHelicity(uh25, uh03, srh01, srh03, srh25)
+         if ( associated(uh25)  .or. associated(uh03) .or. &
+              associated(srh01) .or. associated(srh03) .or. associated(srh03)) then
+            if (.not. HYDROSTATIC) then
+               call fv_getUpdraftHelicity(uh25tmp, uh03tmp, srh01tmp, srh03tmp, srh25tmp)
+               if (associated(uh25)) uh25 = uh25tmp
+               if (associated(uh03)) uh03 = uh03tmp
+               if (associated(srh01)) srh01 = srh01tmp
+               if (associated(srh03)) srh03 = srh03tmp
+               if (associated(srh25)) srh25 = srh25tmp
             endif
-         endif
+         end if
 
          ! Divergence Exports
          logpe = log(vars%pe)
@@ -2689,7 +2692,7 @@ contains
 
       end if   ! SW_DYNAMICS
 
-      ! call MAPL_TimerOff(MAPL, "-DYN_EPILOGUE")
+      call MAPL_GridCompTimerStop(gc, "DYN_EPILOGUE", _RC)
 
       ! De-Allocate Arrays
 
@@ -3796,9 +3799,9 @@ contains
          endif
 
          ! Add Diabatic Forcing to State Variables
-         ! call MAPL_TimerOn (GENSTATE,"PHYS_ADD_INCS")
+         call MAPL_GridCompTimerStart(gc, "PHYS_ADD_INCS", _RC)
          call ADD_INCS(esmfgrid, self, import, DT)
-         ! call MAPL_TimerOff(GENSTATE,"PHYS_ADD_INCS")
+         call MAPL_GridCompTimerStop(gc, "PHYS_ADD_INCS", _RC)
 
          if (DYN_DEBUG) call DEBUG_FV_STATE('PHYSICS ADD_INCS', self)
 
@@ -4456,8 +4459,7 @@ contains
          tend_va(is:ie,js:je,1:km) = tend
 
          !if (.not. HYDROSTATIC ) then
-         !  call ESMFL_StateGetPointerToData ( import,TEND,'DWDT',RC=STATUS )
-         !  VERIFY_(STATUS)
+         !  call MAPL_StateGetPointer(import, TEND, 'DWDT', _RC)
          !  self%vars%W = self%vars%W + DT*TEND(is:ie,js:je,1:km)
          !endif
 

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -27,7 +27,6 @@ module FVdycoreCubed_GridComp
    use MAPL_AbstractRegridderMod, only: AbstractRegridder
    ! pchakrab - TODO: need MAPL3 equivalent
    ! use MAPL_SunMod, only: MAPL_SunOrbit, MAPL_SunGetInsolation
-   use MAPL_BaseMod, only: MAPL_RemapBounds
    use MAPL_GridManagerMod, only: grid_manager
    use MAPL_RegridderManagerMod, only: regridder_manager
    use MAPL_RegridMethods, only: REGRID_METHOD_BILINEAR
@@ -3414,11 +3413,6 @@ contains
             call logger%info(trim(STRING))
          endif
          _ASSERT(nq3d>=2, "state_remap: invalid number of tracers")
-         ! if (nq3d<2) then
-         !    call WRITE_PARALLEL('state_remap: invalid number of tracers')
-         !    status=999
-         !    _VERIFY(STATUS)
-         ! endif
 
          iib = lbound(vars%pe,1)
          iie = ubound(vars%pe,1)
@@ -3455,21 +3449,11 @@ contains
                if (rank==3) then
                   icnt=icnt+1
                   _ASSERT(icnt<=nq3d, "state_remap: number of tracers exceeds known value")
-                  ! if (icnt>nq3d) then
-                  !    call WRITE_PARALLEL('state_remap: number of tracers exceeds known value')
-                  !    status=999
-                  !    _VERIFY(STATUS)
-                  ! endif
                   call ESMFL_BundleGetPointerToData(BUNDLE, NAME, ptr3dr4, _RC)
                   ana_qq(:,:,:,icnt) = ptr3dr4
                endif
             enddo
             _ASSERT(icnt==nq3d, "state_remap: inconsitent number of tracers")
-            ! if (icnt/=nq3d) then
-            !    call WRITE_PARALLEL('state_remap: inconsitent number of tracers')
-            !    status=999
-            !    _VERIFY(STATUS)
-            ! endif
          else
             if( qqq%is_r4 ) then
                ana_qq(:,:,:,1) = qqq%content_r4(:,:,:)
@@ -3599,7 +3583,7 @@ contains
          self%vars%TRACER(N)%TNAME = fieldname
          if ( self%vars%TRACER(N)%IS_R4 ) then
             call ESMF_ArrayGet(array, localDE=0, farrayptr=ptr_r4, _RC)
-            self%vars%tracer(n)%content_r4 => MAPL_RemapBounds(ptr_r4, i1, in, j1, jn, 1, km)
+            self%vars%tracer(n)%content_r4(i1:in, j1:jn, 1:km) => ptr_r4
             if (fieldname == QFieldName) then
                qqq%is_r4 = .true.
                qqq%content_r4 => self%vars%tracer(n)%content_r4

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -444,13 +444,12 @@ contains
       character(len=:), allocatable :: ReplayMode
 
       real(r4), pointer :: pref(:)
-      ! real(r4), pointer :: ple(:,:,:)
       real(r4), pointer :: u(:,:,:), v(:,:,:), t(:,:,:)
       real(r4), pointer :: temp2d(:,:)
 
       real(r8), pointer ::  ak(:), bk(:)
       real(r8), pointer ::  ud(:,:,:), vd(:,:,:)
-      real(r8), pointer ::  pe(:,:,:), pt(:,:,:), pk(:,:,:)
+      real(r8), pointer ::  pt(:,:,:), pk(:,:,:)
       real(r8), allocatable ::  ur(:,:,:), vr(:,:,:) ! rotated winds
 
       real :: DNS_INTERVAL
@@ -481,38 +480,36 @@ contains
       call DynInit(self, clock, import, gc, _RC)
       call MAPL_GridCompTimerStop(gc, "DynInit", _RC)
 
-      ! Create PLE and PREF EXPORT Coupling (Needs to be done only once per run)
+      ! Create PREF EXPORT Coupling (Needs to be done only once per run)
       call MAPL_StateGetPointer(internal, ak, "AK", _RC)
       call MAPL_StateGetPointer(internal, bk, "BK", _RC)
       call MAPL_StateGetPointer(export, pref, "PREF", _RC)
       if (associated(pref)) pref = ak + bk * P00
 
-      call MAPL_StateGetPointer(internal, ud, "U", _RC)
-      call MAPL_StateGetPointer(internal, vd, "V", _RC)
-      call MAPL_StateGetPointer(internal, pe, "PE", _RC)
-      call MAPL_StateGetPointer(internal, pt, "PT", _RC)
-      call MAPL_StateGetPointer(internal, pk, "PKZ", _RC)
-
-      ! pchakrab: TODO - how to handle `alloc=.true.` in MAPL3??
-      call MAPL_GetPointer(export, u, "U", alloc=.true., _RC)
-      call MAPL_GetPointer(export, v, "V", alloc=.true., _RC)
-      call MAPL_GetPointer(export, t, "T", alloc=.true., _RC)
-
       ! Create A-Grid Winds
-      ifirst = self%grid%is
-      ilast  = self%grid%ie
-      jfirst = self%grid%js
-      jlast  = self%grid%je
-      km     = self%grid%npz
+      call MAPL_StateGetPointer(export, u, "U", _RC)
+      call MAPL_StateGetPointer(export, v, "V", _RC)
+      if (associated(u) .and. associated(v)) then
+         ifirst = self%grid%is; ilast = self%grid%ie
+         jfirst = self%grid%js; jlast = self%grid%je
+         km = self%grid%npz
+         allocate(ur(ifirst:ilast, jfirst:jlast, km))
+         allocate(vr(ifirst:ilast, jfirst:jlast, km))
+         call MAPL_StateGetPointer(internal, ud, "U", _RC)
+         call MAPL_StateGetPointer(internal, vd, "V", _RC)
+         call getAllWinds(ud, vd, ur=ur, vr=vr)
+         u = ur
+         v = vr
+         deallocate(ur, vr)
+      end if
 
-      allocate(ur(ifirst:ilast, jfirst:jlast, km))
-      allocate(vr(ifirst:ilast, jfirst:jlast, km))
-      call getAllWinds(ud, vd, ur=ur, vr=vr)
-      u = ur
-      v = vr
-      t = pt*pk
-      ! ple = pe
-      deallocate(ur, vr)
+      ! Temperature
+      call MAPL_StateGetPointer(export, t, "T", _RC)
+      if (associated(t)) then
+         call MAPL_StateGetPointer(internal, pt, "PT", _RC)
+         call MAPL_StateGetPointer(internal, pk, "PKZ", _RC)
+         t = pt*pk
+      end if
 
       ! Fill Grid-Cell Area Delta-X/Y
       call MAPL_StateGetPointer(export, temp2d, "DXC", _RC)
@@ -560,13 +557,11 @@ contains
       end if
 
       !=====Begin intemittent replay=======================
-
       ! Set the intermittent replay alarm, if needed.
       ! Note that it is a non-sticky alarm
       ! and is set to ringing on first step. So it will
       ! work whether the clock is backed-up and ticked
       ! or not.
-
       call MAPL_GridCompGetResource(gc, "REPLAY_MODE", ReplayMode, default="NoReplay", _RC)
       if (adjustl(ReplayMode) == "Intermittent") then
          call MAPL_GridCompGetResource(gc, "REPLAY_INTERVAL", DNS_INTERVAL, default=21600., _RC)
@@ -574,7 +569,6 @@ contains
          alarm = ESMF_AlarmCreate(name="INTERMITTENT", clock=clock, ringInterval=intv, sticky=.false., _RC)
          call ESMF_AlarmRingerOn(alarm, _RC)
       end if
-
       !========End intermittent replay========================
 
       _RETURN(_SUCCESS)

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -8,13 +8,13 @@ module FV_StateMod
 #if defined( MAPL_MODE )
    use ESMF
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY, MAPL_RTRN
-   use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
    use FileIOSharedMod, only: WRITE_PARALLEL
 
    use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
    use mapl3g_Geom_API, only: MAPL_GridGet
    use mapl3g_State_API, only: MAPL_StateGetPointer
+   use mapl3g_utilities, only: MAPL_MemInfoWrite
 #endif
    use MAPL_ConstantsMod, only: MAPL_UNDEFINED_REAL
    use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
@@ -316,7 +316,7 @@ contains
       type(ESMF_VM) :: vm
       type(ESMF_Geom) :: geom
       type(ESMF_HConfig) :: hconfig
-      character(len=ESMF_MAXSTR) :: Iam='FV_StateMod::FV_Setup'
+      character(len=*), parameter :: Iam="FV_StateMod::FV_Setup"
       character(len=:), allocatable :: DYCORE
       real(FVPRC) :: DT
       real :: temp_real
@@ -327,19 +327,19 @@ contains
       call logger%info("FV_Setup::starting...")
 
       call ESMF_VMGetCurrent(vm, _RC)
-      call MAPL_MemUtilsWrite(vm, trim(Iam), _RC)
-
       call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+      call MAPL_MemInfoWrite(comm, logger, Iam, _RC)
+
       call MAPL_GridCompTimerStart(gc, "fms_init", _RC)
       call fms_init(comm)
       call MAPL_GridCompTimerStop(gc, "fms_init", _RC)
-      call MAPL_MemUtilsWrite(vm, 'FV_StateMod::fms_init', _RC)
+      call MAPL_MemInfoWrite(comm, logger, "fms_init", _RC)
 
       ! Start up FV
       call MAPL_GridCompTimerStart(gc, "fv_init1", _RC)
       call fv_init1(FV_Atm, DT, grids_on_this_pe, p_split)
       call MAPL_GridCompTimerStop(gc, "fv_init1", _RC)
-      call MAPL_MemUtilsWrite(vm, 'FV_StateMod::fv_init1', _RC)
+      call MAPL_MemInfoWrite(comm, logger, "fv_init1", _RC)
 
       ! FV grid dimensions setup from MAPL
       call MAPL_GridCompGet(gc, hconfig=hconfig, num_levels=num_levels, _RC)
@@ -667,7 +667,7 @@ contains
       call MAPL_GridCompTimerStart(gc, "fv_init2", _RC)
       call fv_init2(FV_Atm, DT, grids_on_this_pe, p_split)
       call MAPL_GridCompTimerStop(gc, "fv_init2", _RC)
-      call MAPL_MemUtilsWrite(VM, 'FV_StateMod::fv_init2', _RC)
+      call MAPL_MemInfoWrite(comm, logger, "fv_init2", _RC)
 
       ! Force compatibility of gmao_remap and n_zfilter
       if (FV_Atm(1)%flagstruct%gmao_remap > 0) then
@@ -689,7 +689,7 @@ contains
       DEBUG = FV_Atm(1)%flagstruct%fv_debug
       call MAPL_GridCompGetResource(gc, "DEBUG_STATE", DEBUG, default=DEBUG, _RC)
 
-      call MAPL_MemUtilsWrite(vm, trim(Iam), _RC)
+      call MAPL_MemInfoWrite(comm, logger, Iam, _RC)
 
 #ifdef RUN_GTFV3
       call MAPL_GridCompGetResource(gc, "RUN_GTFV3", run_gtfv3, default=0, _RC)
@@ -746,7 +746,7 @@ contains
       type(ESMF_VM) :: vm
       type(ESMF_Time) :: fv_time
       type(T_FVDYCORE_GRID), pointer :: grid
-      character(len=ESMF_MAXSTR) :: IAm='FV:FV_InitState'
+      character(len=*), parameter :: IAm="FV:FV_InitState"
       character(len=1) :: sCODE, rCODE, zCODE
 
       real :: rPRS
@@ -776,8 +776,9 @@ contains
 
 #ifdef RUN_GTFV3
       logical :: halting_mode(5)
-      integer :: comm
 #endif
+      integer :: comm
+      class(logger_t), pointer :: logger
 
       call MAPL_GridCompGetResource(gc, "RUN_DT", ndt, default=0, _RC)
       DT = ndt
@@ -799,7 +800,8 @@ contains
       gid = mpp_pe()
 
       call ESMF_GridCompGet(gc, vm=vm, _RC)
-      call MAPL_GridCompGet(gc, grid=grid%grid, _RC)
+      call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+      call MAPL_GridCompGet(gc, grid=grid%grid, logger=logger, _RC)
 
       call WRITE_PARALLEL(' ')
       call WRITE_PARALLEL(state%DT,format='("Dynamics time step : ",(F10.4))')
@@ -828,7 +830,7 @@ contains
            FV_Atm(1)%bd%isc, FV_Atm(1)%bd%iec, FV_Atm(1)%bd%jsc, FV_Atm(1)%bd%jec, &
            1, FV_Atm(1)%flagstruct%npz, FV_Atm(1)%flagstruct%npz+1, &
            U, V, PT, PE, PKZ, DZ, W, state%vars)
-      call MAPL_MemUtilsWrite(vm, 'FV_StateMod: CREATE_VARS', _RC)
+      call MAPL_MemInfoWrite(comm, logger, "create_vars", _RC)
 
       grid%IS = FV_Atm(1)%bd%isc
       grid%IE = FV_Atm(1)%bd%iec
@@ -1054,12 +1056,10 @@ contains
 300      format(A1,A1,A1,2x,i5,2x,f10.6,2x,f8.4,2x,f10.4,3x,f8.4)
       endif
 
-      call MAPL_MemUtilsWrite(vm, 'FV_StateMod::FV Initialize', _RC)
+      call MAPL_MemInfoWrite(comm, logger, "FV Initialize", _RC)
 
 #ifdef RUN_GTFV3
       if (run_gtfv3 /= 0) then
-         ! call ESMF_VMGetCurrent(vm, _RC)
-         call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
          ! A workaround to the issue of SIGFPE abort during importing of numpy, is to
          ! disable trapping of FPEs temporarily, call the Python interface and resume trapping
          call ieee_get_halting_mode(ieee_all, halting_mode)

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -6,19 +6,18 @@ module FV_StateMod
 
    !USES:
 #if defined( MAPL_MODE )
-   use ESMF                ! ESMF base class
-   ! use MAPL              ! MAPL base class
+   use ESMF
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY, MAPL_RTRN
    use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
-   use MAPL_BaseMod, only: MAPL_UNDEF
    use ESMFL_Mod, only: ESMFL_StateGetPointerToData
    use FileIOSharedMod, only: WRITE_PARALLEL
 
    use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
-   use mapl3g_Geom_API, only: MAPL_GridGet !, MAPL_GeomGet
+   use mapl3g_Geom_API, only: MAPL_GridGet
    use mapl3g_State_API, only: MAPL_StateGetPointer
 #endif
+   use MAPL_ConstantsMod, only: MAPL_UNDEFINED_REAL
    use MAPL_ConstantsMod, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
    use MAPL_ConstantsMod, only: MAPL_KAPPA, MAPL_PI_R8, MAPL_ALHL, MAPL_PSDRY, MAPL_OMEGA
 
@@ -3097,8 +3096,8 @@ subroutine fv_computeMassFluxes_r4(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
   integer     :: it, nsplt
 
 ! Fill Ghosted arrays and update halos
-  uc = MAPL_UNDEF
-  vc = MAPL_UNDEF
+  uc = MAPL_UNDEFINED_REAL
+  vc = MAPL_UNDEFINED_REAL
   uc(is:ie,js:je,:) = ucI
   vc(is:ie,js:je,:) = vcI
   call mpp_get_boundary(uc, vc, FV_Atm(1)%domain, &
@@ -3280,8 +3279,8 @@ subroutine fv_computeMassFluxes_r8(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
   integer     :: it, nsplt
 
 ! Fill Ghosted arrays and update halos
-  uc = MAPL_UNDEF
-  vc = MAPL_UNDEF
+  uc = MAPL_UNDEFINED_REAL
+  vc = MAPL_UNDEFINED_REAL
   uc(is:ie,js:je,:) = ucI
   vc(is:ie,js:je,:) = vcI
   call mpp_get_boundary(uc, vc, FV_Atm(1)%domain, &
@@ -3927,11 +3926,11 @@ end subroutine fv_getDivergence
 subroutine fv_getUpdraftHelicity(uh25, uh03, srh01, srh03, srh25)
    use constants_mod, only: fms_grav=>grav
 ! made this REAL4
-   real(REAL4), intent(OUT) ::  uh25(:,:)
-   real(REAL4), intent(OUT) ::  uh03(:,:)
-   real(REAL4), intent(OUT) :: srh01(:,:)
-   real(REAL4), intent(OUT) :: srh03(:,:)
-   real(REAL4), intent(OUT) :: srh25(:,:)
+   real(REAL4), allocatable, intent(OUT) ::  uh25(:,:)
+   real(REAL4), allocatable, intent(OUT) ::  uh03(:,:)
+   real(REAL4), allocatable, intent(OUT) :: srh01(:,:)
+   real(REAL4), allocatable, intent(OUT) :: srh03(:,:)
+   real(REAL4), allocatable, intent(OUT) :: srh25(:,:)
 
 ! made an intermediate output of FVPRC
    real(FVPRC) :: uh_tmp(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec,FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec)

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -9,7 +9,6 @@ module FV_StateMod
    use ESMF
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY, MAPL_RTRN
    use MAPL_MemUtilsMod, only: MAPL_MemUtilsWrite
-   use ESMFL_Mod, only: ESMFL_StateGetPointerToData
    use FileIOSharedMod, only: WRITE_PARALLEL
 
    use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState

--- a/fv3sa.yaml
+++ b/fv3sa.yaml
@@ -29,6 +29,6 @@ mapl:
     activate_all_imports: true
     activate_all_exports: true
     checkpoint:
-      export: true
+      # export: true
       # import: true
       internal: true


### PR DESCRIPTION
- All `MAPL_GetPointer` calls have been replaced with `MAPL_StateGetPointer`
- Using `MAPL_MemInfoWrite` instead of `MAPL_MemUtilsWrite`
- Removed references to standalones in `CMakeLists.txt` that crept in during one update
- Replaced call to `MAPL_RemapBounds` with standard Fortran syntax
- `Initialize` fills exports `U`, `V`, `T` only when they have been requested