### PR TITLE
Migrate MAPL_BaseMod to MAPL in fv_regrid_c2c.F90

### DIFF
--- a/fv_regrid_c2c.F90
+++ b/fv_regrid_c2c.F90
@@ -20,7 +20,7 @@ module fv_regrid_c2c
    use mapl3g_CubedSphereGeomSpec
    use MAPL_Constants,           only: MAPL_PI_R8, MAPL_OMEGA, MAPL_GRAV, MAPL_KAPPA, &
                                        MAPL_RGAS, MAPL_RVAP, MAPL_CP, MAPL_PSDRY
-   use MAPL_BaseMod,             only: MAPL_GridGet
+   use MAPL,                     only: MAPL_GridGet
    use MAPL_CommsMod,            only: ArrayScatter
    use FileIOSharedMod,          only: ArrDescr, ArrDescrInit, ArrDescrSet
    use NCIOMod,                  only: MAPL_VarRead, MAPL_NCIOGetFileType, &


### PR DESCRIPTION
## Summary

- `MAPL_BaseMod` is being removed as part of the MAPL3 cleanup (GEOS-ESM/MAPL#4862)
- Replace the single `use MAPL_BaseMod, only: MAPL_GridGet` in `fv_regrid_c2c.F90` with `use MAPL, only: MAPL_GridGet`
- This is consistent with the pattern already used elsewhere in this repo (e.g. `AdvCore_GridCompMod.F90`)