### PR TITLE
Remove direct MAPL.generic3g link dependency (closes #392)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 endif ()
 
 set(dependencies
-  esmf MAPL MAPL.shared MAPL.generic3g MAPL.utilities
+  esmf MAPL MAPL.shared MAPL.utilities
   GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared
   OpenMP::OpenMP_Fortran)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (BUILD_GEOS_GTFV3_INTERFACE)
 endif ()
 
 set(dependencies
-  esmf MAPL MAPL.shared MAPL.utilities
+  esmf MAPL
   GFTL_SHARED::gftl-shared-v2 GMAO_hermes GEOS_Shared
   OpenMP::OpenMP_Fortran)
 


### PR DESCRIPTION
## Summary

- Remove `MAPL.generic3g` from `target_link_libraries` in `CMakeLists.txt`

All symbols are available transitively through `MAPL`. This target no longer exists as of GEOS-ESM/MAPL#4990.

## Dependency

**Draft — contingent on GEOS-ESM/MAPL#4990.**