### PR TITLE
DynCore: Export rotated winds as a vector FieldBundle (UV)

### DIFF
--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -2816,6 +2816,7 @@ contains
       type(DynVars), pointer :: vars
       type(DynTracers) :: qqq ! Specific Humidity
       type(ESMF_Grid) :: esmfgrid
+      type(ESMF_FieldBundle) :: uv
 
       real(kind=r8), allocatable :: penrg(:, :) ! Vertically Integrated Cp*T
       real(kind=r8), allocatable :: kenrg(:, :) ! Vertically Integrated K
@@ -2826,6 +2827,7 @@ contains
 
       real(kind=r8), pointer :: phisxy(:, :)
       real(kind=r4), pointer :: phis(:, :)
+      real(kind=r4), pointer :: u(:, :, :), v(:, :, :)
       real(kind=r8), allocatable :: slp(:, :)
       real(kind=r8), allocatable :: H1000(:, :)
       real(kind=r8), allocatable :: H850(:, :)
@@ -2865,7 +2867,7 @@ contains
       real(kind=FVPRC) :: dt
       logical :: do_energetics
       integer :: ifirstxy, ilastxy, jfirstxy, jlastxy
-      integer :: im, jm, km, iNXQ
+      integer :: im, jm, km, iNXQ, field_count
       integer :: i, j, k, status
       class(logger_t), pointer :: logger
 
@@ -3058,8 +3060,15 @@ contains
          ! end if
 
          call FILLOUT3(export, "DELP", dp, _RC)
-         call FILLOUT3(export, "U", ur, _RC)
-         call FILLOUT3(export, "V", vr, _RC)
+         ! TODO: pchakrab - we need another FILLOUT3 routine for vectors
+         call ESMF_StateGet(export, "UV", uv, _RC)
+         call ESMF_FieldBundleGet(uv, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(uv, 1, u, _RC)
+            call MAPL_FieldBundleGetPointer(uv, 2, v, _RC)
+            u = ur
+            v = vr
+         end if
          call FILLOUT3(export, "T", tempxy, _RC)
          call FILLOUT3(export, "Q", qv, _RC)
          call FILLOUT3(export, "PL", pl, _RC)

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -1,16 +1,15 @@
-# Detect if we are using Open MPI and add oversubscribe/bind-to/map-by flags
-string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
-list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
-if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
-  set(MPIEXEC_PREFLAGS "--oversubscribe;--bind-to;core;--map-by;core" CACHE STRING "Flags for mpiexec" FORCE)
-endif()
-
 file(STRINGS "cases.txt" TEST_CASES)
 
 if(APPLE)
   set(LD_PATH "DYLD_LIBRARY_PATH")
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
+  # OpenMPI flags
+  string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
+  list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
+  if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
+    set(MPIEXEC_PREFLAGS "--oversubscribe;--bind-to;core;--map-by;core" CACHE STRING "Flags for mpiexec" FORCE)
+  endif()
 endif()
 
 string(ASCII 27 ESC)


### PR DESCRIPTION
## Summary

Replace the pair of scalar `FILLOUT3` calls for `U` and `V` with a single FieldBundle export `UV`. Retrieve the bundle from the export state, check that it is connected (`fieldCount == 2`), and assign the rotated wind arrays `ur`/`vr` through `MAPL_FieldBundleGetPointer`.

## Changes

### `DynCore_GridCompMod.F90`
- Add `uv` (`ESMF_FieldBundle`) and `u`/`v` pointers to local declarations
- Replace `FILLOUT3(export, "U", ur)` and `FILLOUT3(export, "V", vr)` with a bundle-aware assignment via `ESMF_StateGet` + `MAPL_FieldBundleGetPointer`
- Guard the assignment with a `fieldCount == 2` check to handle unconnected bundles gracefully

### `regression/CMakeLists.txt`
- Scope the OpenMPI `MPIEXEC_PREFLAGS` detection to the Linux/non-Apple branch, avoiding a CMake string-parse error on macOS where `MPI_Fortran_LIBRARY_VERSION_STRING` may not contain the expected token

## Testing

- [x] Builds cleanly with ifort stack
- [x] REGRESSION ctest suite passes