### PR TITLE
Migrate all direct mapl3g_* imports to use MAPL umbrella (fixes #386)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 endif ()
 
 set(dependencies
-  esmf MAPL MAPL.generic3g MAPL.utilities
+  esmf MAPL MAPL.shared MAPL.generic3g MAPL.utilities
   GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared
   OpenMP::OpenMP_Fortran)
 

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -15,15 +15,8 @@ module FVdycoreCubed_GridComp
 
    !USES:
    use ESMF
-   use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return
-
-   use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
-   use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
-   use MAPL_Constants, only: MAPL_VectorField ! pchakrab: TODO - need MAPL3 equivalent
-   use MAPL_Constants, only: MAPL_UNDEFINED_REAL
-
-   use mapl3g_Utilities, only: MAPL_MaxMin, MAPL_AreaMean
-   use MAPL, only: WRITE_PARALLEL, MAPL_Am_I_Root, &
+   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return, &
+                   WRITE_PARALLEL, MAPL_Am_I_Root, MAPL_MaxMin, MAPL_AreaMean, &
                    MAPL_GridCompSetGeometry, MAPL_GridCompGet, MAPL_GridCompGetResource, &
                    MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState, &
                    MAPL_GridCompAddSpec, MAPL_STATEITEM_SERVICE, &
@@ -32,8 +25,11 @@ module FVdycoreCubed_GridComp
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
                    MAPL_GridGetCoordinates, MAPL_StateGetPointer, MAPL_FieldCreate, MAPL_FieldGet, &
                    MAPL_FieldBundleAdd, MAPL_FieldBundleSameData, &
-                   MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED
-   use mapl3g_Comms, only: MAPL_ArrayGather => array_gather
+                   MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED, MAPL_ArrayGather
+   use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
+   use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
+   use MAPL_Constants, only: MAPL_VectorField ! pchakrab: TODO - need MAPL3 equivalent
+   use MAPL_Constants, only: MAPL_UNDEFINED_REAL
 
    use pflogger, only: logger_t => logger
    ! use gftl2_StringVector, only: StringVector

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -8,11 +8,10 @@ module FV_StateMod
 ! !USES:
 #if defined( MAPL_MODE )
    use ESMF                ! ESMF base class
-   use mapl_ErrorHandlingMod, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY
-   use mapl3g_Utilities, only: MAPL_MemInfoWrite
-   use MAPL, only: WRITE_PARALLEL, MAPL_GridCompGetResource, MAPL_GridCompGet, &
+   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return, MAPL_VRFY, &
+                   WRITE_PARALLEL, MAPL_GridCompGetResource, MAPL_GridCompGet, &
                    MAPL_GridCompGetInternalState, MAPL_GridCompTimerStart, MAPL_GridCompTimerStop, &
-                   MAPL_GridGet, MAPL_StateGetPointer
+                   MAPL_GridGet, MAPL_StateGetPointer, MAPL_MemInfoWrite
 #endif
 
    use MAPL_Constants, only: MAPL_CP, MAPL_RGAS, MAPL_RVAP, MAPL_GRAV, MAPL_RADIUS

--- a/fv_regrid_c2c.F90
+++ b/fv_regrid_c2c.F90
@@ -11,20 +11,15 @@ module fv_regrid_c2c
    use tracer_manager_mod, only: get_tracer_names, get_number_tracers, get_tracer_index
    use field_manager_mod,  only: MODEL_ATMOS
 
-   use mapl3g_regridder_mgr
-   use mapl3g_Regridder,         only: Regridder
-   use mapl3g_RegridderMethods,  only: REGRID_METHOD_BILINEAR, generate_esmf_regrid_param
-   use mapl3g_RegridderManager,  only: get_regridder_manager, RegridderManager
-   use mapl3g_RegridderSpec,     only: RegridderSpec
-   use mapl_ErrorHandlingMod
-   use mapl3g_CubedSphereGeomSpec
-   use MAPL_Constants,           only: MAPL_PI_R8, MAPL_OMEGA, MAPL_GRAV, MAPL_KAPPA, &
-                                       MAPL_RGAS, MAPL_RVAP, MAPL_CP, MAPL_PSDRY
-   use MAPL,                      only: mapl_GridGetGlobalCellCountPerDim, &
-                                        ArrDescr, ArrDescrInit, ArrDescrSet, &
-                                        MAPL_VarRead, MAPL_NCIOGetFileType, &
-                                        MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars
-   use MAPL_CommsMod,            only: ArrayScatter
+   use MAPL, only: Regridder, REGRID_METHOD_BILINEAR, generate_esmf_regrid_param, &
+                   get_regridder_manager, RegridderManager, RegridderSpec, &
+                   CubedSphereGeomSpec, mapl_GridGetGlobalCellCountPerDim, &
+                   ArrDescr, ArrDescrInit, ArrDescrSet, &
+                   MAPL_VarRead, MAPL_NCIOGetFileType, &
+                   MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars, ArrayScatter, &
+                   MAPL_Verify, MAPL_Return
+   use MAPL_Constants, only: MAPL_PI_R8, MAPL_OMEGA, MAPL_GRAV, MAPL_KAPPA, &
+                              MAPL_RGAS, MAPL_RVAP, MAPL_CP, MAPL_PSDRY
    use pfio
    use gFTL2_StringVector
    use gFTL2_StringIntegerMap

--- a/interp_restarts.F90
+++ b/interp_restarts.F90
@@ -13,9 +13,8 @@ program interp_restarts
                                MAPL_IOChangeRes, MAPL_IOCountLevels, &
                                ArrDescr, ArrDescrInit, ArrDescrSet
    use MAPL_ShmemMod,  only: MAPL_GetNodeInfo, MAPL_InitializeShmem, MAPL_FinalizeShmem
-   use mapl3g_Geom_API,            only: GeomManager, get_geom_manager, MaplGeom
-   use mapl3g_CubedSphereGeomSpec, only: CubedSphereGeomSpec
-   use mapl3g_CubedSphereDecomposition, only: CubedSphereDecomposition
+   use MAPL, only: GeomManager, get_geom_manager, MaplGeom, &
+                   CubedSphereGeomSpec, CubedSphereDecomposition
    use mpp_mod,        only: mpp_error, FATAL, NOTE, mpp_root_pe, mpp_broadcast
    use fms_mod,        only: print_memory_usage, fms_init, fms_end, file_exist
    use fv_control_mod, only: fv_init1, fv_init2, fv_end


### PR DESCRIPTION
## Summary

Now that the MAPL umbrella exports all needed symbols via GEOS-ESM/MAPL#4954, replace all remaining direct `mapl3g_*` imports with `use MAPL`:

- `DynCore_GridCompMod.F90`: replace `mapl_ErrorHandlingMod`, `mapl3g_Utilities`, `mapl3g_Comms`
- `FV_StateMod.F90`: replace `mapl_ErrorHandlingMod`, `mapl3g_Utilities`
- `fv_regrid_c2c.F90`: replace `mapl3g_regridder_mgr`, `mapl3g_Regridder`, `mapl3g_RegridderMethods`, `mapl3g_RegridderManager`, `mapl3g_RegridderSpec`, `mapl_ErrorHandlingMod`, `mapl3g_CubedSphereGeomSpec`, `MAPL_CommsMod`
- `interp_restarts.F90`: replace `mapl3g_Geom_API`, `mapl3g_CubedSphereGeomSpec`, `mapl3g_CubedSphereDecomposition`

Closes #386