### PR TITLE
Port FVdycore files off MAPL_GenericMod to MAPL3

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -1,4 +1,4 @@
-#include "MAPL_Generic.h"
+#include "MAPL.h"
 
 !BOP
 !MODULE: AdvCore_GridCompMod
@@ -49,7 +49,8 @@ module AdvCore_GridCompMod
 
    !USES:
    use ESMF
-   use MAPL2
+   use MAPL
+   use mapl3g_GridGet, only: GridGet
    use m_set_eta,       only: set_eta
    use mpp_mod,         only: mpp_pe, mpp_root_pe
    use fv_arrays_mod,   only: fv_atmos_type, FVPRC, REAL4, REAL8
@@ -111,7 +112,6 @@ contains
       character(len=ESMF_MAXSTR) :: IAm
       integer :: status
       character(len=ESMF_MAXSTR) :: comp_name
-      type(MAPL_MetaComp), pointer :: MAPL
       character(len=ESMF_MAXSTR) :: dycore
       type(ESMF_VM) :: VM
       integer :: comm, ndt
@@ -141,19 +141,13 @@ contains
       enddo
 
       ! Set the Profiling timers
-      call MAPL_TimerAdd(gc, name="INITIALIZE", _RC)
-      call MAPL_TimerAdd(gc, name="RUN", _RC)
-      call MAPL_TimerAdd(gc, name="FINALIZE", _RC)
-      call MAPL_TimerAdd(gc, name="TOTAL", _RC)
-
       ! Register methods with MAPL
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, Initialize, _RC)
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, Run, _RC)
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_FINALIZE, Finalize, _RC)
 
       ! Check if AdvCore is running without FV3_DynCoreIsRunning, if yes then setup the MAPL Grid
-      call MAPL_GetObjectFromGC(gc, MAPL, _RC)
-      call MAPL_GetResource(MAPL, dycore, 'DYCORE:', default="", _RC)
+      call MAPL_GridCompGetResource(gc, 'DYCORE:', value=dycore, default="", _RC)
 
       if(adjustl(DYCORE)=="FV3") then
          FV3_DynCoreIsRunning = .true.
@@ -164,8 +158,8 @@ contains
          AdvCore_Advection = 1
       endif
 
-      call MAPL_GetResource(MAPL, AdvCore_Advection , label='AdvCore_Advection:', default=AdvCore_Advection, _RC)
-      call MAPL_GetResource(MAPL, DEBUG_ADV, 'DEBUG_ADV:', default=.FALSE., _RC)
+      call MAPL_GridCompGetResource(gc, 'AdvCore_Advection:', value=AdvCore_Advection, default=AdvCore_Advection, _RC)
+      call MAPL_GridCompGetResource(gc, 'DEBUG_ADV:', value=DEBUG_ADV, default=.FALSE., _RC)
 
       ! Start up FMS/MPP
       !-------------------------------------------
@@ -175,10 +169,10 @@ contains
       if (.NOT. FV3_DynCoreIsRunning) then
           ! Make sure FV3 is setup
           call fv_init1(FV_Atm, dt, grids_on_my_pe, p_split)
-         ! Get Domain decomposition
-         call MAPL_GetResource(MAPL, nx, 'NX:', default=0, _RC)
+          ! Get Domain decomposition
+         call MAPL_GridCompGetResource(gc, 'NX:', value=nx, default=0, _RC)
          FV_Atm(1)%layout(1) = nx
-         call MAPL_GetResource(MAPL, ny, 'NY:', default=0, _RC)
+         call MAPL_GridCompGetResource(gc, 'NY:', value=ny, default=0, _RC)
          if (FV_Atm(1)%flagstruct%grid_type == 4) then
             FV_Atm(1)%layout(2) = ny
          else
@@ -186,9 +180,9 @@ contains
          end if
          ! Get Resolution Information
          ! FV grid dimensions setup from MAPL
-         call MAPL_GetResource(MAPL, FV_Atm(1)%flagstruct%npx, 'IM:', default=32, _RC)
-         call MAPL_GetResource(MAPL, FV_Atm(1)%flagstruct%npy, 'JM:', default=192, _RC)
-         call MAPL_GetResource(MAPL, FV_Atm(1)%flagstruct%npz, 'LM:', default=72, _RC)
+         call MAPL_GridCompGetResource(gc, 'IM:', value=FV_Atm(1)%flagstruct%npx, default=32, _RC)
+         call MAPL_GridCompGetResource(gc, 'JM:', value=FV_Atm(1)%flagstruct%npy, default=192, _RC)
+         call MAPL_GridCompGetResource(gc, 'LM:', value=FV_Atm(1)%flagstruct%npz, default=72, _RC)
 
          ! FV likes npx;npy in terms of cell vertices
          if (FV_Atm(1)%flagstruct%npy == 6*FV_Atm(1)%flagstruct%npx) then
@@ -202,11 +196,11 @@ contains
          endif
       endif
 
-      call MAPL_GetResource(MAPL, ndt, 'RUN_DT:', default=0, _RC)
+      call MAPL_GridCompGetResource(gc, 'RUN_DT:', value=ndt, default=0, _RC)
       DT = ndt
 
-      call MAPL_GetResource(MAPL, rpt_mass, 'ADV_CORE_REPORT_TRACER_MASS:', default=rpt_mass, _RC)
-      call MAPL_GetResource(MAPL, QSPLIT, 'ADV_QSPLIT:', default=0, _RC)
+      call MAPL_GridCompGetResource(gc, 'ADV_CORE_REPORT_TRACER_MASS:', value=rpt_mass, default=rpt_mass, _RC)
+      call MAPL_GridCompGetResource(gc, 'ADV_QSPLIT:', value=QSPLIT, default=0, _RC)
 
       ! Start up FV if AdvCore is running without FV3_DynCoreIsRunning
       if (.NOT. FV3_DynCoreIsRunning) then
@@ -214,8 +208,6 @@ contains
       end if
 
       ! Ending with a Generic SetServices call is a MAPL requirement
-      call MAPL_GenericSetServices(gc, _RC)
-
       _RETURN(_SUCCESS)
    end subroutine SetServices
 
@@ -241,7 +233,6 @@ contains
       !BOC
       character(len=ESMF_MAXSTR) :: IAm, comp_name
       type(ESMF_Config) :: cf
-      type(MAPL_MetaComp), pointer :: MAPL
       type(ESMF_VM) :: vm
       type(ESMF_Grid) :: grid
       real, pointer :: temp2d(:,:)
@@ -254,13 +245,7 @@ contains
       Iam = trim(comp_name) // trim(Iam)
 
       ! Retrieve the pointer to the state
-      call MAPL_GetObjectFromGC(gc, MAPL, _RC)
-
-      call MAPL_TimerOn(MAPL, "TOTAL")
-      call MAPL_TimerOn(MAPL, "INITIALIZE")
-
       gridCreated=.false.
-      call MAPL_GetObjectFromGC(gc, MAPL, _RC)
       call ESMF_GridCompGet(gc, grid=grid, rc=status)
       if (status == ESMF_SUCCESS) then
          call ESMF_GridValidate(grid, rc=status)
@@ -268,8 +253,6 @@ contains
       end if
 
       if (.not. gridCreated) call MAPL_GridCreate(gc, _RC)
-
-      call MAPL_GenericInitialize(gc, import, export, clock, _RC)
 
       ! Compute Grid-Cell Area
       if (.NOT. FV3_DynCoreIsRunning) then
@@ -280,9 +263,6 @@ contains
          call MAPL_GetPointer(export, temp2d, 'AREA', ALLOC=.TRUE., _RC)
          temp2d = FV_Atm(1)%gridstruct%area(is:ie, js:je)
       endif
-
-      call MAPL_TimerOff(MAPL, "INITIALIZE")
-      call MAPL_TimerOff(MAPL, "TOTAL")
 
       _RETURN(_SUCCESS)
    end subroutine Initialize
@@ -319,8 +299,6 @@ contains
       integer                       :: STATUS
       character(len=ESMF_MAXSTR)    :: COMP_NAME
       type (ESMF_Grid)              :: ESMFGRID
-      type (MAPL_MetaComp), pointer :: MAPL
-      type (ESMF_Alarm)             :: ALARM
 
 ! Imports
       REAL(REAL8), POINTER, DIMENSION(:,:,:)   :: iCX
@@ -384,15 +362,8 @@ contains
 
 ! Get parameters from generic state.
 !-----------------------------------
-      call MAPL_GetObjectFromGC ( gc, MAPL, RC=STATUS)
-      VERIFY_(STATUS)
-      call MAPL_Get( MAPL, IM=IM, JM=JM, LM=LM,   &
-                                RUNALARM = ALARM, &
-                                      RC = STATUS )
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"TOTAL")
-      call MAPL_TimerOn(MAPL,"RUN")
+      call MAPL_GridCompGet(gc, grid=ESMFGRID, num_levels=LM, _RC)
+      call GridGet(ESMFGRID, im=IM, jm=JM, _RC)
 
       CALL MAPL_GetPointer(import, iPLE0, 'PLE0', ALLOC = .TRUE., RC=STATUS)
       VERIFY_(STATUS)
@@ -432,8 +403,8 @@ contains
       ! ALT: this section attempts to limit the amount of advected tracers
       !-------------------------------------------------------------------
       adjustTracers = .false.
-      call MAPL_GetResource ( MAPL, adjustTracerMode, &
-           'EXCLUDE_ADVECTION_TRACERS:', &
+      call MAPL_GridCompGetResource ( gc, 'EXCLUDE_ADVECTION_TRACERS:', &
+           value=adjustTracerMode, &
            default='ALWAYS', rc=status )
       VERIFY_(STATUS)
       if (adjustTracerMode == 'ALWAYS') then
@@ -704,9 +675,6 @@ contains
       DEALLOCATE(   CX )
       DEALLOCATE(   CY )
 
-      call MAPL_TimerOff(MAPL,"RUN")
-      call MAPL_TimerOff(MAPL,"TOTAL")
-
       end if ! AdvCore_Advection
 
       RETURN_(ESMF_SUCCESS)
@@ -757,9 +725,6 @@ contains
       if (.NOT. FV3_DynCoreIsRunning) then
          call fv_end(FV_Atm, grids_on_my_pe, .false.)
       endif
-
-      call MAPL_GenericFinalize(gc, import, export, clock, RC)
-      VERIFY_(STATUS)
 
       RETURN_(ESMF_SUCCESS)
       end subroutine Finalize

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -50,6 +50,7 @@ module AdvCore_GridCompMod
    !USES:
    use ESMF
    use MAPL
+   use ESMFL_Mod
    use mapl3g_GridGet, only: GridGet
    use m_set_eta,       only: set_eta
    use mpp_mod,         only: mpp_pe, mpp_root_pe
@@ -342,7 +343,7 @@ contains
       logical                             :: tend
       logical                             :: exclude
       character(len=ESMF_MAXSTR)          :: tmpstring
-      character(len=ESMF_MAXSTR)          :: adjustTracerMode
+      character(len=:), allocatable       :: adjustTracerMode
       character(len=ESMF_MAXSTR), allocatable :: xlist(:)
       character(len=ESMF_MAXSTR), allocatable :: biggerlist(:)
       integer, parameter                  :: XLIST_MAX = 60

--- a/AppGridCreate.F90
+++ b/AppGridCreate.F90
@@ -1,11 +1,11 @@
 ! routine to create the global edges and centers of the cubed-sphere grid
 ! but not the ESMF grid
 subroutine AppCSEdgeCreateF(IM_WORLD, LonEdge,LatEdge, LonCenter, LatCenter, rc)
-#include "MAPL_Generic.h"
+#include "MAPL.h"
 
    use ESMF
-   use MAPL2
-   use MAPL_Constants,    only : pi=> MAPL_PI_R8
+   use MAPL
+   use MAPLBase_mod,      only : pi=> MAPL_PI_R8
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
    use fv_grid_utils_mod, only: gnomonic_grids, cell_center2, direct_transform
    use fv_grid_tools_mod, only: mirror_grid
@@ -122,11 +122,12 @@ end subroutine AppCSEdgeCreateF
 
 !!!!!!!!!!!!!!!%%%%%%%%%%%%%%%%%%%%%%%!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 function AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, rc) result(esmfgrid)
-#include "MAPL_Generic.h"
+#include "MAPL.h"
 #define DEALLOCGLOB_(A) if(associated(A))then;A=0;if(MAPL_ShmInitialized)then; call MAPL_DeAllocNodeArray(A,rc=STATUS);else; deallocate(A,stat=STATUS);endif;VERIFY_(STATUS);NULLIFY(A);endif
 
    use ESMF
-   use MAPL2, pi=> MAPL_PI_R8
+   use MAPL
+   use MAPLBase_mod,      only : pi=> MAPL_PI_R8
 
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
    use fv_grid_utils_mod, only: gnomonic_grids, cell_center2, direct_transform
@@ -430,90 +431,6 @@ function AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, rc) result(esmfgrid)
 
    RETURN_(ESMF_SUCCESS)
 end function AppGridCreateF
-
-subroutine AppGridCreate (META, esmfgrid, RC)
-
-#include "MAPL_Generic.h"
-
-   use ESMF
-   use MAPL2
-   use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
-   implicit none
-
-   ! !ARGUMENTS:
-
-   type(MAPL_MetaComp), intent(INOUT) :: META
-   type (ESMF_Grid),    intent(  OUT) :: esmfgrid
-   integer, optional,   intent(  OUT) :: rc
-
-   ! ErrLog variables
-   !-----------------
-
-   integer                      :: STATUS
-   character(len=ESMF_MAXSTR), parameter :: Iam="AppGridCreate"
-
-   ! Local variables
-   !-----------------
-
-   integer                         :: IM_WORLD
-   integer                         :: JM_WORLD
-   integer                         :: LM
-   integer                         :: NX, NY
-   character(len=ESMF_MAXSTR)      :: tmpname, gridname
-   character(len=ESMF_MAXSTR)      :: FMT, FMTIM, FMTJM
-   real(REAL8) :: deglon=0.0
-
-   interface
-      function AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, rc)
-         use ESMF
-         implicit none
-         type(ESMF_Grid)                  :: AppGridCreateF
-         integer,           intent(IN)    :: IM_WORLD, JM_WORLD, LM
-         integer,           intent(IN)    :: NX, NY
-         integer, optional, intent(OUT)   :: rc
-      end function AppGridCreateF
-   end interface
-
-   ! Get Decomposition from CF
-   !--------------------------
-
-   ! !RESOURCE_ITEM: none :: Processing elements in 1st dimension
-   call MAPL_GetResource( META, NX,       label ='NX:', default=1, rc = status )
-   VERIFY_(STATUS)
-   ! !RESOURCE_ITEM: none :: Processing elements in 2nd dimension
-   call MAPL_GetResource( META, NY,       label ='NY:', default=1, rc = status )
-   VERIFY_(STATUS)
-
-   ! Get World problem size from CF
-   !-------------------------------
-
-   ! !RESOURCE_ITEM: none :: Grid size in 1st dimension
-   call MAPL_GetResource( META, IM_WORLD, 'AGCM_IM:',            rc = status )
-   VERIFY_(STATUS)
-   ! !RESOURCE_ITEM: none :: Grid size in 2nd dimension
-   call MAPL_GetResource( META, JM_WORLD, 'AGCM_JM:',            rc = status )
-   VERIFY_(STATUS)
-   ! !RESOURCE_ITEM: none :: Grid size in 3rd dimension
-   call MAPL_GetResource( META, LM,       'AGCM_LM:', default=1, rc = status )
-   VERIFY_(STATUS)
-
-   ! The grid's name is optional
-   !----------------------------
-
-   call GET_INT_FORMAT(IM_WORLD, FMTIM)
-   call GET_INT_FORMAT(JM_WORLD, FMTJM)
-   FMT = '(A,' // trim(FMTIM) //',A,' // trim(FMTJM) // ',A)'
-   write(tmpname,trim(FMT)) 'PE',IM_WORLD,'x',JM_WORLD,'-CF'
-   ! !RESOURCE_ITEM: none :: Optional grid name
-   call MAPL_GetResource( META, GRIDNAME, 'AGCM.GRIDNAME:', default=trim(tmpname), rc = status )
-   VERIFY_(STATUS)
-
-   esmfgrid = AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, STATUS)
-   VERIFY_(STATUS)
-
-   RETURN_(ESMF_SUCCESS)
-
-end subroutine AppGridCreate
 
 subroutine GET_INT_FORMAT(N, FMT)
    integer          :: N

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 endif ()
 
 set(dependencies
-  esmf MAPL2 MAPL MAPL.generic3g MAPL.utilities
+  esmf MAPL2 MAPL MAPL.generic3g MAPL.geom MAPL.utilities
   GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared
   OpenMP::OpenMP_Fortran)
 

--- a/CreateInterpWeights_GridCompMod.F90
+++ b/CreateInterpWeights_GridCompMod.F90
@@ -1,5 +1,5 @@
 
-#include "MAPL_Generic.h"
+#include "MAPL.h"
 
 !-----------------------------------------------------------------------
 !              ESMA - Earth System Modeling Applications
@@ -13,7 +13,7 @@
 ! !USES:
 
    use ESMF                ! ESMF base class
-   use MAPL2               ! GEOS base class
+   use MAPL               ! GEOS base class
 
 ! !PUBLIC MEMBER FUNCTIONS:
 
@@ -63,12 +63,6 @@ contains
     call MAPL_GridCompSetEntryPoint ( gc, ESMF_METHOD_INITIALIZE,  Initialize, rc=status)
     VERIFY_(STATUS)
  
-! Generic SetServices
-!--------------------
-
-    call MAPL_GenericSetServices( GC, RC=STATUS )
-    VERIFY_(STATUS)
-
     RETURN_(ESMF_SUCCESS)
 
   end subroutine SetServices
@@ -94,7 +88,6 @@ contains
   character(len=ESMF_MAXSTR)         :: IAm
   character(len=ESMF_MAXSTR)         :: COMP_NAME
 
-  type (MAPL_MetaComp), pointer      :: MAPL
   type (ESMF_Config)                 :: CF
   type (ESMF_VM)                     :: VM
   character (len=ESMF_MAXSTR)        :: strTxt
@@ -117,13 +110,7 @@ contains
 ! Call Generic Initialize
 !------------------------
 
-    call MAPL_GenericInitialize ( GC, IMPORT, EXPORT, CLOCK,  RC=STATUS)
-    VERIFY_(STATUS)
-
-    call MAPL_GetObjectFromGC (GC, MAPL,  RC=STATUS )
-    VERIFY_(STATUS)
-
-    call ESMF_VMGetCurrent(VM, rc=status)
+    call MAPL_GridCompGetResource(GC, layout_file, 'LAYOUT:', default='weights.rc', _RC)
 
     call ESMF_VMGet(VM,mpiCommunicator=comm,rc=status)
 
@@ -131,8 +118,6 @@ contains
   call MAPL_MemUtilsWrite(VM, strTxt, RC=STATUS )
   VERIFY_(STATUS)
 
-    call MAPL_GetResource ( MAPL, layout_file, 'LAYOUT:', default='weights.rc', rc=status )
-    VERIFY_(STATUS)
     call ESMF_ConfigLoadFile( cf, LAYOUT_FILE, rc = rc )
     call ESMF_ConfigGetAttribute   ( cf, npx, label = 'npx:', default=180, rc = rc )
     npy = npx*6


### PR DESCRIPTION
## Summary

Ports all FVdycore gridcomp files off MAPL2/MAPL_GenericMod onto MAPL3 APIs.

- Replace `#include "MAPL_Generic.h"` → `#include "MAPL.h"`; `use MAPL2` → `use MAPL`
- Remove `MAPL_TimerAdd`/`MAPL_TimerOn`/`MAPL_TimerOff` (no-ops in MAPL3)
- Remove `MAPL_GenericSetServices`, `MAPL_GenericInitialize`, `MAPL_GenericFinalize` (stubs/_FAIL in MAPL3)
- Replace `MAPL_GetObjectFromGC` + `MAPL_GetResource` with `MAPL_GridCompGetResource(gc, ...)`
- Replace `MAPL_Get(MAPL, IM=, JM=, LM=, RUNALARM=)` with `MAPL_GridCompGet(gc, grid=, num_levels=)` + `GridGet(grid, im=, jm=)`
- Delete dead `AppGridCreate` subroutine (took `MAPL_MetaComp` directly; had no callers)
- Add `MAPL.geom` to CMake link deps for `mapl3g_GridGet`

Part of GEOSgcm_GridComp#1383.