### PR TITLE
Migrate FileIOSharedMod/NCIOMod callers to use MAPL (fixes #378)

### DIFF
--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -22,7 +22,7 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_VectorField ! pchakrab: TODO - need MAPL3 equivalent
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL
 
-   use FileIOSharedMod, only: WRITE_PARALLEL
+   use MAPL, only: WRITE_PARALLEL
 
    use mapl3g_Utilities, only: MAPL_MaxMin, MAPL_AreaMean
    use mapl3g_Utilities_Comms_API, only: MAPL_Am_I_Root, MAPL_ArrayGather

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -9,7 +9,7 @@ module FV_StateMod
 #if defined( MAPL_MODE )
    use ESMF                ! ESMF base class
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
-   use FileIOSharedMod, only: WRITE_PARALLEL
+   use MAPL, only: WRITE_PARALLEL
 
    use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
    use mapl3g_generic, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop

--- a/fv_regrid_c2c.F90
+++ b/fv_regrid_c2c.F90
@@ -20,11 +20,11 @@ module fv_regrid_c2c
    use mapl3g_CubedSphereGeomSpec
    use MAPL_Constants,           only: MAPL_PI_R8, MAPL_OMEGA, MAPL_GRAV, MAPL_KAPPA, &
                                        MAPL_RGAS, MAPL_RVAP, MAPL_CP, MAPL_PSDRY
-   use MAPL,                      only: mapl_GridGetGlobalCellCountPerDim
+   use MAPL,                      only: mapl_GridGetGlobalCellCountPerDim, &
+                                        ArrDescr, ArrDescrInit, ArrDescrSet, &
+                                        MAPL_VarRead, MAPL_NCIOGetFileType, &
+                                        MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars
    use MAPL_CommsMod,            only: ArrayScatter
-   use FileIOSharedMod,          only: ArrDescr, ArrDescrInit, ArrDescrSet
-   use NCIOMod,                  only: MAPL_VarRead, MAPL_NCIOGetFileType, &
-                                       MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars
    use pfio
    use gFTL2_StringVector
    use gFTL2_StringIntegerMap

--- a/interp_restarts.F90
+++ b/interp_restarts.F90
@@ -8,10 +8,10 @@ program interp_restarts
 !--------------------------------------------------------------------!
    use ESMF
    use pfio
-   use NCIOMod,        only: MAPL_VarRead, MAPL_VarWrite, MAPL_NCIOGetFileType, &
-                              MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars, &
-                              MAPL_IOChangeRes, MAPL_IOCountLevels
-   use FileIOSharedMod,only: ArrDescr, ArrDescrInit, ArrDescrSet
+   use MAPL,           only: MAPL_VarRead, MAPL_VarWrite, MAPL_NCIOGetFileType, &
+                               MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars, &
+                               MAPL_IOChangeRes, MAPL_IOCountLevels, &
+                               ArrDescr, ArrDescrInit, ArrDescrSet
    use MAPL_ShmemMod,  only: MAPL_GetNodeInfo, MAPL_InitializeShmem, MAPL_FinalizeShmem
    use mapl3g_Geom_API,            only: GeomManager, get_geom_manager, MaplGeom
    use mapl3g_CubedSphereGeomSpec, only: CubedSphereGeomSpec

--- a/rs_scale.F90
+++ b/rs_scale.F90
@@ -1,7 +1,5 @@
       program  main
       use MAPL
-      use MAPL2, only: MAPL_IOCountNonDimVars, MAPL_NCIOGetFileType, &
-           MAPL_VarRead, MAPL_VarWrite
       implicit none
 
 ! ************************************************************************


### PR DESCRIPTION
## Summary

- Replaces direct `use FileIOSharedMod` and `use NCIOMod` with `use MAPL` in all affected files
- Files migrated: `DynCore_GridCompMod.F90`, `FV_StateMod.F90`, `fv_regrid_c2c.F90`, `interp_restarts.F90`, `rs_scale.F90`
- No logic changes — use statement migration only

## Dependency

Requires GEOS-ESM/MAPL#4882 (merged) which re-exports these symbols through the `MAPL` umbrella module.