### PR TITLE
Refactor: Use MAPL vector field for UV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
           # MAPL3 code uses a special branch for now.
           fixture_branch: release/MAPL-v3
           mepodevelop: false
-          checkout_mapl3_release_branch: true
+          # checkout_mapl3_release_branch: true
           run_regression_tests: true
           ctest_options: "-L REGRESSION"
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
@@ -88,7 +88,7 @@ workflows:
           # MAPL3 code uses a special branch for now.
           fixture_branch: release/MAPL-v3
           mepodevelop: false
-          checkout_mapl3_release_branch: true
+          # checkout_mapl3_release_branch: true
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
       # We also turn off the FV3 dycore runs for now
       #############################################################################################

--- a/AdvCore_GridCompMod.F90
+++ b/AdvCore_GridCompMod.F90
@@ -67,7 +67,7 @@ module AdvCore_GridCompMod
    use fv_mp_mod, only: is, ie, js, je, is_master, tile
    use fv_grid_utils_mod, only: g_sum_r8
    use fv_diagnostics_mod, only: prt_maxmin, prt_minmax
-   use FV_StateMod, only: FV_Atm, get_im_world_and_topology
+   use FV_StateMod, only: FV_Atm, setup_fv_dimensions_and_topology
    use FV_StateMod, only: AdvCoreTracers => T_TRACERS
    use FVdycoreCubed_GridComp, only: field_is_cloud_water_species
    use FVdycoreCubed_GridComp, only: get_short_name, is_name_in_list
@@ -555,36 +555,17 @@ contains
       integer :: p_split = 1
       integer :: comm, im_world, topology(2), num_levels, status
 
-      call MAPL_GridCompGet(gc, hconfig=hconfig, num_levels=num_levels, _RC)
-
       call ESMF_VMGetCurrent(vm, _RC)
       call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
       call fms_init(comm)
 
       call fv_init1(FV_Atm, dt, grids_on_my_pe, p_split)
-      call get_im_world_and_topology(hconfig, im_world, topology, _RC)
-      associate(layout => FV_Atm(1)%layout, flags => FV_Atm(1)%flagstruct)
-         ! Domain decomposition
-         layout = topology
-         if (flags%grid_type == 4) then
-            layout(2) = layout(2) * 6
-         end if
-         ! Grid dimensions
-         flags%npx = im_world
-         flags%npy = im_world * 6
-         flags%npz = num_levels
-         ! TODO: pchakrab - check this! npy is always set to 6*npx!
-         if (flags%npy == 6 * flags%npx) then
-            flags%npy = flags%npx + 1
-            flags%npx = flags%npx + 1
-            flags%ntiles = 6
-         else
-            flags%npy = flags%npy + 1
-            flags%npx = flags%npx + 1
-            flags%ntiles = 1
-         end if
-      end associate
+
+      call MAPL_GridCompGet(gc, hconfig=hconfig, num_levels=num_levels, _RC)
+      call setup_fv_dimensions_and_topology(hconfig, num_levels, FV_Atm(1)%flagstruct, FV_Atm(1)%layout, _RC)
       call fv_init2(FV_Atm, dt, grids_on_my_pe, p_split)
+
+      _RETURN(_SUCCESS)
    end subroutine fv_setup
 
 end module AdvCore_GridCompMod

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -392,20 +392,6 @@ contains
 
       ! At this point check if FV is standalone
       call MAPL_GridCompGetResource(gc, "FV3_STANDALONE", FV3_STANDALONE, default=.false., _RC)
-      ! NOTE: pchakrab - Since TRADV is a service, it gets added to both the import and export
-      ! states, so we don't need to explictly export it
-      ! if (FV3_STANDALONE) then
-      !    call MAPL_GridCompAddSpec(gc, &
-      !         state_intent=ESMF_STATEINTENT_EXPORT, &
-      !         short_name='TRADVEX', &
-      !         standard_name='advected_quantities', &
-      !    ! pchakrab - TODO: we shouldn't need dims and vstagger for a bundle
-      !         dims="xyz", &
-      !         vstagger=VERTICAL_STAGGER_NONE, &
-      !         units='unknown', &
-      !         itemtype=MAPL_STATEITEM_SERVICE, _RC)
-      ! end if
-
       call MAPL_GridCompGetResource(gc, "DEBUG_DYN", DEBUG_DYN, default=.false., _RC)
       call MAPL_GridCompGetResource(gc, "DEBUG_ADV", DEBUG_ADV, default=.false., _RC)
       call MAPL_GridCompGetResource(gc, "DEBUG_TQ_ERRORS", DEBUG_TQ_ERRORS, default=.false., _RC)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -24,20 +24,20 @@ module FVdycoreCubed_GridComp
 
    use MAPL, only: WRITE_PARALLEL
 
-   use mapl3g_Utilities, only: MAPL_MaxMin, MAPL_AreaMean
+   use MAPL, only: MAPL_MaxMin, MAPL_AreaMean
+   use MAPL, only: MAPL_GridCompSetGeometry
+   use MAPL, only: MAPL_GridCompGet, MAPL_GridCompGetResource
+   use MAPL, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
+   use MAPL, only: MAPL_GridCompAddSpec, MAPL_STATEITEM_SERVICE, MAPL_STATEITEM_VECTOR
+   use MAPL, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
+   use MAPL, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
+   use MAPL, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
+   use MAPL, only: MAPL_GridGetCoordinates
+   use MAPL, only: MAPL_StateGetPointer
+   use MAPL, only: MAPL_FieldCreate, MAPL_FieldGet
+   use MAPL, only: MAPL_FieldBundleAdd, MAPL_FieldBundleSameData, MAPL_FieldBundleGetPointer
+   use MAPL, only: MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED
    use mapl3g_Utilities_Comms_API, only: MAPL_Am_I_Root, MAPL_ArrayGather
-   use mapl3g_generic, only: MAPL_GridCompSetGeometry
-   use mapl3g_generic, only: MAPL_GridCompGet, MAPL_GridCompGetResource
-   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
-   use mapl3g_generic, only: MAPL_GridCompAddSpec, MAPL_STATEITEM_SERVICE
-   use mapl3g_generic, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
-   use mapl3g_generic, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
-   use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
-   use mapl3g_Geom_API, only: MAPL_GridGetCoordinates
-   use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_Field_API, only: MAPL_FieldCreate, MAPL_FieldGet
-   use mapl3g_FieldBundle_API, only: MAPL_FieldBundleAdd, MAPL_FieldBundleSameData
-   use mapl3g_RestartModes, only: MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED
 
    use pflogger, only: logger_t => logger
    ! use gftl2_StringVector, only: StringVector
@@ -340,6 +340,29 @@ contains
 #include "DynCore_Export___.h"
 #include "DynCore_Internal___.h"
 
+      ! TODO: pchakrab - till we have a way to specify a VECTOR in acg
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_INTERNAL, &
+           short_name="UV", &
+           vector_component_names=["U", "V"], &
+           standard_name="(eastward_wind, northward_wind)", &
+           dims="xyz", &
+           vstagger=VERTICAL_STAGGER_CENTER, &
+           units='m/s', &
+           typekind=ESMF_TYPEKIND_R8, &
+           itemtype=MAPL_STATEITEM_VECTOR, &
+           restart=MAPL_RESTART_REQUIRED, _RC)
+
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_EXPORT, &
+           short_name="UV", &
+           vector_component_names=["U", "V"], &
+           standard_name="(eastward_wind, northward_wind)", &
+           dims="xyz", &
+           vstagger=VERTICAL_STAGGER_CENTER, &
+           units='m/s', &
+           itemtype=MAPL_STATEITEM_VECTOR, _RC)
+
       ! pchakrab - DynCore is the provider here, so the service items are not needed
       ! NOTE: SERVICE, irrespective of whether you are a provider or subscriber, adds the bundle
       ! to BOTH the export and import states
@@ -385,7 +408,7 @@ contains
       call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Run, run, phase_name="run", _RC)
       call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Run, run_add_incs, phase_name="run_add_incs", _RC)
       call MAPL_GridCompSetEntryPoint(gc, ESMF_Method_Finalize, Finalize, _RC)
-      !  call MAPL_GridCompSetEntryPoint(gc, ESMF_SETREADRESTART, Coldstart, _RC)
+      ! call MAPL_GridCompSetEntryPoint(gc, ESMF_SETREADRESTART, Coldstart, _RC)
 
       ! Setup geometry
       call MAPL_GridCompSetGeometry(gc, _RC)
@@ -410,6 +433,7 @@ contains
 
       type(DynState), pointer :: self
       type(ESMF_State) :: internal
+      type(ESMF_FieldBundle) :: uv, uv_exp
       real(kind=r4), pointer :: pref(:)
       real(kind=r4), pointer :: u(:, :, :), v(:, :, :), t(:, :, :)
       real(kind=r4), pointer :: temp2d(:, :)
@@ -420,7 +444,7 @@ contains
       logical :: ColdRestart
       type(ESMF_TimeInterval) :: replay_shutoff_interval
       type(ESMF_Alarm) :: replay_shutoff_alarm
-      integer :: replay_shutoff_seconds, ifirst, ilast, jfirst, jlast, km, status
+      integer :: replay_shutoff_seconds, ifirst, ilast, jfirst, jlast, km, field_count, status
 
       ! Setup FMS/FV3
       call MAPL_GridCompTimerStart(gc, "DYN_SETUP", _RC)
@@ -452,8 +476,13 @@ contains
       if (associated(pref)) pref = ak + bk * P00
 
       ! Create A-Grid Winds
-      call MAPL_StateGetPointer(export, u, "U", _RC)
-      call MAPL_StateGetPointer(export, v, "V", _RC)
+      call ESMF_StateGet(export, "UV", uv_exp, _RC)
+      call ESMF_FieldBundleGet(uv_exp, fieldCount=field_count, _RC)
+      nullify(u, v)
+      if (field_count == 2) then ! export bundle is connected
+         call MAPL_FieldBundleGetPointer(uv_exp, 1, u, _RC)
+         call MAPL_FieldBundleGetPointer(uv_exp, 2, v, _RC)
+      end if
       if (associated(u) .and. associated(v)) then
          ifirst = self%grid%is
          ilast = self%grid%ie
@@ -462,8 +491,9 @@ contains
          km = self%grid%npz
          allocate(ur(ifirst:ilast, jfirst:jlast, km))
          allocate(vr(ifirst:ilast, jfirst:jlast, km))
-         call MAPL_StateGetPointer(internal, ud, "U", _RC)
-         call MAPL_StateGetPointer(internal, vd, "V", _RC)
+         call ESMF_StateGet(internal, "UV", uv, _RC)
+         call MAPL_FieldBundleGetPointer(uv, 1, ud, _RC)
+         call MAPL_FieldBundleGetPointer(uv, 2, vd, _RC)
          call getAllWinds(ud, vd, ur=ur, vr=vr)
          u = ur
          v = vr
@@ -1829,8 +1859,8 @@ contains
          call FILLOUT3r8(export, 'MFZ', mfzxyz, _RC)
          call FILLOUT3(export, 'MZ', mfzxyz, _RC)
 
-         call FILLOUT3(export, 'U', ur, _RC)
-         call FILLOUT3(export, 'V', vr, _RC)
+         ! call FILLOUT3(export, 'U', ur, _RC)
+         ! call FILLOUT3(export, 'V', vr, _RC)
          call FILLOUT3(export, 'T', tempxy, _RC)
          call FILLOUT3(export, 'Q', qv, _RC)
          call FILLOUT3(export, 'PL', pl, _RC)
@@ -4058,6 +4088,7 @@ contains
       type(ESMF_State) :: internal
 
       real(kind=REAL8), pointer :: ak1(:), bk1(:), ak(:), bk(:)
+      type(ESMF_FieldBundle) :: uv
       real(kind=REAL8), pointer :: u(:, :, :), v(:, :, :), pt(:, :, :)
       real(kind=REAL8), pointer :: pe1(:, :, :), pkz(:, :, :)
       real(kind=REAL8), allocatable :: pe(:, :, :)
@@ -4114,7 +4145,9 @@ contains
          lats(:, :) = 15.0 * PI / 180.0
       end if
 
-      call MAPL_StateGetPointer(internal, u, "U", _RC) ! A-Grid U Wind
+      call ESMF_StateGet(internal, "UV", uv, _RC)
+      call MAPL_FieldBundleGetPointer(uv, 1, u, _RC) ! A-Grid U Wind
+      call MAPL_FieldBundleGetPointer(uv, 2, v, _RC) ! A-Grid V Wind
       is = lbound(u, 1)
       ie = ubound(u, 1)
       js = lbound(u, 2)
@@ -4122,11 +4155,10 @@ contains
       ks = lbound(u, 3)
       ke = ubound(u, 3)
       km = ke - ks + 1
-      call MAPL_StateGetPointer(internal, v, "V", _RC) ! A-Grid V Wind
       call MAPL_StateGetPointer(internal, pt, "PT", _RC) ! potential temperature
       ! call MAPL_StateGetPointer(internal, PE1, "PE", _RC) ! edge pressures - 1 based
       ! pchakrab - gfortran has issues with the following rank
-      ! remapping (ifort doesn't) , so we allocate a new array
+      ! remapping (ifort doesn't), so we allocate a new array
       ! PE(is:ie, js:je, 0:km) => PE1(is:ie, js:je, 1:km+1)
       allocate(pe(is:ie, js:je, 0:km), _STAT)
       call MAPL_StateGetPointer(internal, pkz, "PKZ", _RC) ! presssure ^ kappa at mid-layers

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -22,6 +22,7 @@ module FVdycoreCubed_GridComp
    use MAPL_Constants, only: MAPL_VectorField ! pchakrab: TODO - need MAPL3 equivalent
    use MAPL_Constants, only: MAPL_UNDEFINED_REAL
 
+   use MAPL, only: write_parallel
    use MAPL, only: MAPL_MaxMin, MAPL_AreaMean
    use MAPL, only: MAPL_GridCompSetGeometry
    use MAPL, only: MAPL_GridCompGet, MAPL_GridCompGetResource

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -50,8 +50,6 @@ category: EXPORT
   CONVTHV        |  vertically_integrated_thetav_convergence                                 |  W m-2             |  xy   |  N   |                    |
   CONVCPT        |  vertically_integrated_enthalpy_convergence                               |  W m-2             |  xy   |  N   |                    |
   CONVPHI        |  vertically_integrated_geopotential_convergence                           |  W m-2             |  xy   |  N   |                    |
-  U              |  eastward_wind                                                            |  m s-1             |  xyz  |  C   |  MAPL_VectorField  |
-  V              |  northward_wind                                                           |  m s-1             |  xyz  |  C   |  MAPL_VectorField  |
   T              |  air_temperature                                                          |  K                 |  xyz  |  C   |                    |
   PL             |  mid_level_pressure                                                       |  Pa                |  xyz  |  C   |                    |
   ZLE0           |  edge_heights_above_surface                                               |  m                 |  xyz  |  E   |                    |
@@ -263,8 +261,6 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------------------------------
   AK        |  hybrid_sigma_pressure_a       |  Pa                |  R8        |    z  |  REQUIRED  |  E   |    T       |
   BK        |  hybrid_sigma_pressure_b       |  1                 |  R8        |    z  |  REQUIRED  |  E   |    T       |
-  U         |  eastward_wind                 |  m s-1             |  R8        |  xyz  |  REQUIRED  |  C   |    F       |
-  V         |  northward_wind                |  m s-1             |  R8        |  xyz  |  REQUIRED  |  C   |    F       |
   W         |  vertical_velocity             |  m s-1             |  R8        |  xyz  |            |  C   |    F       |
   PT        |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |  R8        |  xyz  |  REQUIRED  |  C   |    F       |
   PE        |  air_pressure                  |  Pa                |  R8        |  xyz  |  REQUIRED  |  E   |    T       |    PLE

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -10,7 +10,6 @@ module FV_StateMod
    use ESMF                ! ESMF base class
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
    use MAPL, only: WRITE_PARALLEL
-
    use MAPL, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
    use MAPL, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
    use MAPL, only: MAPL_GridGet

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -11,11 +11,11 @@ module FV_StateMod
    use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
    use MAPL, only: WRITE_PARALLEL
 
-   use mapl3g_generic, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
-   use mapl3g_generic, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
-   use mapl3g_Geom_API, only: MAPL_GridGet
-   use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_utilities, only: MAPL_MemInfoWrite
+   use MAPL, only: MAPL_GridCompGetResource, MAPL_GridCompGet, MAPL_GridCompGetInternalState
+   use MAPL, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
+   use MAPL, only: MAPL_GridGet
+   use MAPL, only: MAPL_StateGetPointer, MAPL_FieldBundleGetPointer
+   use MAPL, only: MAPL_MemInfoWrite
 #endif
 
    use MAPL_Constants, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS
@@ -869,6 +869,7 @@ contains
 
   real(REAL8), pointer                   :: AK(:) => NULL(), AK1(:) => NULL()
   real(REAL8), pointer                   :: BK(:) => NULL(), BK1(:) => NULL()
+  type(ESMF_FieldBundle) :: uv
   real(REAL8), dimension(:,:,:), pointer :: U     => NULL()
   real(REAL8), dimension(:,:,:), pointer :: V     => NULL()
   real(REAL8), dimension(:,:,:), pointer :: PT    => NULL()
@@ -927,10 +928,9 @@ contains
   VERIFY_(STATUS)
   call MAPL_StateGetPointer(internal, bk1, "BK",rc=status)
   VERIFY_(STATUS)
-  call MAPL_StateGetPointer(internal, u, "U",rc=status)
-  VERIFY_(STATUS)
-  call MAPL_StateGetPointer(internal, v, "V",rc=status)
-  VERIFY_(STATUS)
+  call ESMF_StateGet(internal, "UV", uv, _RC)
+  call MAPL_FieldBundleGetPointer(uv, 1, u, _RC)
+  call MAPL_FieldBundleGetPointer(uv, 2, v, _RC)
   call MAPL_StateGetPointer(internal, pt, "PT",rc=status)
   VERIFY_(STATUS)
   call MAPL_StateGetPointer(internal, pe, "PE",rc=status)

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -1,4 +1,4 @@
-#include "MAPL_Generic.h"
+#include "MAPL.h"
 
 module FV_StateMod
 !BOP
@@ -105,7 +105,7 @@ private
 
   public fv_getAllWinds
   public INTERP_AGRID_TO_DGRID
-  public get_im_world_and_topology
+  public setup_fv_dimensions_and_topology
 
   interface fv_computeMassFluxes
      module procedure fv_computeMassFluxes_r4
@@ -374,30 +374,7 @@ contains
 
 ! FV grid dimensions setup from MAPL
       call MAPL_GridCompGet(gc, hconfig=hconfig, num_levels=num_levels, _RC)
-      ! call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%npx, 'AGCM_IM:', default= 32, RC=STATUS )
-      ! VERIFY_(STATUS)
-      ! call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%npy, 'AGCM_JM:', default=192, RC=STATUS )
-      ! VERIFY_(STATUS)
-      ! call MAPL_GetResource( MAPL, FV_Atm(1)%flagstruct%npz, 'AGCM_LM:', default= 72, RC=STATUS )
-      ! VERIFY_(STATUS)
-      call get_im_world_and_topology(hconfig, im_world, topology, _RC)
-      associate(flags => FV_Atm(1)%flagstruct)
-        flags%npx = im_world
-        flags%npy = im_world * 6
-        flags%npz = num_levels
-! FV likes npx;npy in terms of cell vertices
-        ! TODO: pchakrab - check this! npy is always set to 6*npx, so the if
-        ! statement is always true and the else branch is never taken. Is this intentional?
-        if (flags%npy == 6*flags%npx) then
-           flags%npy = flags%npx+1
-           flags%npx = flags%npx+1
-           flags%ntiles = 6
-        else
-           flags%npy = flags%npy+1
-           flags%npx = flags%npx+1
-           flags%ntiles = 1
-        endif
-      end associate
+      call setup_fv_dimensions_and_topology(hconfig, num_levels, FV_Atm(1)%flagstruct, FV_Atm(1)%layout, _RC)
       if (FV_Atm(1)%flagstruct%npz == 1) SW_DYNAMICS = .true.
       ! stretch_fac is kind(R_GRID) in FV, so to prevent a MAPL failure on RC check, we pull
       ! AGCM.STRETCH_FACTOR: as a REAL32 and then cast it to REAL64. This is because
@@ -409,13 +386,6 @@ contains
 ! Check for Doubly Periodic Domain Info
       call MAPL_GridCompGetResource( gc, 'FIXED_LATS', FV_Atm(1)%flagstruct%deglat, default=FV_Atm(1)%flagstruct%deglat, rc=status )
       VERIFY_(STATUS)
-! MPI decomp setup
-      associate(layout => FV_Atm(1)%layout)
-        layout = topology
-        if (FV_Atm(1)%flagstruct%grid_type == 4) then
-           layout(2) = layout(2) * 6
-        end if
-      end associate
 
 ! Get other scalars
 ! -----------------
@@ -794,11 +764,45 @@ contains
 
  end subroutine FV_Setup
 
-    subroutine get_im_world_and_topology(hconfig, im_world, topology, rc)
+   subroutine setup_fv_dimensions_and_topology(hconfig, num_levels, flags, layout, rc)
+      use fv_arrays_mod, only: fv_flags_type
       type(ESMF_HConfig), intent(in) :: hconfig
+      integer, intent(in) :: num_levels
+      type(FV_Flags_Type), intent(inout) :: flags
+      integer, intent(inout) :: layout(2)
       integer, optional, intent(out) :: rc
+
+      integer :: im_world, topology(2), status
+
+      call get_im_world_and_topology(hconfig, im_world, topology, _RC)
+      flags%npx = im_world
+      flags%npy = im_world * 6
+      flags%npz = num_levels
+      ! FV likes npx;npy in terms of cell vertices
+      ! TODO: pchakrab - check this! npy is always set to 6*npx, so the if
+      ! statement is always true and the else branch is never taken. Is this intentional?
+      if (flags%npy == 6*flags%npx) then
+         flags%npy = flags%npx+1
+         flags%npx = flags%npx+1
+         flags%ntiles = 6
+      else
+         flags%npy = flags%npy+1
+         flags%npx = flags%npx+1
+         flags%ntiles = 1
+      endif
+      layout = topology
+      if (FV_Atm(1)%flagstruct%grid_type == 4) then
+         layout(2) = layout(2) * 6
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine setup_fv_dimensions_and_topology
+
+   subroutine get_im_world_and_topology(hconfig, im_world, topology, rc)
+      type(ESMF_HConfig), intent(in) :: hconfig
       integer, intent(out) :: im_world
       integer, intent(out) :: topology(2)
+      integer, optional, intent(out) :: rc
 
       type(ESMF_HConfig) :: geometry_cfg, geom_cfg
       logical :: has_section


### PR DESCRIPTION
This PR refactors FVdycoreCubed_GridComp to use the MAPL vector field for UV, updates state specifications, and improves FV_StateMod logic.

- Switches UV to MAPL vector field
- Updates DynCore_StateSpecs.rc
- Refactors FV_StateMod.F90 for improved logic and MAPL compatibility

All changes validated with passing tests.