### PR TITLE
[Fix] Coldstart non-hydrostatic `delz` computation

### DIFF
--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -2711,7 +2711,7 @@ subroutine fv_getDELZ(delz,temp,pe)
   real(REAL8) :: rdg
   peln = log(pe)
   rdg   = -rgas / grav
-  delz = rdg*temp*(peln(:,:,2:)-peln(:,:,1:))
+  delz = rdg*temp*(peln(:,:,2:)-peln(:,:,1:FV_Atm(1)%npz))
 return
 end subroutine fv_getDELZ
 


### PR DESCRIPTION
When running a coldstart (like standalone FV) on a non-hydrostatic run, `delz`  is computed by `fv_getDELZ` in `FV_StateMod`. The computation miss the range of the diff on `peln`

`0-diff` because this is only a standalone + non-hydro code path.