### PR TITLE
AppGridCreate.F90: get MAPL_AM_I_ROOT from MAPL (MAPL3)

### DIFF
--- a/AppGridCreate.F90
+++ b/AppGridCreate.F90
@@ -5,7 +5,7 @@ subroutine AppCSEdgeCreateF(IM_WORLD, LonEdge,LatEdge, LonCenter, LatCenter, rc)
 
    use ESMF
    use MAPL
-   use MAPL2, only: MAPL_AllocNodeArray, MAPL_AM_I_ROOT, MAPL_DeAllocNodeArray, &
+   use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
         MAPL_GRID_INTERIOR, MAPL_MemUtilsWrite
    use MAPL_Constants,    only : pi=> MAPL_PI_R8
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID


### PR DESCRIPTION
## Summary

- `MAPL_AM_I_ROOT` is no longer re-exported via `MAPLBase_Mod` (see GEOS-ESM/MAPL#4752)
- `MAPL_AM_I_ROOT` is now obtained via the existing `use MAPL` rather than `use MAPL2`

## Prerequisite

Must merge before GEOS-ESM/MAPL#4752 (removal of `MAPL_CommsMod` and `MAPL_SatVaporMod` from `MAPLBase_Mod`).