### PR TITLE
Fix ifort resolution of pi in AppGridCreate.F90

### DIFF
--- a/AppGridCreate.F90
+++ b/AppGridCreate.F90
@@ -4,7 +4,7 @@ subroutine AppCSEdgeCreateF(IM_WORLD, LonEdge,LatEdge, LonCenter, LatCenter, rc)
 #include "MAPL_Generic.h"
 
    use ESMF
-   use MAPL, only: pi => MAPL_PI_R8
+   use MAPL, pi => MAPL_PI_R8
    use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
         MAPL_MemUtilsWrite
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
@@ -127,7 +127,7 @@ function AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, rc) result(esmfgrid)
 #define DEALLOCGLOB_(A) if(associated(A))then;A=0;if(MAPL_ShmInitialized)then; call MAPL_DeAllocNodeArray(A,rc=STATUS);else; deallocate(A,stat=STATUS);endif;VERIFY_(STATUS);NULLIFY(A);endif
 
    use ESMF
-   use MAPL, only: pi => MAPL_PI_R8
+   use MAPL, pi => MAPL_PI_R8
    use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
         MAPL_MemUtilsWrite
    use mapl3g_GridGet, only: mapl_GridGet => GridGet

--- a/AppGridCreate.F90
+++ b/AppGridCreate.F90
@@ -4,10 +4,9 @@ subroutine AppCSEdgeCreateF(IM_WORLD, LonEdge,LatEdge, LonCenter, LatCenter, rc)
 #include "MAPL_Generic.h"
 
    use ESMF
-   use MAPL
+   use MAPL, only: pi => MAPL_PI_R8
    use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
         MAPL_MemUtilsWrite
-   use MAPL_Constants,    only : pi=> MAPL_PI_R8
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
    use fv_grid_utils_mod, only: gnomonic_grids, cell_center2, direct_transform
    use fv_grid_tools_mod, only: mirror_grid
@@ -128,11 +127,10 @@ function AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, rc) result(esmfgrid)
 #define DEALLOCGLOB_(A) if(associated(A))then;A=0;if(MAPL_ShmInitialized)then; call MAPL_DeAllocNodeArray(A,rc=STATUS);else; deallocate(A,stat=STATUS);endif;VERIFY_(STATUS);NULLIFY(A);endif
 
    use ESMF
-   use MAPL
+   use MAPL, only: pi => MAPL_PI_R8
    use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
         MAPL_MemUtilsWrite
    use mapl3g_GridGet, only: mapl_GridGet => GridGet
-   use MAPL_Constants, only: pi => MAPL_PI_R8
 
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
    use fv_grid_utils_mod, only: gnomonic_grids, cell_center2, direct_transform


### PR DESCRIPTION
## Summary

Fixes #373. Resolves ifort/ifx CI failure seen in MAPL PR GEOS-ESM/MAPL#4859.

MAPL PR #4859 removes `use MAPL_BaseMod` from `MAPLBase_Mod`, changing the transitive export chain of `MAPL2`. ifort then fails to resolve `MAPL_PI_R8` when `use MAPL_Constants, only: pi => MAPL_PI_R8` appears alongside a blanket `use MAPL`.

## Fix

Replace the separate `use MAPL_Constants, only: pi => MAPL_PI_R8` with `use MAPL, only: pi => MAPL_PI_R8` in both `AppCSEdgeCreateF` and `AppGridCreateF`, giving ifort a single unambiguous path to `pi`.

## Related

- Fixes #373
- Required for GEOS-ESM/MAPL#4859 to pass CI