### PR TITLE
Port FVdycoreCubed/AdvCore to MAPL3 API

### DIFF
--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -67,23 +67,23 @@ module AdvCore_GridCompMod
    use fv_mp_mod, only: is, ie, js, je, is_master, tile
    use fv_grid_utils_mod, only: g_sum_r8
    use fv_diagnostics_mod, only: prt_maxmin, prt_minmax
+   use FV_StateMod, only: FV_Atm, get_im_world_and_topology
    use FV_StateMod, only: AdvCoreTracers => T_TRACERS
-   use FV_StateMod, only: FV_Atm
-   use FV_StateMod, only: get_im_world_and_topology
+   use FVdycoreCubed_GridComp, only: field_is_cloud_water_species
+   use FVdycoreCubed_GridComp, only: get_short_name, is_name_in_list
 
    use pflogger, only: logger_t => logger
 
    implicit none
    private
 
-   logical :: FV3_DynCoreIsRunning = .false.
-   integer :: AdvCore_Advection = 1
+   logical :: FV3_DynCoreIsRunning
+   integer :: AdvCore_Advection
    logical, allocatable, save :: grids_on_my_pe(:)
    real(kind=FVPRC) :: dt
 
    ! Tracer I/O History stuff
    integer, parameter :: ntracers = 38
-   logical, save :: first_run = .true.
 
    !PUBLIC MEMBER FUNCTIONS:
    public SetServices
@@ -107,14 +107,16 @@ contains
       ! private to the module.
       !EOP
 
-      type(ESMF_VM) :: vm
-      type(ESMF_HConfig) :: hconfig
-      character(len=:), allocatable :: dycore, my_tracer
-      integer :: comm, ndt, itracer, im_world, topology(2), num_levels
-      integer :: p_split = 1
+      character(len=:), allocatable :: dycore
+      character(len=ESMF_MAXSTR) :: my_tracer
+      integer :: ndt, itracer
       integer :: status
 
 #include "AdvCore_Import___.h"
+#include "AdvCore_Export___.h"
+      ! AdvCore provides advection SERVICE
+      ! NOTE: SERVICE, irrespective of whether you are a provider or subscriber, adds the bundle
+      ! to BOTH the export and import states
       call MAPL_GridCompAddSpec(gc, &
            state_intent=ESMF_STATEINTENT_EXPORT, &
            short_name="TRADV", &
@@ -125,10 +127,7 @@ contains
            units="unknown", &
            itemtype=MAPL_STATEITEM_SERVICE, _RC)
 
-#include "AdvCore_Export___.h"
-
-      ! 3D Tracers
-      ! TODO: pchakrab - do we need these ntracers
+      ! 3D Tracers, for diagnostics
       do itracer = 1, ntracers
          write(my_tracer, "('TEST_TRACER',i5.5)") itracer - 1
          call MAPL_GridCompAddSpec(gc, &
@@ -140,64 +139,30 @@ contains
               vstagger=VERTICAL_STAGGER_CENTER, _RC)
       end do
 
-      ! Register methods with MAPL
+      ! Register methods
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, Initialize, _RC)
-      call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, Run, _RC)
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, Run, phase_name="run", _RC)
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_FINALIZE, Finalize, _RC)
 
-      ! Check if AdvCore is running without FV3_DynCoreIsRunning, if yes then setup the MAPL Grid
-      call MAPL_GridCompGetResource(gc, "DYCORE", dycore, default="", _RC)
-      ! TODO: pchakrab - use select case here
-      if (trim(dycore) == "FV3") then
-         FV3_DynCoreIsRunning = .true.
-         AdvCore_Advection = 0
-      end if
-      if (trim(dycore) == "FV3+ADV") then
-         FV3_DynCoreIsRunning = .true.
-         AdvCore_Advection = 1
-      end if
-      call MAPL_GridCompGetResource(gc, "AdvCore_Advection", AdvCore_Advection, default=AdvCore_Advection, _RC)
-
-
-      ! Start up FMS/MPP
-      call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
-      call fms_init(comm)
-
+      ! TODO: pchakrab - should we get RUN_DT from clock instead?
       call MAPL_GridCompGetResource(gc, "RUN_DT", ndt, default=0, _RC)
       dt = ndt
 
-      if (.not. FV3_DynCoreIsRunning) then
-         ! Make sure FV3 is setup
-         call fv_init1(FV_Atm, dt, grids_on_my_pe, p_split)
-
-         call MAPL_GridCompGet(gc, hconfig=hconfig, num_levels=num_levels, _RC)
-         call get_im_world_and_topology(hconfig, im_world, topology, _RC)
-         associate(layout => FV_Atm(1)%layout, flags => FV_Atm(1)%flagstruct)
-            ! Domain decomposition
-            layout = topology
-            if (flags%grid_type == 4) then
-               layout(2) = layout(2) * 6
-            end if
-            ! Grid dimensions
-            flags%npx = im_world
-            flags%npy = im_world * 6
-            flags%npz = num_levels
-            ! TODO: pchakrab - check this! npy is always set to 6*npx!
-            if (flags%npy == 6 * flags%npx) then
-               flags%npy = flags%npx + 1
-               flags%npx = flags%npx + 1
-               flags%ntiles = 6
-            else
-               flags%npy = flags%npy + 1
-               flags%npx = flags%npx + 1
-               flags%ntiles = 1
-            end if
-         end associate
-
-         ! TODO: pchakrab - shouldn't we setup the geomtry here?
-
-         call fv_init2(FV_Atm, dt, grids_on_my_pe, p_split)
-      end if
+      ! Check if AdvCore is running without FV3. If not, initialize FMS/FV3
+      call MAPL_GridCompGetResource(gc, "DYCORE", dycore, default="", _RC)
+      select case (trim(dycore))
+      case ("FV3")
+         FV3_DynCoreIsRunning = .true.
+         AdvCore_Advection = 0
+      case ("FV3+ADV")
+         FV3_DynCoreIsRunning = .true.
+         AdvCore_Advection = 1
+      case default
+         FV3_DynCoreIsRunning = .false.
+         AdvCore_Advection = 1
+      end select
+      if (.not. FV3_DynCoreIsRunning) call fv_setup(gc, _RC)
+      call MAPL_GridCompGetResource(gc, "AdvCore_Advection", AdvCore_Advection, default=AdvCore_Advection, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine SetServices
@@ -220,18 +185,21 @@ contains
       !EOP
 
       !BOC
-      type(ESMF_Grid) :: grid
       real, pointer :: area(:, :)
-      logical :: grid_created
       integer :: is, ie, js, je, status
 
-      grid_created = .false.
-      call ESMF_GridCompGet(gc, grid=grid, rc=status)
-      if (status == ESMF_SUCCESS) then
-         call ESMF_GridValidate(grid, rc=status)
-         if (status == ESMF_SUCCESS) grid_created = .true.
+      ! pchakrab - maybe use the FV_DynCoreIsRunning flag instead
+      if (.not. FV3_DynCoreIsRunning) then
+         call MAPL_GridCompSetGeometry(gc, _RC)
       end if
-      if (.not. grid_created) call MAPL_GridCompSetGeometry(gc, _RC)
+      ! pchakrab - below was the original logic for grid creation
+      ! grid_created = .false.
+      ! call ESMF_GridCompGet(gc, grid=grid, rc=status)
+      ! if (status == ESMF_SUCCESS) then
+      !    call ESMF_GridValidate(grid, rc=status)
+      !    if (status == ESMF_SUCCESS) grid_created = .true.
+      ! end if
+      ! if (.not. grid_created) call MAPL_GridCompSetGeometry(gc, _RC)
 
       ! Compute Grid-Cell Area
       if (.not. FV3_DynCoreIsRunning) then
@@ -266,46 +234,28 @@ contains
       ! number of internal, small steps, also configurable.
       !EOP
 
-      integer :: status
-      type(ESMF_Grid) :: esmfgrid, bgrid
+      type(ESMF_Grid) :: esmfgrid
       type(ESMF_HConfig) :: hconfig
       type(ESMF_FieldBundle) :: tradv, tradv_import
       type(ESMF_Field) :: field
       type(ESMF_Array) :: array
-      type(ESMF_TypeKind_Flag) :: kind
+      type(ESMF_TypeKind_Flag) :: tk
       type(ESMF_FieldBundle), save :: bundle_adv
-      type(ESMF_Alarm) :: predictor_alarm
-
-      ! Imports
-      ! TODO: pchakrab - replace with AdvCore_DeclarePointer___.h once the typekind bug is fixed
-      real(kind=REAL8), pointer, dimension(:, :, :) :: area
-      real(kind=REAL8), pointer, dimension(:, :, :) :: CX
-      real(kind=REAL8), pointer, dimension(:, :, :) :: CY
-      real(kind=REAL8), pointer, dimension(:, :, :) :: MFX
-      real(kind=REAL8), pointer, dimension(:, :, :) :: MFY
-      real(kind=REAL8), pointer, dimension(:, :, :) :: PLE0
-      real(kind=REAL8), pointer, dimension(:, :, :) :: PLE1
-      ! TODO: pchakrab - this stays
+      type(AdvCoreTracers), allocatable :: adv_tracers(:)
+#include "AdvCore_DeclarePointer___.h"
       real(kind=FVPRC), allocatable, dimension(:, :, :) :: xPLE1
-      real(kind=FVPRC), pointer, dimension(:, :, :, :) :: tracers
+      real(kind=FVPRC), allocatable, dimension(:, :, :, :) :: tracers
       real(kind=REAL8), allocatable :: tmass0(:), tmass1(:)
-      type(AdvCoreTracers), pointer :: adv_tracers(:)
-
-      integer :: im, jm, lm, nq, nqt, QSPLIT
-      integer :: i, j, n
-      integer, save :: nq_saved = 0
-      logical :: exclude, same_tradv_data, rpt_mass, DEBUG_ADV, adjust_tracers
-
       real, pointer :: temp3D(:, :, :)
       real(kind=REAL4), pointer :: tracer_r4(:, :, :)
       real(kind=REAL8), pointer :: tracer_r8(:, :, :)
-
-      character(len=ESMF_MAXSTR) :: field_name, mytracer
-      character(len=:), allocatable :: adjust_tracer_mode
-      character(len=ESMF_MAXSTR), allocatable :: xlist(:), biggerlist(:)
-
       real(kind=FVPRC), allocatable :: DEBUG_ARRAY(:, :, :)
-      real(kind=FVPRC) :: fac1 = 1.0
+      real(kind=FVPRC), parameter :: fac1 = 1.0
+      real :: tmp0, tmp1, tmp2
+      logical :: same_tradv_data, rpt_mass, DEBUG_ADV, adjust_tracers
+      logical, save :: first_run = .true.
+      character(len=ESMF_MAXSTR) :: field_name, mytracer
+      integer :: n, im, jm, lm, nq, QSPLIT, status
       class(logger_t), pointer :: logger
 
       _RETURN_UNLESS(AdvCore_Advection > 0)
@@ -324,217 +274,127 @@ contains
       same_tradv_data = MAPL_FieldBundleSameData(tradv_import, tradv, _RC)
       _ASSERT(same_tradv_data, "TRADV bundles in import and export do not point to the same data")
 
-      ! ALT: this section attempts to limit the amount of advected tracers
-      adjust_tracers = .false.
-      call MAPL_GridCompGetResource(gc, "EXCLUDE_ADVECTION_TRACERS", adjust_tracer_mode, default="ALWAYS", _RC)
-      select case (trim(adjust_tracer_mode))
-      case ("ALWAYS")
-         adjust_tracers = .true.
-      case ("PREDICTOR")
-         call ESMF_ClockGetAlarm(clock, alarmName="PredictorAlarm", alarm=predictor_alarm, rc=status)
-         if (status == ESMF_SUCCESS) then
-            if (ESMF_AlarmIsRinging(predictor_alarm)) then
-               adjust_tracers = .true.
-            end if
-         end if
-      case ("NO")
-         adjust_tracers = .false. ! proceed without warning
-      case default
-         call logger%info("Invalid value specified for EXCLUDE_ADVECTION_TRACERS, ignored")
-         adjust_tracers = .false.
-      end select
+      adjust_tracers = should_adjust_tracers(gc, clock, _RC)
       if (adjust_tracers) then
          if (first_run) then
-            xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR,&
-                 & _RC)
-            n = 0
-            if (allocated(xlist)) n = size(xlist)
-            ! Count the number of tracers
-            call ESMF_FieldBundleGet(tradv, grid=bgrid, fieldCount=nqt, _RC)
-            bundle_adv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
-            call ESMF_FieldBundleSet(bundle_adv, grid=bgrid, _RC)
-            ! Loop over NQ in TRADV
-            do i = 1, nqt
-               ! Get field from TRADV and its name
-               call ESMF_FieldBundleGet(tradv, fieldIndex=i, field=field, _RC)
-               ! TODO: pchakrab - replace the call below with a call to get_short_name
-               call ESMF_FieldGet(field, name=field_name, _RC)
-               ! field_name = get_short_name(field, _RC)
-               ! Exclude everything that is not cloud/water species
-               if ((FV3_DynCoreIsRunning) .and. &
-                    (field_name == 'Q') .or. &
-                    (field_name == 'QLCN') .or. &
-                    (field_name == 'QLLS') .or. &
-                    (field_name == 'QICN') .or. &
-                    (field_name == 'QILS') .or. &
-                    (field_name == 'CLCN') .or. &
-                    (field_name == 'CLLS') .or. &
-                    (field_name == 'NCPL') .or. &
-                    (field_name == 'NCPI') .or. &
-                    (field_name == 'QRAIN') .or. &
-                    (field_name == 'QSNOW') .or. &
-                    (field_name == 'QGRAUPEL')) then
-                  ! write(STRING,'(A,A)') "ADV is excluding ", TRIM(field_name)
-                  ! call WRITE_PARALLEL( trim(STRING)   )
-                  n = n + 1
-                  if (n > size(xlist)) then
-                     allocate(biggerlist(2 * n), _STAT)
-                     biggerlist(1:n - 1) = xlist
-                     call move_alloc(from=biggerlist, to=xlist)
-                  end if
-                  xlist(n) = trim(field_name)
-               end if
-               ! Loop over exclude_list
-               exclude = .false.
-               do j = 1, n
-                  if (field_name == xlist(j)) then
-                     exclude = .true.
-                     exit
-                  end if
-               end do
-               if (.not. exclude) then
-                  call MAPL_FieldBundleAdd(bundle_adv, [field], _RC)
-               end if
-            end do
-
-            if (allocated(xlist)) deallocate(xlist)
-            if (allocated(biggerlist)) deallocate(biggerlist)
-
             first_run = .false.
-         end if ! first_run
+            bundle_adv = get_adjusted_tracer_bundle(tradv, hconfig, _RC) ! save'd
+         end if
          tradv = bundle_adv
-      end if ! adjust_tracers
+      end if
 
+      call ESMF_FieldBundleGet(tradv, fieldCount=nq, _RC)
+      _RETURN_UNLESS(nq > 0)
+
+      call logger%info("Advcore is Advecting the following %i tracers", nq)
+      do n = 1, nq
+         call ESMF_FieldBundleGet(tradv, fieldIndex=n, field=field, _RC)
+         field_name = get_short_name(field, _RC)
+         call logger%info(field_name)
+      end do
+
+      ! We allocate a list of tracers big enough to hold all items in the bundle
       call MAPL_GridCompGet(gc, grid=esmfgrid, num_levels=lm, _RC)
       call MAPL_GridGet(esmfgrid, im=im, jm=jm, _RC)
-      call ESMF_FieldBundleGet(tradv, fieldCount=nq, _RC)
+      allocate(tracers(im, jm, lm, nq), adv_tracers(nq), _STAT)
 
-      if (nq > 0) then
-         ! We allocate a list of tracers big enough to hold all items in the bundle
-         allocate(tracers(im, jm, lm, nq), _STAT)
-         allocate(adv_tracers(nq), _STAT)
-
-         if (nq /= nq_saved) then
-            call logger%info("Advcore is Advecting the following %i tracers", nq)
+      ! Go through the bundle copying the fields into the tracer list
+      ! This is essentially PULL_Q in DynCore
+      do n = 1, nq
+         call ESMF_FieldBundleGet(tradv, fieldIndex=n, field=field, _RC)
+         call ESMF_FieldGet(field, array=array, _RC)
+         call ESMF_ArrayGet(array, typekind=tk, _RC)
+         adv_tracers(n)%is_r4 = (tk == ESMF_TYPEKIND_R4)
+         adv_tracers(n)%tname = get_short_name(field, _RC)
+         if (adv_tracers(n)%is_r4) then
+            call ESMF_ArrayGet(array, farrayptr=tracer_r4, _RC)
+            adv_tracers(n)%content_r4 => tracer_r4
+            tracers(:, :, :, n) = tracer_r4
+         else
+            call ESMF_ArrayGet(array, farrayptr=tracer_r8, _RC)
+            adv_tracers(n)%content => tracer_r8
+            tracers(:, :, :, n) = tracer_r8
          end if
+      end do
 
-         ! Go through the bundle copying the friendlies into the tracer list.
+      ! Tracer Mass before advection
+      call MAPL_GridCompGetResource(gc, "ADV_CORE_REPORT_TRACER_MASS", rpt_mass, default=.false., _RC)
+      if (rpt_mass) then
+         allocate(tmass0(nq), _STAT)
+         call global_integral(tmass0, tracers, real(PLE0, kind=FVPRC), im, jm, lm, nq)
+      end if
+
+      ! Run FV3 advection
+      call MAPL_GridCompGetResource(gc, "ADV_QSPLIT", QSPLIT, default=0, _RC)
+      call offline_tracer_advection(tracers, &
+           real(PLE0, kind=FVPRC), xPLE1, &
+           real(MFX, kind=FVPRC), real(MFY, kind=FVPRC), &
+           real(CX, kind=FVPRC), real(CY, kind=FVPRC), &
+           FV_Atm(1)%gridstruct, FV_Atm(1)%flagstruct, FV_Atm(1)%bd, FV_Atm(1)%domain, &
+           FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, nq, dt, QSPLIT)
+
+      ! Tracer Mass after advection
+      if (rpt_mass) then
+         allocate(tmass1(nq), _STAT)
+         call global_integral(tmass1, tracers, xPLE1, im, jm, lm, nq)
+         ! Conserve Specific Mass of Constituents Keeping Mixing_Ratio Constant WRT_Dry_Air
          do n = 1, nq
-            call ESMF_FieldBundleGet(tradv, fieldIndex=n, field=field, _RC)
-            ! TODO: pchakrab - replace the call below with a call to get_short_name
-            call ESMF_FieldGet(field, array=array, name=field_name, _RC)
-            ! field_name = get_short_name(field, _RC)
-            call ESMF_ArrayGet(array, typekind=kind, _RC)
-            adv_tracers(n)%is_r4 = (kind == ESMF_TYPEKIND_R4) ! Is real*4?
-            adv_tracers(n)%tName = field_name
-            if (nq /= nq_saved) call logger%info(trim('--' // field_name))
-            if (adv_tracers(n)%is_r4) then
-               call ESMF_ArrayGet(array, farrayptr=tracer_r4, _RC)
-               adv_tracers(n)%content_r4 => tracer_r4
-               tracers(:, :, :, n) = adv_tracers(n)%content_r4
-            else
-               call ESMF_ArrayGet(array, farrayptr=tracer_r8, _RC)
-               adv_tracers(n)%content => tracer_r8
-               tracers(:, :, :, n) = adv_tracers(n)%content
-            end if
-         end do
-
-         if (nq /= nq_saved) then
-            nq_saved = nq
-         end if
-
-         ! Get Tracer Mass before advection
-         call MAPL_GridCompGetResource(gc, "ADV_CORE_REPORT_TRACER_MASS", rpt_mass, default=.false., _RC)
-         if (rpt_mass) then
-            allocate(tmass0(nq))
-            call global_integral(tmass0, tracers, real(PLE0, kind=FVPRC), im, jm, lm, nq)
-         end if
-
-         ! Run FV3 advection
-         call MAPL_GridCompGetResource(gc, "ADV_QSPLIT", QSPLIT, default=0, _RC)
-         call offline_tracer_advection(tracers, &
-              real(PLE0, kind=FVPRC), xPLE1, &
-              real(MFX, kind=FVPRC), real(MFY, kind=FVPRC), &
-              real(CX, kind=FVPRC), real(CY, kind=FVPRC), &
-              FV_Atm(1)%gridstruct, FV_Atm(1)%flagstruct, &
-              FV_Atm(1)%bd, FV_Atm(1)%domain, FV_Atm(1)%npx, FV_Atm(1)%npy, FV_Atm(1)%npz, &
-              nq, dt, QSPLIT)
-
-         ! Get Tracer Mass after advection
-         if (rpt_mass) then
-            allocate(tmass1(nq))
-            call global_integral(tmass1, tracers, real(PLE1, kind=FVPRC), im, jm, lm, nq)
-            ! Conserve Specific Mass of Constituents Keeping Mixing_Ratio Constant WRT_Dry_Air
-            do n = 1, nq
-               if (tmass1(n) > 0.0) then
-                  if (ABS((tmass0(n) - tmass1(n)) / tmass1(n)) >= epsilon(1.0_REAL4)) then
-                     if (is_master()) call logger%info(trim(adv_tracers(n)%tName) // ': ' // &
-                          trim(adjustl(transfer((tmass1(n) - tmass0(n)) / tmass0(n), 'G21.14'))))
-                     !!TRACERS(:,:,:,N) = TRACERS(:,:,:,N) * TMASS0(N)/TMASS1(N)
-                  end if
-                  125 format('Mass Conservation Adjustment in AdvCore:'2x, A, 2x, g21.14)
+            if (tmass1(n) > 0.0) then
+               tmp0 = tmass1(n) - tmass0(n)
+               tmp1 = tmp0 / tmass1(n)
+               if (abs(tmp1) >= epsilon(1.0_REAL4)) then
+                  tmp2 = tmp0 / tmass0(n)
+                  call logger%info(trim(adv_tracers(n)%tname) // ": %f", tmp2)
+                  ! tracers(:,:,:,n) = tracers(:,:,:,n) * tmass0(n)/tmass1(n)
                end if
-            end do
-            deallocate(tmass0)
-            deallocate(tmass1)
-         end if
-
-         ! Go through the bundle copying tracers back to the bundle.
-         do n = 1, nq
-            if (adv_tracers(n)%is_r4) then
-               adv_tracers(n)%content_r4 = tracers(:, :, :, n)
-            else
-               adv_tracers(n)%content = tracers(:, :, :, n)
-            end if
-
-            !-----------------------------------------------
-            !--> Fill Export States
-            !--> This section is used for diagnostics only.
-            !--> It has no effect on CTM experiments.
-            !-----------------------------------------------
-            if (n <= min(ntracers, nq)) then
-               write(mytracer, "('TEST_TRACER',i5.5)") n - 1
-               call MAPL_StateGetPointer(export, temp3D, trim(mytracer), _RC)
-               if (associated(temp3D)) temp3D = tracers(:, :, :, n)
             end if
          end do
+      end if
 
-         ! Clean negative tracers and check
-         call MAPL_GridCompGetResource(gc, "DEBUG_ADV", DEBUG_ADV, default=.false., _RC)
-         if (DEBUG_ADV) then
-            prt_minmax = DEBUG_ADV
-            if (mpp_pe() == 0) print*, ''
-            if (mpp_pe() == 0) print*, '-------------- FV3 Tracer Debug After ADV --------------'
-            allocate(DEBUG_ARRAY(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec, FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec, FV_Atm(1)%npz))
+      !--> Fill Export States
+      !--> This section is used for diagnostics only.
+      !--> It has no effect on CTM experiments.
+      do n = 1, nq
+         if (n <= min(ntracers, nq)) then
+            write(mytracer, "('TEST_TRACER',i5.5)") n - 1
+            call MAPL_StateGetPointer(export, temp3D, trim(mytracer), _RC)
+            if (associated(temp3D)) temp3D = tracers(:, :, :, n)
          end if
+      end do
+
+      ! Clean negative tracers
+      do n = 1, nq
+         where (tracers(:, :, :, n) < tiny(0.0))
+            tracers(:, :, :, n) = 0.0
+         end where
+      end do
+
+      ! Save tracer data for subsequent runs
+      do n = 1, nq
+         if (adv_tracers(n)%is_r4) then
+            adv_tracers(n)%content_r4 = tracers(:, :, :, n)
+         else
+            adv_tracers(n)%content = tracers(:, :, :, n)
+         end if
+      end do
+
+      call MAPL_GridCompGetResource(gc, "DEBUG_ADV", DEBUG_ADV, default=.false., _RC)
+      if (DEBUG_ADV) then
+         prt_minmax = DEBUG_ADV
+         if (mpp_pe() == 0) print*, ''
+         if (mpp_pe() == 0) print*, '-------------- FV3 Tracer Debug After ADV --------------'
+         allocate(DEBUG_ARRAY(FV_Atm(1)%bd%isc:FV_Atm(1)%bd%iec, FV_Atm(1)%bd%jsc:FV_Atm(1)%bd%jec, FV_Atm(1)%npz))
          do n = 1, nq
-            if (adv_tracers(n)%is_r4) then
-               where (adv_tracers(n)%content_r4 < tiny(0.0))
-                  adv_tracers(n)%content_r4 = 0.0
-               end where
-               if (DEBUG_ADV) DEBUG_ARRAY = adv_tracers(n)%content_r4
-            else
-               where (adv_tracers(n)%content < tiny(0.0))
-                  adv_tracers(n)%content = 0.0
-               end where
-               if (DEBUG_ADV) DEBUG_ARRAY = adv_tracers(n)%content
-            end if
-            if (DEBUG_ADV) then
-               call prt_maxmin(trim(adv_tracers(n)%tName), DEBUG_ARRAY, FV_Atm(1)%bd%isc, FV_Atm(1)%bd%iec, FV_Atm(1)&
-                    %bd%jsc, FV_Atm(1)%bd%jec, 0, FV_Atm(1)%npz, fac1)
-            end if
+            DEBUG_ARRAY = tracers(:, :, :, n)
+            call prt_maxmin( &
+                 trim(adv_tracers(n)%tname), DEBUG_ARRAY, &
+                 FV_Atm(1)%bd%isc, FV_Atm(1)%bd%iec, FV_Atm(1)%bd%jsc, FV_Atm(1)%bd%jec, &
+                 0, FV_Atm(1)%npz, fac1)
          end do
-         if (DEBUG_ADV) then
-            deallocate(DEBUG_ARRAY)
-            if (mpp_pe() == 0) print*, '-------------- FV3 Tracer Debug After ADV --------------'
-            if (mpp_pe() == 0) print*, ''
-            prt_minmax = .false.
-         end if
-
-         ! Deallocate the list of tracers
-         deallocate(tracers, adv_tracers, _STAT)
-
-      end if ! NQ > 0
+         if (mpp_pe() == 0) print*, '-------------- FV3 Tracer Debug After ADV --------------'
+         if (mpp_pe() == 0) print*, ''
+         prt_minmax = .false.
+      end if
 
       _RETURN(_SUCCESS)
    end subroutine Run
@@ -605,6 +465,126 @@ contains
       deallocate(dp)
       deallocate(qsum1)
    end subroutine global_integral
+
+   function should_adjust_tracers(gc, clock, rc) result(adjust_tracers)
+      type(ESMF_GridComp), intent(inout) :: gc
+      type(ESMF_Clock), intent(in) :: clock
+      integer, intent(out) :: rc
+      logical :: adjust_tracers
+
+      class(logger_t), pointer :: logger
+      character(len=:), allocatable :: adjust_tracer_mode
+      type(ESMF_Alarm) :: predictor_alarm
+      integer :: status
+
+      adjust_tracers = .false.
+
+      call MAPL_GridCompGetResource(gc, "EXCLUDE_ADVECTION_TRACERS", adjust_tracer_mode, default="ALWAYS", _RC)
+      select case (trim(adjust_tracer_mode))
+      case ("ALWAYS")
+         adjust_tracers = .true.
+      case ("PREDICTOR")
+         call ESMF_ClockGetAlarm(clock, alarmName="PredictorAlarm", alarm=predictor_alarm, rc=status)
+         if (status == ESMF_SUCCESS) then
+            if (ESMF_AlarmIsRinging(predictor_alarm)) then
+               adjust_tracers = .true.
+            end if
+         end if
+      case ("NO")
+         adjust_tracers = .false. ! proceed without warning
+      case default
+         call MAPL_GridCompGet(gc, logger=logger, _RC)
+         call logger%info("Invalid value specified for EXCLUDE_ADVECTION_TRACERS, ignored")
+         adjust_tracers = .false.
+      end select
+
+      _RETURN(_SUCCESS)
+   end function should_adjust_tracers
+
+   function get_adjusted_tracer_bundle(orig_bundle, hconfig, rc) result(adjusted_bundle)
+      type(ESMF_FieldBundle), intent(in) :: orig_bundle
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, intent(out) :: rc
+      type(ESMF_FieldBundle) :: adjusted_bundle
+
+      type(ESMF_Grid) :: grid
+      type(ESMF_Field) :: field
+      character(len=:), allocatable :: field_name
+      character(len=ESMF_MAXSTR), allocatable :: xlist(:), biggerlist(:)
+      integer :: i, nqt, num_excluded, status
+
+      call ESMF_FieldBundleGet(orig_bundle, grid=grid, fieldCount=nqt, _RC)
+      adjusted_bundle = ESMF_FieldBundleCreate(name="xTRADV", _RC) ! saved between runs
+      call ESMF_FieldBundleSet(adjusted_bundle, grid=grid, _RC)
+      xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR, _RC)
+      num_excluded = 0
+      if (allocated(xlist)) num_excluded = size(xlist)
+      ! Exclude tracers that are to be advected by DynCore (cloud/water species)
+      do i = 1, nqt
+         call ESMF_FieldBundleGet(orig_bundle, fieldIndex=i, field=field, _RC)
+         field_name = get_short_name(field, _RC)
+         if (field_is_cloud_water_species(field_name)) then
+            num_excluded = num_excluded + 1
+            if (num_excluded > size(xlist)) then
+               allocate(biggerlist(2*num_excluded), _STAT)
+               biggerlist(1:num_excluded-1) = xlist
+               call move_alloc(from=biggerlist, to=xlist)
+            end if
+            xlist(num_excluded) = trim(field_name)
+         end if
+      end do
+      ! Add non-excluded tracers to adjusted bundle
+      do i = 1, nqt
+         call ESMF_FieldBundleGet(orig_bundle, fieldIndex=i, field=field, _RC)
+         field_name = get_short_name(field, _RC)
+         if (.not. is_name_in_list(field_name, xlist)) then
+            call MAPL_FieldBundleAdd(adjusted_bundle, [field], _RC)
+         end if
+      end do
+
+      _RETURN(_SUCCESS)
+   end function get_adjusted_tracer_bundle
+
+   subroutine fv_setup(gc, rc)
+      type(ESMF_GridComp), intent(inout) :: gc
+      integer, intent(out) :: rc
+
+      type(ESMF_VM) :: vm
+      type(ESMF_HConfig) :: hconfig
+      integer :: p_split = 1
+      integer :: comm, im_world, topology(2), num_levels, status
+
+      call MAPL_GridCompGet(gc, hconfig=hconfig, num_levels=num_levels, _RC)
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+      call fms_init(comm)
+
+      call fv_init1(FV_Atm, dt, grids_on_my_pe, p_split)
+      call get_im_world_and_topology(hconfig, im_world, topology, _RC)
+      associate(layout => FV_Atm(1)%layout, flags => FV_Atm(1)%flagstruct)
+         ! Domain decomposition
+         layout = topology
+         if (flags%grid_type == 4) then
+            layout(2) = layout(2) * 6
+         end if
+         ! Grid dimensions
+         flags%npx = im_world
+         flags%npy = im_world * 6
+         flags%npz = num_levels
+         ! TODO: pchakrab - check this! npy is always set to 6*npx!
+         if (flags%npy == 6 * flags%npx) then
+            flags%npy = flags%npx + 1
+            flags%npx = flags%npx + 1
+            flags%ntiles = 6
+         else
+            flags%npy = flags%npy + 1
+            flags%npx = flags%npx + 1
+            flags%ntiles = 1
+         end if
+      end associate
+      call fv_init2(FV_Atm, dt, grids_on_my_pe, p_split)
+   end subroutine fv_setup
 
 end module AdvCore_GridCompMod
 

--- a/AdvCore_StateSpecs.rc
+++ b/AdvCore_StateSpecs.rc
@@ -8,12 +8,12 @@ category: EXPORT
  AREA       | m+2   | xy   | N    |  agrid_cell_area
 
 category: IMPORT
-#--------------------------------------------------------------
- SHORT_NAME | UNITS       | TYPEKIND | DIMS | VLOC | LONG_NAME
-#--------------------------------------------------------------
- MFX        | Pa m+2 s-1  | R8       | xyz  | C    | pressure_weighted_eastward_mass_flux
- MFY        | Pa m+2 s-1  | R8       | xyz  | C    | pressure_weighted_northward_mass_flux
- CX         | 1           | R8       | xyz  | C    | eastward_accumulated_courant_number
- CY         | 1           | R8       | xyz  | C    | northward_accumulated_courant_number
- PLE0       | Pa          | R8       | xyz  | E    | pressure_at_layer_edges_before_advection
- PLE1       | Pa          | R8       | xyz  | E    | pressure_at_layer_edges_after_advection
+#---------------------------------------------------------
+ SHORT_NAME | UNITS  | TYPEKIND | DIMS | VLOC | LONG_NAME
+#---------------------------------------------------------
+ MFX        | Pa m+2 | R8       | xyz  | C    | pressure_weighted_eastward_mass_flux
+ MFY        | Pa m+2 | R8       | xyz  | C    | pressure_weighted_northward_mass_flux
+ CX         | 1      | R8       | xyz  | C    | eastward_accumulated_courant_number
+ CY         | 1      | R8       | xyz  | C    | northward_accumulated_courant_number
+ PLE0       | Pa     | R8       | xyz  | E    | pressure_at_layer_edges_before_advection
+ PLE1       | Pa     | R8       | xyz  | E    | pressure_at_layer_edges_after_advection

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -85,12 +85,16 @@ module FVdycoreCubed_GridComp
    ! Include the MPI library definitons:
    include 'mpif.h'
 
-   type(ESMF_FieldBundle), save :: BundleAdv
+   type(ESMF_FieldBundle), save :: bundle_adv
    integer :: NXQ = 0
    logical :: overwrite_Q = .true.
    logical :: DEBUG_TQ_ERRORS
 
    public :: SetServices ! Register component methods
+   public :: get_short_name
+   public :: field_is_cloud_water_species
+   public :: is_name_in_list
+   public :: resize
 
    !DESCRIPTION: This module implements the Dynamical Core as
    !               an ESMF gridded component.
@@ -852,8 +856,8 @@ contains
          if (first_run) then
             first_run = .false.
             call ESMF_FieldBundleGet(bundle, grid=bgrid, fieldCount=nqt, _RC) ! num tracers
-            BundleAdv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
-            call ESMF_FieldBundleSet(BundleAdv, grid=bgrid, _RC)
+            bundle_adv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
+            call ESMF_FieldBundleSet(bundle_adv, grid=bgrid, _RC)
             xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR, _RC)
             n = 0
             if (allocated(xlist)) n = size(xlist)
@@ -871,19 +875,19 @@ contains
                   end if
                end do
             end if
-            ! Add non-excluded tracers to the BundleAdv
+            ! Add non-excluded tracers to the bundle_adv
             do i = 1, nqt
                call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
                field_name = get_short_name(field, _RC)
                if (.not. is_name_in_list(field_name, xlist)) then
-                  call MAPL_FieldBundleAdd(BundleAdv, [field], _RC)
+                  call MAPL_FieldBundleAdd(bundle_adv, [field], _RC)
                end if
             end do
             if (allocated(xlist)) deallocate(xlist)
          end if ! first_run
-         bundle = BundleAdv ! replace TRADV
+         bundle = bundle_adv ! replace TRADV
       else
-         BundleAdv = bundle ! replace with TRADV
+         bundle_adv = bundle ! replace with TRADV
       end if ! adjust_tracers
 
       ! Collect tracer names from the bundle for later use
@@ -2604,7 +2608,7 @@ contains
       jm = self%grid%npy
       km = self%grid%npz
 
-      bundle = BundleAdv
+      bundle = bundle_adv
 
       ! Count the bundles tracers
       call ESMF_FieldBundleGet(bundle, fieldCount=nq, _RC)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -94,7 +94,6 @@ module FVdycoreCubed_GridComp
    public :: get_short_name
    public :: field_is_cloud_water_species
    public :: is_name_in_list
-   public :: resize
 
    !DESCRIPTION: This module implements the Dynamical Core as
    !               an ESMF gridded component.
@@ -424,7 +423,6 @@ contains
       integer, intent(out) :: rc ! Error code, 0 all is well, error otherwise
 
       type(DynState), pointer :: self
-      type(ESMF_Field) :: field
       type(ESMF_State) :: internal
       real(kind=r4), pointer :: pref(:)
       real(kind=r4), pointer :: u(:, :, :), v(:, :, :), t(:, :, :)
@@ -433,12 +431,10 @@ contains
       real(kind=r8), pointer :: ud(:, :, :), vd(:, :, :)
       real(kind=r8), pointer :: pt(:, :, :), pk(:, :, :)
       real(kind=r8), allocatable :: ur(:, :, :), vr(:, :, :) ! rotated winds
-      logical :: ColdRestart, FV3_STANDALONE
-      integer :: ifirst, ilast, jfirst, jlast, km
-      integer :: i, numTracers, status
-      integer :: replay_shutoff_seconds
+      logical :: ColdRestart
       type(ESMF_TimeInterval) :: replay_shutoff_interval
       type(ESMF_Alarm) :: replay_shutoff_alarm
+      integer :: replay_shutoff_seconds, ifirst, ilast, jfirst, jlast, km, status
 
       ! Setup FMS/FV3
       call MAPL_GridCompTimerStart(gc, "DYN_SETUP", _RC)
@@ -556,11 +552,8 @@ contains
       type(DynGrid), pointer :: grid
       type(DynVars), pointer :: vars
 
-      integer :: nq
-      integer :: im, jm, km
-      integer :: numvars
+      integer :: nq, im, jm, km, kend, i, j, k, n
       integer :: ifirstxy, ilastxy, jfirstxy, jlastxy
-      integer :: kend, i, j, k, n
       ! TODO: pchakrab - convt is not used anywhere
       logical, parameter :: convt = .false. ! Until this is run with full physics
       logical :: is_shutoff, is_ringing
@@ -712,11 +705,10 @@ contains
 #ifdef SKIP_TRACERS
       integer :: itracer
 #endif
-      type(ESMF_Alarm) :: predictor_alarm
       type(ESMF_Grid) :: bgrid
       character(len=:), allocatable :: field_name
       character(len=ESMF_MAXSTR), allocatable :: xlist(:), biggerlist(:)
-      character(len=:), allocatable :: adjust_tracer_mode
+      ! character(len=:), allocatable :: adjust_tracer_mode
       real(kind=r8) :: t1, t2, dyn_run_timer
       class(logger_t), pointer :: logger
       logical :: same_tradv_data
@@ -835,60 +827,16 @@ contains
       same_tradv_data = MAPL_FieldBundleSameData(bundle_imp, bundle, _RC)
       _ASSERT(same_tradv_data, "TRADV bundles in import and export do not point to the same data")
 
-      ! ALT: this section attempts to limit the amount of advected tracers
-      adjust_tracers = .false.
-      call MAPL_GridCompGetResource(gc, "EXCLUDE_ADVECTION_TRACERS", adjust_tracer_mode, default="ALWAYS", _RC)
-      select case(trim(adjust_tracer_mode))
-      case ("ALWAYS")
-         adjust_tracers = .true.
-      case ("PREDICTOR")
-         call ESMF_ClockGetAlarm(clock, alarmName="PredictorAlarm", alarm=predictor_alarm, rc=status)
-         if (status == ESMF_SUCCESS) then
-            if (ESMF_AlarmIsRinging(predictor_alarm)) then
-               adjust_tracers = .true.
-            end if
-         end if
-      case default
-         call logger%info("run:: Invalid value specified for EXCLUDE_ADVECTION_TRACERS, ignored")
-         adjust_tracers = .false.
-      end select
+      adjust_tracers = should_adjust_tracers(gc, clock, _RC)
       if (adjust_tracers) then
          if (first_run) then
             first_run = .false.
-            call ESMF_FieldBundleGet(bundle, grid=bgrid, fieldCount=nqt, _RC) ! num tracers
-            bundle_adv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
-            call ESMF_FieldBundleSet(bundle_adv, grid=bgrid, _RC)
-            xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR, _RC)
-            n = 0
-            if (allocated(xlist)) n = size(xlist)
-            ! Also exclude tracers that are to be advected by AdvCore
-            ! NOTE: DynCore always advects the cloud/water species, even when AdvCore is active
-            if (AdvCore_Advection >= 1) then
-               do i = 1, nqt
-                  call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
-                  field_name = get_short_name(field, _RC)
-                  if (.not. field_is_cloud_water_species(field_name)) then
-                     call logger%info("run:: DYN is excluding " // field_name)
-                     n = n + 1
-                     if (n > size(xlist)) xlist = resize(xlist, _RC)
-                     xlist(n) = trim(field_name)
-                  end if
-               end do
-            end if
-            ! Add non-excluded tracers to the bundle_adv
-            do i = 1, nqt
-               call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
-               field_name = get_short_name(field, _RC)
-               if (.not. is_name_in_list(field_name, xlist)) then
-                  call MAPL_FieldBundleAdd(bundle_adv, [field], _RC)
-               end if
-            end do
-            if (allocated(xlist)) deallocate(xlist)
-         end if ! first_run
+            bundle_adv = get_adjusted_tracer_bundle(bundle, hconfig, _RC) ! save'd
+         end if
          bundle = bundle_adv ! replace TRADV
       else
          bundle_adv = bundle ! replace with TRADV
-      end if ! adjust_tracers
+      end if
 
       ! Collect tracer names from the bundle for later use
       call ESMF_FieldBundleGet(bundle, fieldCount=nq, _RC)
@@ -2654,6 +2602,86 @@ contains
       _UNUSED_DUMMY(import)
    end subroutine PULL_Q
 
+   function should_adjust_tracers(gc, clock, rc) result(adjust_tracers)
+      type(ESMF_GridComp), intent(inout) :: gc
+      type(ESMF_Clock), intent(in) :: clock
+      integer, intent(out) :: rc
+      logical :: adjust_tracers
+
+      class(logger_t), pointer :: logger
+      character(len=:), allocatable :: adjust_tracer_mode
+      type(ESMF_Alarm) :: predictor_alarm
+      integer :: status
+
+      adjust_tracers = .false.
+
+      call MAPL_GridCompGetResource(gc, "EXCLUDE_ADVECTION_TRACERS", adjust_tracer_mode, default="ALWAYS", _RC)
+      select case(trim(adjust_tracer_mode))
+      case ("ALWAYS")
+         adjust_tracers = .true.
+      case ("PREDICTOR")
+         call ESMF_ClockGetAlarm(clock, alarmName="PredictorAlarm", alarm=predictor_alarm, rc=status)
+         if (status == ESMF_SUCCESS) then
+            if (ESMF_AlarmIsRinging(predictor_alarm)) then
+               adjust_tracers = .true.
+            end if
+         end if
+      case default
+         call logger%info("run:: Invalid value specified for EXCLUDE_ADVECTION_TRACERS, ignored")
+         adjust_tracers = .false.
+      end select
+
+      _RETURN(_SUCCESS)
+   end function should_adjust_tracers
+
+   function get_adjusted_tracer_bundle(orig_bundle, hconfig, rc) result(adjusted_bundle)
+      type(ESMF_FieldBundle), intent(in) :: orig_bundle
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, intent(out) :: rc
+      type(ESMF_FieldBundle) :: adjusted_bundle
+
+      type(ESMF_Grid) :: grid
+      type(ESMF_Field) :: field
+      character(len=:), allocatable :: field_name
+      character(len=ESMF_MAXSTR), allocatable :: xlist(:), biggerlist(:)
+      integer :: i, nqt, num_excluded, status
+
+      call ESMF_FieldBundleGet(orig_bundle, grid=grid, fieldCount=nqt, _RC)
+      adjusted_bundle = ESMF_FieldBundleCreate(name="xTRADV", _RC)
+      call ESMF_FieldBundleSet(adjusted_bundle, grid=grid, _RC)
+      xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR, _RC)
+      num_excluded = 0
+      if (allocated(xlist)) num_excluded = size(xlist)
+      ! Exclude tracers that are to be advected by AdvCore
+      ! NOTE: DynCore always advects the cloud/water species, even when AdvCore is active
+      if (AdvCore_Advection >= 1) then
+         do i = 1, nqt
+            call ESMF_FieldBundleGet(orig_bundle, fieldIndex=i, field=field, _RC)
+            field_name = get_short_name(field, _RC)
+            if (.not. field_is_cloud_water_species(field_name)) then
+               ! call logger%info("run:: DYN is excluding " // field_name)
+               num_excluded = num_excluded + 1
+               if (num_excluded > size(xlist)) then
+                  allocate(biggerlist(2*num_excluded), _STAT)
+                  biggerlist(1:num_excluded-1) = xlist
+                  call move_alloc(from=biggerlist, to=xlist)
+               end if
+               xlist(num_excluded) = trim(field_name)
+            end if
+         end do
+      end if
+      ! Add non-excluded tracers to the bundle_adv
+      do i = 1, nqt
+         call ESMF_FieldBundleGet(orig_bundle, fieldIndex=i, field=field, _RC)
+         field_name = get_short_name(field, _RC)
+         if (.not. is_name_in_list(field_name, xlist)) then
+            call MAPL_FieldBundleAdd(adjusted_bundle, [field], _RC)
+         end if
+      end do
+
+      _RETURN(_SUCCESS)
+   end function get_adjusted_tracer_bundle
+
    function get_short_name(field, rc) result(short_name)
       type(ESMF_Field) :: field
       integer, intent(out) :: rc
@@ -2685,7 +2713,8 @@ contains
       case ("mass_fraction_of_graupel")
          short_name = "QGRAUPEL"
       case default
-         _FAIL("Unrecognized standard_name: " // trim(standard_name))
+         ! _FAIL("Unrecognized standard_name: " // trim(standard_name))
+         short_name = trim(standard_name)
       end select
 
       _RETURN(_SUCCESS)
@@ -2712,23 +2741,6 @@ contains
          is_cloud_water_species = .true.
       end if
    end function field_is_cloud_water_species
-
-   function resize(old_list, factor, rc) result(resized)
-      character(len=ESMF_MAXSTR), intent(in) :: old_list(:)
-      integer, optional, intent(in) :: factor
-      integer, intent(out) :: rc
-      character(len=ESMF_MAXSTR), allocatable :: resized(:)
-
-      integer :: old_size, new_size, status
-
-      old_size = size(old_list)
-      new_size = 2 * old_size
-      if (present(factor)) new_size = factor * old_size
-      allocate(resized(new_size), _STAT)
-      resized(1:old_size) = old_list
-
-      _RETURN(_SUCCESS)
-   end function resize
 
    function is_name_in_list(name, list) result(is_in_list)
       character(len=*), intent(in) :: name

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -701,7 +701,7 @@ contains
       logical :: LCONSV, LFILL
       integer :: CONSV, FILL
 
-      logical, save :: firstime = .true.
+      logical, save :: first_run = .true.
       logical :: adjust_tracers, exclude, do_energetics, do_tropvars
       logical :: FV3_STANDALONE
       integer :: pos, nqt
@@ -711,8 +711,8 @@ contains
       type(ESMF_Alarm) :: predictor_alarm
       type(ESMF_Grid) :: bgrid
       character(len=:), allocatable :: field_name
-      character(len=ESMF_MAXSTR), allocatable :: biggerlist(:)
-      character(len=:), allocatable :: adjust_tracer_mode, xlist(:)
+      character(len=ESMF_MAXSTR), allocatable :: xlist(:), biggerlist(:)
+      character(len=:), allocatable :: adjust_tracer_mode
       real(kind=r8) :: t1, t2, dyn_run_timer
       class(logger_t), pointer :: logger
       logical :: same_tradv_data
@@ -849,60 +849,38 @@ contains
          adjust_tracers = .false.
       end select
       if (adjust_tracers) then
-         if (firstime) then
-            firstime = .false.
+         if (first_run) then
+            first_run = .false.
+            call ESMF_FieldBundleGet(bundle, grid=bgrid, fieldCount=nqt, _RC) ! num tracers
+            BundleAdv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
+            call ESMF_FieldBundleSet(BundleAdv, grid=bgrid, _RC)
             xlist = ESMF_HConfigAsStringSeq(hconfig, keyString="EXCLUDE_ADVECTION_TRACERS_LIST", stringLen=ESMF_MAXSTR, _RC)
             n = 0
             if (allocated(xlist)) n = size(xlist)
-
-            ! Count the number of tracers
-            call ESMF_FieldBundleGet(bundle, grid=bgrid, fieldCount=nqt, _RC)
-            BundleAdv = ESMF_FieldBundleCreate(name="xTRADV", _RC)
-            call ESMF_FieldBundleSet(BundleAdv, grid=bgrid, _RC)
-            do i = 1, nqt ! loop over nq in TRADV
-               ! Get field from TRADV and its name
-               call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
-               field_name = get_short_name(field, _RC)
-               ! Exclude everything that is not cloud/water species
-               if ((AdvCore_Advection >= 1) .and. &
-                    (field_name /= "Q") .and. &
-                    (field_name /= "QLCN") .and. &
-                    (field_name /= "QLLS") .and. &
-                    (field_name /= "QICN") .and. &
-                    (field_name /= "QILS") .and. &
-                    (field_name /= "CLCN") .and. &
-                    (field_name /= "CLLS") .and. &
-                    (field_name /= "NCPL") .and. &
-                    (field_name /= "NCPI") .and. &
-                    (field_name /= "QRAIN") .and. &
-                    (field_name /= "QSNOW") .and. &
-                    (field_name /= "QGRAUPEL")) then
-                  call logger%info("run:: FV3+ADV is excluding " // field_name)
-
-                  n = n + 1
-                  if (n > size(xlist)) then
-                     allocate(biggerlist(2 * n), _STAT)
-                     biggerlist(1:n - 1) = xlist
-                     call move_alloc(from=biggerlist, to=xlist)
-                  end if
-                  xlist(n) = trim(field_name)
-               end if
-               ! Loop over exclude_list
-               exclude = .false.
-               do j = 1, n
-                  if (field_name == xlist(j)) then
-                     exclude = .true.
-                     exit
+            ! Also exclude tracers that are to be advected by AdvCore
+            ! NOTE: DynCore always advects the cloud/water species, even when AdvCore is active
+            if (AdvCore_Advection >= 1) then
+               do i = 1, nqt
+                  call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
+                  field_name = get_short_name(field, _RC)
+                  if (.not. field_is_cloud_water_species(field_name)) then
+                     call logger%info("run:: DYN is excluding " // field_name)
+                     n = n + 1
+                     if (n > size(xlist)) xlist = resize(xlist, _RC)
+                     xlist(n) = trim(field_name)
                   end if
                end do
-               if (.not.exclude) then
+            end if
+            ! Add non-excluded tracers to the BundleAdv
+            do i = 1, nqt
+               call ESMF_FieldBundleGet(bundle, fieldIndex=i, field=field, _RC)
+               field_name = get_short_name(field, _RC)
+               if (.not. is_name_in_list(field_name, xlist)) then
                   call MAPL_FieldBundleAdd(BundleAdv, [field], _RC)
                end if
             end do
-
             if (allocated(xlist)) deallocate(xlist)
-
-         end if ! firstime
+         end if ! first_run
          bundle = BundleAdv ! replace TRADV
       else
          BundleAdv = bundle ! replace with TRADV
@@ -2708,6 +2686,61 @@ contains
 
       _RETURN(_SUCCESS)
    end function get_short_name
+
+   function field_is_cloud_water_species(field_name) result(is_cloud_water_species)
+      character(len=*), intent(in) :: field_name
+      logical :: is_cloud_water_species
+
+      is_cloud_water_species = .false.
+      if ( &
+           (trim(field_name) == "Q") .or. &
+           (trim(field_name) == "QLCN") .or. &
+           (trim(field_name) == "QLLS") .or. &
+           (trim(field_name) == "QICN") .or. &
+           (trim(field_name) == "QILS") .or. &
+           (trim(field_name) == "CLCN") .or. &
+           (trim(field_name) == "CLLS") .or. &
+           (trim(field_name) == "NCPL") .or. &
+           (trim(field_name) == "NCPI") .or. &
+           (trim(field_name) == "QRAIN") .or. &
+           (trim(field_name) == "QSNOW") .or. &
+           (trim(field_name) == "QGRAUPEL")) then
+         is_cloud_water_species = .true.
+      end if
+   end function field_is_cloud_water_species
+
+   function resize(old_list, factor, rc) result(resized)
+      character(len=ESMF_MAXSTR), intent(in) :: old_list(:)
+      integer, optional, intent(in) :: factor
+      integer, intent(out) :: rc
+      character(len=ESMF_MAXSTR), allocatable :: resized(:)
+
+      integer :: old_size, new_size, status
+
+      old_size = size(old_list)
+      new_size = 2 * old_size
+      if (present(factor)) new_size = factor * old_size
+      allocate(resized(new_size), _STAT)
+      resized(1:old_size) = old_list
+
+      _RETURN(_SUCCESS)
+   end function resize
+
+   function is_name_in_list(name, list) result(is_in_list)
+      character(len=*), intent(in) :: name
+      character(len=ESMF_MAXSTR), intent(in) :: list(:)
+      logical :: is_in_list
+
+      integer :: n
+
+      is_in_list = .false.
+      do n = 1, size(list)
+         if (trim(name) == trim(list(n))) then
+            is_in_list = .true.
+            exit
+         end if
+      end do
+   end function is_name_in_list
 
    !BOP
    !IROUTINE: run_add_incs

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -71,8 +71,8 @@ category: EXPORT
   CV             |  northward_accumulated_courant_number                                     |  1                 |  xyz  |  C   |                    |
   MX             |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |
   MY             |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |
-  MFX            |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |  R8
-  MFY            |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |  R8
+  MFX            |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2 s-1        |  xyz  |  C   |                    |  R8
+  MFY            |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2 s-1        |  xyz  |  C   |                    |  R8
   MFZ            |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R8
   MZ             |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R4
   PV             |  ertels_isentropic_potential_vorticity                                    |  m+2 kg-1 s-1      |  xyz  |  C   |                    |

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -71,8 +71,8 @@ category: EXPORT
   CV             |  northward_accumulated_courant_number                                     |  1                 |  xyz  |  C   |                    |
   MX             |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |
   MY             |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |
-  MFX            |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2 s-1        |  xyz  |  C   |                    |  R8
-  MFY            |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2 s-1        |  xyz  |  C   |                    |  R8
+  MFX            |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |  R8
+  MFY            |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |  R8
   MFZ            |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R8
   MZ             |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R4
   PV             |  ertels_isentropic_potential_vorticity                                    |  m+2 kg-1 s-1      |  xyz  |  C   |                    |


### PR DESCRIPTION
### Summary

Ports the FVdycoreCubed and AdvCore grid components to the MAPL3 API, and
refactors the tracer exclusion logic in both components into helper
functions.

---

### Changes

#### `AdvCore_GridCompMod.F90`
- Extract FV3 initialization from `SetServices` into a dedicated `fv_setup`
  subroutine (wraps `fv_init1`/`fv_init2`, FMS init, and grid dimension setup)
- Replace chained `if/end if` DYCORE checks with `select case`
- Replace manually declared import pointers with `AdvCore_DeclarePointer___.h`
- Extract inline TRADV exclusion logic from `Run` into two new module-private
  functions:
  - `should_adjust_tracers` — queries `EXCLUDE_ADVECTION_TRACERS` resource and
    checks `PredictorAlarm` for `"PREDICTOR"` mode
  - `get_adjusted_tracer_bundle` — builds the filtered bundle using
    `field_is_cloud_water_species` and `is_name_in_list` (imported from
    `FVdycoreCubed_GridComp`), replacing the hardcoded field-name list
- Switch `tracer_data` from a pointer to an allocatable; add
  `_RETURN_UNLESS(nq > 0)` early-exit guard
- Register Run phase with `phase_name="run"`

#### `DynCore_GridCompMod.F90`
- Extract inline TRADV exclusion logic from `Run` into the same two helper
  functions (`should_adjust_tracers`, `get_adjusted_tracer_bundle`)
- Replace the public `resize()` helper with inline `move_alloc`-based list
  growth; remove `resize` from the public interface
- Make `get_short_name` fall back to the field's `standard_name` for
  unrecognized names instead of hard-failing
- Clean up unused declarations (`field`, `FV3_STANDALONE`, `numvars`,
  `adjust_tracer_mode`, `predictor_alarm`)

#### `DynCore_StateSpecs.rc`
- Correct units for `MFX`/`MFY`

---

### Testing

- [x] Builds cleanly with ifort stack
- [x] ESSENTIAL ctest suite passes
- [x] Offline AdvCore advection test  (FV3+ADV mode) is zero diff