### PR TITLE
regression: refactor adv-dyn test

### DIFF
--- a/regression/README.md
+++ b/regression/README.md
@@ -23,7 +23,9 @@ Key files:
 - `cap.yaml`, `cap_restart.yaml`
 - `root.yaml`
 - `dyn.yaml`, `adv.yaml`
-- `data-*.yaml`
+- `data-moist.yaml` — `DataMoist` component; owns `Q`, that is advected by DYN
+- `data-tracers.yaml` — `DataTracers` component; owns synthetic tracers `Q001`, `Q002`, that are advected by ADV
+- `data-ana.yaml`
 - `input.nml`
 
 ### `dyn-sa`

--- a/regression/adv-dyn/data-moist.yaml
+++ b/regression/adv-dyn/data-moist.yaml
@@ -1,0 +1,13 @@
+mapl:
+  states:
+    internal:
+      Q:
+        standard_name: "specific_humidity"
+        units: "kg kg-1"
+        vertical_dim_spec: "c"
+        fill_value: 1.0e-6
+
+    import:
+      TRADV:
+        class: service
+        items: [Q]

--- a/regression/adv-dyn/data-tracers.yaml
+++ b/regression/adv-dyn/data-tracers.yaml
@@ -1,11 +1,6 @@
 mapl:
   states:
     internal:
-      Q:
-        standard_name: "specific_humidity"
-        units: "kg kg-1"
-        vertical_dim_spec: "c"
-        fill_value: 1.0e-6
       Q001:
         standard_name: "Q001"
         units: "unknown"
@@ -20,4 +15,4 @@ mapl:
     import:
       TRADV:
         class: service
-        items: [Q, Q001, Q002]
+        items: [Q001, Q002]

--- a/regression/adv-dyn/root.yaml
+++ b/regression/adv-dyn/root.yaml
@@ -16,6 +16,10 @@ mapl:
       config_file: adv.yaml
       setservice: advcore_setservices_
 
+    DataMoist:
+      dso: libconfigurable_gridcomp
+      config_file: data-moist.yaml
+
     DataTracers:
       dso: libconfigurable_gridcomp
       config_file: data-tracers.yaml
@@ -29,6 +33,16 @@ mapl:
       config_file: data-ana.yaml
 
   connections:
+    - src_name: TRADV
+      dst_name: TRADV
+      src_comp: DYN
+      dst_comp: DataMoist
+
+    - src_name: TRADV
+      dst_name: TRADV
+      src_comp: ADV
+      dst_comp: DataMoist
+
     - src_name: TRADV
       dst_name: TRADV
       src_comp: DYN


### PR DESCRIPTION
Refactor the advection + dynamics regression test to separate specific humidity into its own DataMoist component. So now we have
- component `DataMoist`, that owns `Q`, which is advected by `DYN`
- component `DataTracers`, that owns the synthetic tracers `Q001`, `Q002`, that are advected by `ADV`