### PR TITLE
Replace MAPL2 with MAPL in source and CMakeLists

### DIFF
--- a/AppGridCreate.F90
+++ b/AppGridCreate.F90
@@ -5,8 +5,6 @@ subroutine AppCSEdgeCreateF(IM_WORLD, LonEdge,LatEdge, LonCenter, LatCenter, rc)
 
    use ESMF
    use MAPL, pi => MAPL_PI_R8
-   use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
-        MAPL_MemUtilsWrite
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID
    use fv_grid_utils_mod, only: gnomonic_grids, cell_center2, direct_transform
    use fv_grid_tools_mod, only: mirror_grid
@@ -128,8 +126,6 @@ function AppGridCreateF(IM_WORLD, JM_WORLD, LM, NX, NY, rc) result(esmfgrid)
 
    use ESMF
    use MAPL, pi => MAPL_PI_R8
-   use MAPL2, only: MAPL_AllocNodeArray, MAPL_DeAllocNodeArray, &
-        MAPL_MemUtilsWrite
    use mapl3g_GridGet, only: mapl_GridGet => GridGet
 
    use fv_arrays_mod,     only: REAL4, REAL8, R_GRID

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 endif ()
 
 set(dependencies
-  esmf MAPL2 MAPL MAPL.generic3g MAPL.utilities
+  esmf MAPL MAPL.generic3g MAPL.utilities
   GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared
   OpenMP::OpenMP_Fortran)
 


### PR DESCRIPTION
## Summary

- Replaces `use MAPL2` with `use MAPL` in `AppGridCreate.F90`
- Removes `MAPL2` from `DEPENDENCIES` in top-level `CMakeLists.txt`
- Removes `MAPL2` from `DEPENDENCIES` in `@fvdycore/CMakeLists.txt` via GEOS-ESM/GFDL_atmos_cubed_sphere#124

## Motivation

Part of the MAPL2 retirement sequence. Contingent on GEOS-ESM/MAPL#4889 (PR1) being merged.

## Related Issues

Closes #380