### PR TITLE
DynCore: migrate scalar export fields to MAPL3 vector field bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ workflows:
           # MAPL3 code uses a special branch for now.
           fixture_branch: release/MAPL-v3
           mepodevelop: false
-          # checkout_mapl3_release_branch: true
           run_regression_tests: true
           ctest_options: "-L REGRESSION"
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
@@ -88,7 +87,6 @@ workflows:
           # MAPL3 code uses a special branch for now.
           fixture_branch: release/MAPL-v3
           mepodevelop: false
-          # checkout_mapl3_release_branch: true
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
       # We also turn off the FV3 dycore runs for now
       #############################################################################################

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -15,17 +15,17 @@ module FVdycoreCubed_GridComp
 
    !USES:
    use ESMF
-   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return, &
-                   WRITE_PARALLEL, MAPL_Am_I_Root, MAPL_MaxMin, MAPL_AreaMean, &
-                   MAPL_GridCompSetGeometry, MAPL_GridCompGet, MAPL_GridCompGetResource, &
-                   MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState, &
-                   MAPL_GridCompAddSpec, MAPL_STATEITEM_SERVICE, MAPL_STATEITEM_VECTOR, &
-                   MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState, &
-                   MAPL_GridCompTimerStart, MAPL_GridCompTimerStop, &
-                   VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
-                   MAPL_GridGetCoordinates, MAPL_StateGetPointer, MAPL_FieldCreate, MAPL_FieldGet, &
-                   MAPL_FieldBundleAdd, MAPL_FieldBundleSameData, MAPL_FieldBundleGetPointer, &
-                   MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED, MAPL_ArrayGather
+   use MAPL, only: MAPL_Verify, MAPL_Assert, MAPL_Return
+   use MAPL, only: WRITE_PARALLEL, MAPL_Am_I_Root, MAPL_MaxMin, MAPL_AreaMean
+   use MAPL, only: MAPL_GridCompSetGeometry, MAPL_GridCompGet, MAPL_GridCompGetResource
+   use MAPL, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompGetInternalState
+   use MAPL, only: MAPL_GridCompAddSpec, MAPL_STATEITEM_SERVICE, MAPL_STATEITEM_VECTOR
+   use MAPL, only: MAPL_UserCompSetInternalState, MAPL_UserCompGetInternalState
+   use MAPL, only: MAPL_GridCompTimerStart, MAPL_GridCompTimerStop
+   use MAPL, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
+   use MAPL, only: MAPL_GridGetCoordinates, MAPL_StateGetPointer, MAPL_FieldCreate, MAPL_FieldGet
+   use MAPL, only: MAPL_FieldBundleAdd, MAPL_FieldBundleSameData, MAPL_FieldBundleGetPointer
+   use MAPL, only: MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED, MAPL_ArrayGather
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
    use MAPL_Constants, only: MAPL_VectorField ! pchakrab: TODO - need MAPL3 equivalent
@@ -336,11 +336,10 @@ contains
       call MAPL_GridCompAddSpec(gc, &
            state_intent=ESMF_STATEINTENT_INTERNAL, &
            short_name="UV", &
-           vector_component_names=["U", "V"], &
            standard_name="(eastward_wind, northward_wind)", &
            dims="xyz", &
            vstagger=VERTICAL_STAGGER_CENTER, &
-           units='m/s', &
+           units="m/s", &
            typekind=ESMF_TYPEKIND_R8, &
            itemtype=MAPL_STATEITEM_VECTOR, &
            restart=MAPL_RESTART_REQUIRED, _RC)
@@ -348,11 +347,50 @@ contains
       call MAPL_GridCompAddSpec(gc, &
            state_intent=ESMF_STATEINTENT_EXPORT, &
            short_name="UV", &
-           vector_component_names=["U", "V"], &
            standard_name="(eastward_wind, northward_wind)", &
            dims="xyz", &
            vstagger=VERTICAL_STAGGER_CENTER, &
-           units='m/s', &
+           units="m/s", &
+           itemtype=MAPL_STATEITEM_VECTOR, _RC)
+
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_EXPORT, &
+           short_name="D_UV_DTANA", &
+           standard_name="(tendency_of_eastward_wind_due_to_analysis, &
+           tendency_of_northward_wind_due_to_analysis)", &
+           dims="xyz", &
+           vstagger=VERTICAL_STAGGER_CENTER, &
+           units="m/s/s", &
+           itemtype=MAPL_STATEITEM_VECTOR, _RC)
+
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_EXPORT, &
+           short_name="UV_KE", &
+           standard_name="(eastward_flux_of_atmospheric_kinetic_energy, &
+           northward_flux_of_atmospheric_kinetic_energy)", &
+           dims="xy", &
+           vstagger=VERTICAL_STAGGER_NONE, &
+           units="J m-1 s-1", &
+           itemtype=MAPL_STATEITEM_VECTOR, _RC)
+
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_EXPORT, &
+           short_name="UV_PHI", &
+           standard_name="(eastward_flux_of_atmospheric_potential_energy, &
+           northward_flux_of_atmospheric_potential_energy)", &
+           dims="xy", &
+           vstagger=VERTICAL_STAGGER_NONE, &
+           units="J m-1 s-1", &
+           itemtype=MAPL_STATEITEM_VECTOR, _RC)
+
+      call MAPL_GridCompAddSpec(gc, &
+           state_intent=ESMF_STATEINTENT_EXPORT, &
+           short_name="UV_QV", &
+           standard_name="(eastward_flux_of_atmospheric_water_vapor, &
+           northward_flux_of_atmospheric_water_vapor)", &
+           dims="xy", &
+           vstagger=VERTICAL_STAGGER_NONE, &
+           units="kg m-1 s-1", &
            itemtype=MAPL_STATEITEM_VECTOR, _RC)
 
       ! pchakrab - DynCore is the provider here, so the service items are not needed
@@ -470,12 +508,9 @@ contains
       ! Create A-Grid Winds
       call ESMF_StateGet(export, "UV", uv_exp, _RC)
       call ESMF_FieldBundleGet(uv_exp, fieldCount=field_count, _RC)
-      nullify(u, v)
       if (field_count == 2) then ! export bundle is connected
          call MAPL_FieldBundleGetPointer(uv_exp, 1, u, _RC)
          call MAPL_FieldBundleGetPointer(uv_exp, 2, v, _RC)
-      end if
-      if (associated(u) .and. associated(v)) then
          ifirst = self%grid%is
          ilast = self%grid%ie
          jfirst = self%grid%js
@@ -550,7 +585,7 @@ contains
 
       integer :: status, comm
       type(ESMF_VM) :: vm
-      type(ESMF_FieldBundle) :: bundle_imp, bundle
+      type(ESMF_FieldBundle) :: bundle_imp, bundle, tmp_bundle
       type(ESMF_Field) :: field
       type(ESMF_Alarm) :: alarm
       type(ESMF_Grid) :: esmfgrid
@@ -560,7 +595,7 @@ contains
       type(DynGrid), pointer :: grid
       type(DynVars), pointer :: vars
 
-      integer :: nq, im, jm, km, kend, i, j, k, n
+      integer :: nq, im, jm, km, kend, i, j, k, n, field_count
       integer :: ifirstxy, ilastxy, jfirstxy, jlastxy
       ! TODO: pchakrab - convt is not used anywhere
       logical, parameter :: convt = .false. ! Until this is run with full physics
@@ -678,8 +713,9 @@ contains
       real(kind=r4), pointer :: vtmp3d(:, :, :)
       real(kind=r4), pointer :: area(:, :)
       real(kind=r4), pointer :: temp2d(:, :)
-      real(kind=r4), pointer :: tempu(:, :)
-      real(kind=r4), pointer :: tempv(:, :)
+      real(kind=r4), pointer :: uke(:, :), vke(:, :)
+      real(kind=r4), pointer :: uphi(:, :), vphi(:, :)
+      real(kind=r4), pointer :: uqv(:, :), vqv(:, :)
 
       real(kind=r4), pointer :: uh25(:, :), uh03(:, :)
       real(kind=r4), pointer :: srh01(:, :), srh03(:, :), srh25(:, :), shr06(:, :)
@@ -1006,13 +1042,15 @@ contains
             call Energetics(ur, vr, tempxy, vars%pe, delp, vars%pkz, phisxy, kenrg, penrg, tenrg)
          end if
 
-         ! DUDTANA
-         call MAPL_StateGetPointer(export, dudtana, "DUDTANA", _RC)
-         if (associated(dudtana)) dudtana = ur
-
-         ! DVDTANA
-         call MAPL_StateGetPointer(export, dvdtana, "DVDTANA", _RC)
-         if (associated(dvdtana)) dvdtana = vr
+         ! DUDTANA/DVDTANA
+         call ESMF_StateGet(export, "D_UV_DTANA", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, dudtana, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, dvdtana, _RC)
+            dudtana = ur
+            dvdtana = vr
+         end if
 
          ! DTDTANA
          call MAPL_StateGetPointer(export, dtdtana, "DTDTANA", _RC)
@@ -1276,14 +1314,10 @@ contains
 
          dmdt = vars%pe(:, :, km + 1) - vars%pe(:, :, 1) ! Psurf-Ptop
 
-         ! DUDTANA
-         call MAPL_StateGetPointer(export, dudtana, "DUDTANA", _RC)
+         ! Update DUDTANA/DVDTANA
          if (associated(dudtana)) then
             dudtana = (ur - dudtana) / dt
          end if
-
-         ! DVDTANA
-         call MAPL_StateGetPointer(export, dvdtana, "DVDTANA", _RC)
          if (associated(dvdtana)) then
             dvdtana = (vr - dvdtana) / dt
          end if
@@ -1301,7 +1335,6 @@ contains
          end if
 
          ! DTHVDTANAINT
-         ! ------------
          call MAPL_StateGetPointer(export, temp2d, "DTHVDTANAINT", _RC)
          if (associated(temp2d)) then
             tempxy = vars%pt * (1 + EPS * qv) ! Set tempxy = TH*QVnew (After Analysis Update)
@@ -2072,46 +2105,40 @@ contains
          call getOmega(omaxyz)
 
          ! Fluxes: UKE & VKE
-         call MAPL_StateGetPointer(export, tempu, 'UKE', _RC)
-         call MAPL_StateGetPointer(export, tempv, 'VKE', _RC)
-
-         if (associated(tempu) .or. associated(tempv)) then
+         call ESMF_StateGet(export, "UV_KE", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, uke, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vke, _RC)
             tmp3d = 0.5 * (ur**2 + vr**2)
-         end if
-
-         if (associated(tempu)) then
-            tempu = 0.0
+            uke = 0.0
             do k = 1, km
-               tempu = tempu + ur(:, :, k) * tmp3d(:, :, k) * delp(:, :, k)
+               uke = uke + ur(:, :, k) * tmp3d(:, :, k) * delp(:, :, k)
             end do
-            tempu = tempu / GRAV
-         end if
-
-         if (associated(tempv)) then
-            tempv = 0.0
+            uke = uke / GRAV
+            vke = 0.0
             do k = 1, km
-               tempv = tempv + vr(:, :, k) * tmp3d(:, :, k) * delp(:, :, k)
+               vke = vke + vr(:, :, k) * tmp3d(:, :, k) * delp(:, :, k)
             end do
-            tempv = tempv / GRAV
+            vke = vke / GRAV
          end if
 
          ! Fluxes: UQV & VQV
-         call MAPL_StateGetPointer(export, temp2d, 'UQV', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+         call ESMF_StateGet(export, "UV_QV", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, uqv, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vqv, _RC)
+            uqv = 0.0
             do k = 1, km
-               temp2d = temp2d + ur(:, :, k) * qv(:, :, k) * delp(:, :, k)
+               uqv = uqv + ur(:, :, k) * qv(:, :, k) * delp(:, :, k)
             end do
-            temp2d = temp2d / GRAV
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, 'VQV', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+            uqv = uqv / GRAV
+            vqv = 0.0
             do k = 1, km
-               temp2d = temp2d + vr(:, :, k) * qv(:, :, k) * delp(:, :, k)
+               vqv = vqv + vr(:, :, k) * qv(:, :, k) * delp(:, :, k)
             end do
-            temp2d = temp2d / GRAV
+            vqv = vqv / GRAV
          end if
 
          ! Fluxes: UQL & VQL
@@ -2205,22 +2232,19 @@ contains
          if (associated(temp3d)) temp3d = temp3d + GRAV * (0.5 * (zle(:, :, :km) + zle(:, :, 2:)))
 
          ! Fluxes: UPHI & VPHI
-         call MAPL_StateGetPointer(export, tempu, 'UPHI', _RC)
-         call MAPL_StateGetPointer(export, tempv, 'VPHI', _RC)
-
-         if (associated(tempu) .or. associated(tempv)) zl = 0.5 * (zle(:, :, :km) + zle(:, :, 2:))
-
-         if (associated(tempu)) then
-            tempu = 0.0
+         call ESMF_StateGet(export, "UV_PHI", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, uphi, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vphi, _RC)
+            zl = 0.5 * (zle(:, :, :km) + zle(:, :, 2:))
+            uphi = 0.0
             do k = 1, km
-               tempu = tempu + ur(:, :, k) * zl(:, :, k) * delp(:, :, k)
+               uphi = uphi + ur(:, :, k) * zl(:, :, k) * delp(:, :, k)
             end do
-         end if
-
-         if (associated(tempv)) then
-            tempv = 0.0
+            vphi = 0.0
             do k = 1, km
-               tempv = tempv + vr(:, :, k) * zl(:, :, k) * delp(:, :, k)
+               vphi = vphi + vr(:, :, k) * zl(:, :, k) * delp(:, :, k)
             end do
          end if
 

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -77,16 +77,18 @@ category: EXPORT
   EPV            |  ertels_potential_vorticity                                               |  K m+2 kg-1 s-1    |  xyz  |  C   |                    |
   Q              |  specific_humidity                                                        |  1                 |  xyz  |  C   |                    |
   QC             |  specific_mass_of_condensate                                              |  1                 |  xyz  |  C   |                    |
-  DUDTSUBZ       |  tendency_of_eastward_wind_due_to_subgrid_dz                              |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
-  DVDTSUBZ       |  tendency_of_northward_wind_due_to_subgrid_dz                             |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
-  DTDTSUBZ       |  tendency_of_air_temperature_due_to_subgrid_dz                            |  K s-1             |  xyz  |  C   |                    |
-  DWDTSUBZ       |  tendency_of_vertical_velocity_due_to_subgrid_dz                          |  m/s/s             |  xyz  |  C   |                    |
+# DUDTSUBZ       |  tendency_of_eastward_wind_due_to_subgrid_dz                              |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+# DVDTSUBZ       |  tendency_of_northward_wind_due_to_subgrid_dz                             |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+# DTDTSUBZ       |  tendency_of_air_temperature_due_to_subgrid_dz                            |  K s-1             |  xyz  |  C   |                    |
+# DWDTSUBZ       |  tendency_of_vertical_velocity_due_to_subgrid_dz                          |  m/s/s             |  xyz  |  C   |                    |
   DTDT_RAY       |  air_temperature_tendency_due_to_Rayleigh_friction                        |  K s-1             |  xyz  |  C   |                    |
   DUDT_RAY       |  tendency_of_eastward_wind_due_to_Rayleigh_friction                       |  m s-2             |  xyz  |  C   |  MAPL_VectorField  |
   DVDT_RAY       |  tendency_of_northward_wind_due_to_Rayleigh_friction                      |  m s-2             |  xyz  |  C   |  MAPL_VectorField  |
   DWDT_RAY       |  vertical_velocity_tendency_due_to_Rayleigh_friction                      |  m/s/s             |  xyz  |  C   |                    |
-  DUDTANA        |  tendency_of_eastward_wind_due_to_analysis                                |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
-  DVDTANA        |  tendency_of_northward_wind_due_to_analysis                               |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+#
+# DUDTANA        |  tendency_of_eastward_wind_due_to_analysis                                |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+# DVDTANA        |  tendency_of_northward_wind_due_to_analysis                               |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+#
   DTDTANA        |  tendency_of_air_temperature_due_to_analysis                              |  K s-1             |  xyz  |  C   |                    |
   DDELPDTANA     |  tendency_of_pressure_thickness_due_to_analysis                           |  K s-1             |  xyz  |  C   |                    |
   DUDTDYN        |  tendency_of_eastward_wind_due_to_dynamics                                |  m/s/s             |  xyz  |  C   |                    |
@@ -101,8 +103,10 @@ category: EXPORT
   PS             |  surface_pressure                                                         |  Pa                |  xy   |  N   |                    |
   TA             |  surface_air_temperature                                                  |  K                 |  xy   |  N   |                    |
   QA             |  surface_specific_humidity                                                |  1                 |  xy   |  N   |                    |
+#
   US             |  surface_eastward_wind                                                    |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
   VS             |  surface_northward_wind                                                   |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+#
   SPEED          |  surface_wind_speed                                                       |  m s-1             |  xy   |  N   |                    |
   WSPD_10M       |  wind_speed_at_10m                                                        |  m s-1             |  xy   |  N   |                    |
   VVEL_UP_100_1000  | max_vertical_velocity_up_between_100_1000_hPa                          |  m s-1             |  xy   |  N   |                    |
@@ -130,18 +134,25 @@ category: EXPORT
   THV            |  scaled_virtual_potential_temperature                                     |  K/Pa$^\kappa$     |  xyz  |  C   |                    |
   DPLEDTDYN      |  tendency_of_edge_pressure_due_to_dynamics                                |  Pa s-1            |  xyz  |  C   |                    |
   DDELPDTDYN     |  tendency_of_pressure_thickness_due_to_dynamics                           |  Pa s-1            |  xyz  |  C   |                    |
-  UKE            |  eastward_flux_of_atmospheric_kinetic_energy                              |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-  VKE            |  northward_flux_of_atmospheric_kinetic_energy                             |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+#
+# UKE            |  eastward_flux_of_atmospheric_kinetic_energy                              |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+# VKE            |  northward_flux_of_atmospheric_kinetic_energy                             |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+#
   UCPT           |  eastward_flux_of_atmospheric_enthalpy                                    |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
   VCPT           |  northward_flux_of_atmospheric_enthalpy                                   |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-  UPHI           |  eastward_flux_of_atmospheric_potential_energy                            |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-  VPHI           |  northward_flux_of_atmospheric_potential_energy                           |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-  UQV            |  eastward_flux_of_atmospheric_water_vapor                                 |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
-  VQV            |  northward_flux_of_atmospheric_water_vapor                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+#
+# UPHI           |  eastward_flux_of_atmospheric_potential_energy                            |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+# VPHI           |  northward_flux_of_atmospheric_potential_energy                           |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+#
+# UQV            |  eastward_flux_of_atmospheric_water_vapor                                 |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+# VQV            |  northward_flux_of_atmospheric_water_vapor                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+#
   UQL            |  eastward_flux_of_atmospheric_liquid_water                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
   VQL            |  northward_flux_of_atmospheric_liquid_water                               |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+#
   UQI            |  eastward_flux_of_atmospheric_ice                                         |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
   VQI            |  northward_flux_of_atmospheric_ice                                        |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+#
   DKE            |  tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics            |  W m-2             |  xy   |  N   |                    |
   DCPT           |  tendency_of_atmosphere_dry_energy_content_due_to_dynamics                |  W m-2             |  xy   |  N   |                    |
   DPET           |  tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics      |  W m-2             |  xy   |  N   |                    |
@@ -166,37 +177,46 @@ category: EXPORT
   DIVG700        |  divergence_at_700_hPa                                                    |  s-1               |  xy   |  N   |                    |
   DIVG500        |  divergence_at_500_hPa                                                    |  s-1               |  xy   |  N   |                    |
   DIVG200        |  divergence_at_200_hPa                                                    |  s-1               |  xy   |  N   |                    |
+#
   U850           |  eastward_wind_at_850_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  U700           |  eastward_wind_at_700_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  U500           |  eastward_wind_at_500_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  U300           |  eastward_wind_at_300_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  U250           |  eastward_wind_at_250_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  U200           |  eastward_wind_at_200_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  U100           |  eastward_wind_at_100_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  UTOP           |  eastward_wind_at_model_top                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
   V850           |  northward_wind_at_850_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V700           |  northward_wind_at_700_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V500           |  northward_wind_at_500_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V300           |  northward_wind_at_300_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V250           |  northward_wind_at_250_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V200           |  northward_wind_at_200_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V100           |  northward_wind_at_100_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  VTOP           |  northward_wind_at_model_top                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
   T850           |  air_temperature_at_850_hPa                                               |  K                 |  xy   |  N   |                    |
-  T700           |  air_temperature_at_700_hPa                                               |  K                 |  xy   |  N   |                    |
-  T500           |  air_temperature_at_500_hPa                                               |  K                 |  xy   |  N   |                    |
-  T300           |  air_temperature_at_300_hPa                                               |  K                 |  xy   |  N   |                    |
-  T250           |  air_temperature_at_250_hPa                                               |  K                 |  xy   |  N   |                    |
-  T200           |  air_temperature_at_200_hPa                                               |  K                 |  xy   |  N   |                    |
-  T100           |  air_temperature_at_100_hPa                                               |  K                 |  xy   |  N   |                    |
-  TTOP           |  air_temperature_at_model_top                                             |  K                 |  xy   |  N   |                    |
   Q850           |  specific_humidity_at_850_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  U700           |  eastward_wind_at_700_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V700           |  northward_wind_at_700_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T700           |  air_temperature_at_700_hPa                                               |  K                 |  xy   |  N   |                    |
   Q700           |  specific_humidity_at_700_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  U500           |  eastward_wind_at_500_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V500           |  northward_wind_at_500_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T500           |  air_temperature_at_500_hPa                                               |  K                 |  xy   |  N   |                    |
   Q500           |  specific_humidity_at_500_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  U300           |  eastward_wind_at_300_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V300           |  northward_wind_at_300_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T300           |  air_temperature_at_300_hPa                                               |  K                 |  xy   |  N   |                    |
   Q300           |  specific_humidity_at_300_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  U250           |  eastward_wind_at_250_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V250           |  northward_wind_at_250_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T250           |  air_temperature_at_250_hPa                                               |  K                 |  xy   |  N   |                    |
   Q250           |  specific_humidity_at_250_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  U200           |  eastward_wind_at_200_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V200           |  northward_wind_at_200_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T200           |  air_temperature_at_200_hPa                                               |  K                 |  xy   |  N   |                    |
   Q200           |  specific_humidity_at_200_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  U100           |  eastward_wind_at_100_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  V100           |  northward_wind_at_100_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  T100           |  air_temperature_at_100_hPa                                               |  K                 |  xy   |  N   |                    |
   Q100           |  specific_humidity_at_100_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+#
+  UTOP           |  eastward_wind_at_model_top                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  VTOP           |  northward_wind_at_model_top                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  TTOP           |  air_temperature_at_model_top                                             |  K                 |  xy   |  N   |                    |
+#
   Z700           |  geopotential_height_at_700_hPa                                           |  m                 |  xy   |  N   |                    |
   Z500           |  geopotential_height_at_500_hPa                                           |  m                 |  xy   |  N   |                    |
   Z300           |  geopotential_height_at_300_hPa                                           |  m                 |  xy   |  N   |                    |
@@ -216,8 +236,10 @@ category: EXPORT
   W500           |  w_at_500_hPa                                                             |  m s-1             |  xy   |  N   |                    |
   W200           |  w_at_200_hPa                                                             |  m s-1             |  xy   |  N   |                    |
   W10            |  w_at_10_hPa                                                              |  m s-1             |  xy   |  N   |                    |
+#
   U50M           |  eastward_wind_at_50_meters                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
   V50M           |  northward_wind_at_50_meters                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+#
   DXC            |  cgrid_delta_x                                                            |  m                 |  xy   |  N   |                    |
   DYC            |  cgrid_delta_y                                                            |  m                 |  xy   |  N   |                    |
   AREA           |  agrid_cell_area                                                          |  m+2               |  xy   |  N   |                    |

--- a/regression/adv-dyn/cap.yaml
+++ b/regression/adv-dyn/cap.yaml
@@ -10,14 +10,17 @@ cap:
     segment_duration: PT1H  # P1DT
 
   run_extdata: false
-  run_history: false
-  root_name: root
+  history_name: History
+  root_name: Root
 
   mapl:
     children:
-      root:
+      Root:
         dso: libconfigurable_gridcomp
         config_file: root.yaml
+      History:
+        dso: libMAPL.history
+        config_file: history.yaml
 
   checkpointing:
     enabled: true

--- a/regression/adv-dyn/cmpchk.py
+++ b/regression/adv-dyn/cmpchk.py
@@ -6,6 +6,16 @@ import netCDF4 as nc4
 BASELINE_VERSION = "GCMv12-rc27p1+Held-Suarez"
 BASELINE_DIR = f"/home/pchakrab/workspace/runs/fv3sa/AdvCore/{BASELINE_VERSION}/C12L91/baseline/const-tracer"
 
+def alias(name):
+    match name:
+        case "U":
+            alias = "UV_1"
+        case "V":
+            alias = "UV_2"
+        case _:
+            alias = name
+    return alias
+
 print("\nDYN")
 states = ["internal"]
 for state in states:
@@ -14,9 +24,9 @@ for state in states:
     current = f"checkpoints/last/DYN_{state}.nc"
     with nc4.Dataset(baseline) as bas, nc4.Dataset(current) as cur:
         for var in bas.variables:
-            if var in cur.variables:
+            if alias(var) in cur.variables:
                 bas_var = bas[var][:]
-                cur_var = cur[var][0]
+                cur_var = cur[alias(var)][0]
                 diff = np.abs(bas_var- cur_var)
                 diffnorm = np.linalg.norm(diff)
                 print(f" {var:<5} diff(Linf, L2): {np.max(diff)}, {diffnorm}")

--- a/regression/adv-dyn/history.yaml
+++ b/regression/adv-dyn/history.yaml
@@ -1,15 +1,19 @@
 active_collections:
-  - HeldSuarez
+  - test
 
 time_specs:
   three_hour: &one_hour
     frequency: PT1H
 
 collections:
-  HeldSuarez:
+  test:
     template: "%c.nc4"
     time_spec: *one_hour
     var_list:
       TEST_TRACER00000: {source: ADV.TEST_TRACER00000}
       TEST_TRACER00001: {source: ADV.TEST_TRACER00001}
-
+      "[U,V]": {source: DYN.UV}
+      "[DUDTANA,DVDTANA]": {source: DYN.D_UV_DTANA}
+      "[UKE,VKE]": {source: DYN.UV_KE}
+      "[UPHI,VPHI]": {source: DYN.UV_PHI}
+      "[UQV,VQV]": {source: DYN.UV_QV}

--- a/regression/dyn-sa/cap.yaml
+++ b/regression/dyn-sa/cap.yaml
@@ -10,14 +10,17 @@ cap:
     segment_duration: PT1H  # P1DT
 
   run_extdata: false
-  run_history: false
-  root_name: root
+  history_name: History
+  root_name: Root
 
   mapl:
     children:
-      root:
+      Root:
         dso: libconfigurable_gridcomp
         config_file: root.yaml
+      History:
+        dso: libMAPL.history
+        config_file: history.yaml
 
   checkpointing:
     enabled: true

--- a/regression/dyn-sa/cmpchk.py
+++ b/regression/dyn-sa/cmpchk.py
@@ -3,18 +3,28 @@
 import numpy as np
 import netCDF4 as nc4
 
-VARS2CHECK = ["DZ", "PE", "PKZ", "PT", "U", "V", "W"]
 BASELINE_VERSION = "v3.0.0-rc.13"
 BASELINE_DIR = f"/home/pchakrab/workspace/runs/fv3sa/DynCore/{BASELINE_VERSION}/C48L181/baseline"
+
+def alias(name):
+    match name:
+        case "U":
+            alias = "UV_1"
+        case "V":
+            alias = "UV_2"
+        case _:
+            alias = name
+    return alias
+
 for state in ["internal"]:
     print("\nSTATE:", state)
     baseline = f"{BASELINE_DIR}/one-hour/fvcore_{state}_checkpoint.nc"
     current = f"checkpoints/last/DYNsa_{state}.nc"
     with nc4.Dataset(baseline) as bas, nc4.Dataset(current) as cur:
         for var in bas.variables:
-            if var in cur.variables:
+            if alias(var) in cur.variables:
                 bas_var = bas[var][:]
-                cur_var = cur[var][0]
+                cur_var = cur[alias(var)][0]
                 diff = np.abs(bas_var- cur_var)
                 diffnorm = np.linalg.norm(diff)
                 print(f" {var:<5} diff(Linf, L2): {np.max(diff)}, {diffnorm}")

--- a/regression/dyn-sa/history.yaml
+++ b/regression/dyn-sa/history.yaml
@@ -1,0 +1,17 @@
+active_collections:
+  - test
+
+time_specs:
+  three_hour: &one_hour
+    frequency: PT1H
+
+collections:
+  test:
+    template: "%c.nc4"
+    time_spec: *one_hour
+    var_list:
+      "[U,V]": {source: DYNsa.UV}
+      "[DUDTANA,DVDTANA]": {source: DYNsa.D_UV_DTANA}
+      "[UKE,VKE]": {source: DYNsa.UV_KE}
+      "[UPHI,VPHI]": {source: DYNsa.UV_PHI}
+      "[UQV,VQV]": {source: DYNsa.UV_QV}


### PR DESCRIPTION
## Summary
Migrate DynCore export fields to MAPL3 vector field bundle conventions.

## What changed
- Remove `vector_component_names` from UV spec declarations
- Add export specs for `D_UV_DTANA`, `UV_KE`, `UV_PHI`, `UV_QV` as MAPL3 vector bundles
- Replace `MAPL_StateGetPointer` calls for scalar U/V exports with `ESMF_StateGet` + `MAPL_FieldBundleGetPointer` on the corresponding vector bundle
- Split MAPL `use` statement into per-group lines
- Remove stale commented-out CI option in `.circleci/config.yml`

## Validation
- Regression configs (adv-dyn, dyn-sa) updated in a companion commit to exercise the new vector bundle outputs
