### PR TITLE
DynCore: migrate some of the pairs of Fields to Vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,8 @@ else ()
   )
 endif ()
 
-mapl_acg (${this} DynCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS 3g)
-mapl_acg (${this} AdvCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS GET_POINTERS DECLARE_POINTERS 3g)
+mapl_acg (${this} DynCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS)
+mapl_acg (${this} AdvCore_StateSpecs.rc IMPORT_SPECS EXPORT_SPECS GET_POINTERS DECLARE_POINTERS)
 
 if (FV_PRECISION STREQUAL R4)
   target_link_libraries (${this} PUBLIC FMS::fms_r4)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -658,6 +658,8 @@ contains
       real(kind=r4), pointer :: uqv(:, :), vqv(:, :)
       real(kind=r4), pointer :: uql(:, :), vql(:, :)
       real(kind=r4), pointer :: uqi(:, :), vqi(:, :)
+      real(kind=r4), pointer :: ucpt(:, :), vcpt(:, :)
+      real(kind=r4), pointer :: us(:, :), vs(:, :)
 
       real(kind=r4), pointer :: uh25(:, :), uh03(:, :)
       real(kind=r4), pointer :: srh01(:, :), srh03(:, :), srh25(:, :), shr06(:, :)
@@ -2005,23 +2007,21 @@ contains
          if (associated(temp3d)) temp3d = tempxy
 
          ! Fluxes: UCPT & VCPT
-         !--------------------
-         call MAPL_StateGetPointer(export, temp2d, 'UCPT', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+         call ESMF_StateGet(export, "UV_CPT", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, ucpt, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vcpt, _RC)
+            ucpt = 0.0
             do k = 1, km
-               temp2d = temp2d + ur(:, :, k) * tempxy(:, :, k) * delp(:, :, k)
+               ucpt = ucpt + ur(:, :, k) * tempxy(:, :, k) * delp(:, :, k)
             end do
-            temp2d = temp2d * (CP / GRAV)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, 'VCPT', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+            ucpt = ucpt * (CP / GRAV)
+            vcpt = 0.0
             do k = 1, km
-               temp2d = temp2d + vr(:, :, k) * tempxy(:, :, k) * delp(:, :, k)
+               vcpt = vcpt + vr(:, :, k) * tempxy(:, :, k) * delp(:, :, k)
             end do
-            temp2d = temp2d * (CP / GRAV)
+            vcpt = vcpt * (CP / GRAV)
          end if
 
          ! Compute Energetics After Dycore
@@ -2209,14 +2209,13 @@ contains
             call MAPL_StateGetPointer(export, temp2d, 'PS', _RC)
             if (associated(temp2d)) temp2d = vars%pe(:, :, km + 1)
 
-            call MAPL_StateGetPointer(export, temp2d, 'US', _RC)
-            if (associated(temp2d)) then
-               call VertInterp(temp2d, ur, -zle, -HGT_SURFACE, _RC)
-            end if
-
-            call MAPL_StateGetPointer(export, temp2d, 'VS', _RC)
-            if (associated(temp2d)) then
-               call VertInterp(temp2d, vr, -zle, -HGT_SURFACE, _RC)
+            call ESMF_StateGet(export, 'UV_S', tmp_bundle, _RC)
+            call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+            if (field_count == 2) then ! export bundle is connected
+               call MAPL_FieldBundleGetPointer(tmp_bundle, 1, us, _RC)
+               call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vs, _RC)
+               call VertInterp(us, ur, -zle, -HGT_SURFACE, _RC)
+               call VertInterp(vs, vr, -zle, -HGT_SURFACE, _RC)
             end if
 
             call MAPL_StateGetPointer(export, temp2d, 'TA', _RC)
@@ -2242,11 +2241,14 @@ contains
             call MAPL_StateGetPointer(export, temp2d, 'PS', _RC)
             if (associated(temp2d)) temp2d = vars%pe(:, :, km + 1)
 
-            call MAPL_StateGetPointer(export, temp2d, 'US', _RC)
-            if (associated(temp2d)) temp2d = ur(:, :, km)
-
-            call MAPL_StateGetPointer(export, temp2d, 'VS', _RC)
-            if (associated(temp2d)) temp2d = vr(:, :, km)
+            call ESMF_StateGet(export, 'UV_S', tmp_bundle, _RC)
+            call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+            if (field_count == 2) then ! export bundle is connected
+               call MAPL_FieldBundleGetPointer(tmp_bundle, 1, us, _RC)
+               call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vs, _RC)
+               us = ur(:, :, km)
+               vs = vr(:, :, km)
+            end if
 
             call MAPL_StateGetPointer(export, temp2d, 'TA', _RC)
             if (associated(temp2d)) then
@@ -2760,7 +2762,7 @@ contains
       type(DynVars), pointer :: vars
       type(DynTracers) :: qqq ! Specific Humidity
       type(ESMF_Grid) :: esmfgrid
-      type(ESMF_FieldBundle) :: uv
+      type(ESMF_FieldBundle) :: tmp_bundle
 
       real(kind=r8), allocatable :: penrg(:, :) ! Vertically Integrated Cp*T
       real(kind=r8), allocatable :: kenrg(:, :) ! Vertically Integrated K
@@ -2800,6 +2802,15 @@ contains
       real(kind=r4), pointer :: qold(:, :, :)
       real(kind=r4), pointer :: temp3d(:, :, :)
       real(kind=r4), pointer :: temp2d(:, :)
+      real(kind=r4), pointer :: u50m(:, :), v50m(:, :)
+      real(kind=r4), pointer :: u100(:, :), v100(:, :)
+      real(kind=r4), pointer :: u200(:, :), v200(:, :)
+      real(kind=r4), pointer :: u250(:, :), v250(:, :)
+      real(kind=r4), pointer :: u300(:, :), v300(:, :)
+      real(kind=r4), pointer :: u500(:, :), v500(:, :)
+      real(kind=r4), pointer :: u700(:, :), v700(:, :)
+      real(kind=r4), pointer :: utop(:, :), vtop(:, :)
+      real(kind=r4), pointer :: u850(:, :), v850(:, :)
 
       real(kind=r4), pointer :: ztemp1(:, :)
       real(kind=r4), pointer :: ztemp2(:, :)
@@ -3101,84 +3112,76 @@ contains
             call VertInterp(temp2d, zle, logpe, log(100000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U50M", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, -zle, -50., _RC)
+         call ESMF_StateGet(export, "UV_50M", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u50m, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v50m, _RC)
+            call VertInterp(u50m, ur, -zle, -50., _RC)
+            call VertInterp(v50m, vr, -zle, -50., _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "V50M", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, -zle, -50., _RC)
+         call ESMF_StateGet(export, "UV_100", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u100, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v100, _RC)
+            call VertInterp(u100, ur, logpe, log(10000.), _RC)
+            call VertInterp(v100, vr, logpe, log(10000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U100", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(10000.), _RC)
+         call ESMF_StateGet(export, "UV_200", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u200, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v200, _RC)
+            call VertInterp(u200, ur, logpe, log(20000.), _RC)
+            call VertInterp(v200, vr, logpe, log(20000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U200", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(20000.), _RC)
+         call ESMF_StateGet(export, "UV_250", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u250, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v250, _RC)
+            call VertInterp(u250, ur, logpe, log(25000.), _RC)
+            call VertInterp(v250, vr, logpe, log(25000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U250", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(25000.), _RC)
+         call ESMF_StateGet(export, "UV_300", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u300, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v300, _RC)
+            call VertInterp(u300, ur, logpe, log(30000.), _RC)
+            call VertInterp(v300, vr, logpe, log(30000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U300", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(30000.), _RC)
+         call ESMF_StateGet(export, "UV_500", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u500, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v500, _RC)
+            call VertInterp(u500, ur, logpe, log(50000.), _RC)
+            call VertInterp(v500, vr, logpe, log(50000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U500", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(50000.), _RC)
+         call ESMF_StateGet(export, "UV_700", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u700, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v700, _RC)
+            call VertInterp(u700, ur, logpe, log(70000.), _RC)
+            call VertInterp(v700, vr, logpe, log(70000.), _RC)
          end if
 
-         call MAPL_StateGetPointer(export, temp2d, "U700", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(70000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "U850", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, ur, logpe, log(85000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V100", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(10000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V200", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(20000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V250", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(25000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V300", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(30000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V500", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(50000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V700", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(70000.), _RC)
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, "V850", _RC)
-         if (associated(temp2d)) then
-            call VertInterp(temp2d, vr, logpe, log(85000.), _RC)
+         call ESMF_StateGet(export, "UV_850", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u850, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v850, _RC)
+            call VertInterp(u850, ur, logpe, log(85000.), _RC)
+            call VertInterp(v850, vr, logpe, log(85000.), _RC)
          end if
 
          call MAPL_StateGetPointer(export, temp2d, "T100", _RC)
@@ -3252,11 +3255,14 @@ contains
          end if
 
          ! Fill Model Top Level Variables
-         call MAPL_StateGetPointer(export, temp2d, "UTOP", _RC)
-         if (associated(temp2d)) temp2d = ur(:, :, 1)
-
-         call MAPL_StateGetPointer(export, temp2d, "VTOP", _RC)
-         if (associated(temp2d)) temp2d = vr(:, :, 1)
+         call ESMF_StateGet(export, "UV_TOP", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, utop, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vtop, _RC)
+            utop = ur(:, :, 1)
+            vtop = vr(:, :, 1)
+         end if
 
          call MAPL_StateGetPointer(export, temp2d, "TTOP", _RC)
          if (associated(temp2d)) temp2d = tempxy(:, :, 1)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -636,6 +636,8 @@ contains
 
       real(kind=r4), pointer :: dudtana(:, :, :)
       real(kind=r4), pointer :: dvdtana(:, :, :)
+      real(kind=r4), pointer :: u_dyn_in(:, :, :)
+      real(kind=r4), pointer :: v_dyn_in(:, :, :)
       real(kind=r4), pointer :: dtdtana(:, :, :)
       real(kind=r4), pointer :: ddpdtana(:, :, :)
       real(kind=r4), pointer :: qctmp(:, :, :)
@@ -1432,8 +1434,7 @@ contains
 
       call FILLOUT3(export, "QV_DYN_IN", qv, _RC)
       call FILLOUT3(export, "T_DYN_IN", tempxy, _RC)
-      call FILLOUT3(export, "U_DYN_IN", ur, _RC)
-      call FILLOUT3(export, "V_DYN_IN", vr, _RC)
+      call fillout_vector_r8(export, "UV_DYN_IN", ur, vr, _RC)
       call FILLOUT3(export, "PLE_DYN_IN", vars%pe, _RC)
       call FILLOUT3(export, "PLE4", vars%pe, _RC)
 
@@ -3415,7 +3416,10 @@ contains
       integer :: II, JJ, i, j, k, L
       integer :: is, ie, js, je, km
       integer :: isd, ied, jsd, jed
+      integer :: field_count
+      type(ESMF_FieldBundle) :: tmp_bundle
       real(kind=r4), pointer :: tend(:, :, :)
+      real(kind=r4), pointer :: dudt(:, :, :), dvdt(:, :, :)
       real(kind=r4), allocatable, dimension(:, :) :: lons, lats
       real(kind=r8), allocatable :: DPNEW(:, :, :), DPOLD(:, :, :)
       real(kind=r8), allocatable :: tend_ua(:, :, :), tend_va(:, :, :)
@@ -3600,11 +3604,14 @@ contains
          allocate(tend_un(is:ie, js:je + 1, km))
          allocate(tend_vn(is:ie + 1, js:je, km))
 
-         call MAPL_StateGetPointer(import, tend, "DUDT", _RC)
-         tend_ua(is:ie, js:je, 1:km) = tend
-
-         call MAPL_StateGetPointer(import, tend, "DVDT", _RC)
-         tend_va(is:ie, js:je, 1:km) = tend
+         call ESMF_StateGet(import, 'D_UV_DT', tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! import bundle is connected
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, dudt, _RC)
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, dvdt, _RC)
+            tend_ua(is:ie, js:je, 1:km) = dudt
+            tend_va(is:ie, js:je, 1:km) = dvdt
+         end if
 
          !if (.not. HYDROSTATIC ) then
          !  call MAPL_StateGetPointer(import, TEND, 'DWDT', _RC)
@@ -3819,8 +3826,8 @@ contains
       if (typekind == ESMF_TYPEKIND_R4) then
          call ESMF_FieldGet(field_list(1), farrayPtr=x1, _RC)
          call ESMF_FieldGet(field_list(2), farrayPtr=x2, _RC)
-         x1 = v1
-         x2 = v2
+         x1 = real(v1, kind=r4)
+         x2 = real(v2, kind=r4)
       else if (typekind == ESMF_TYPEKIND_R8) then
          call ESMF_FieldGet(field_list(1), farrayPtr=x1_r8, _RC)
          call ESMF_FieldGet(field_list(2), farrayPtr=x2_r8, _RC)
@@ -3832,30 +3839,6 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine fillout_vector_r8
-
-   ! subroutine fillout_vector_r4(export, name, v1, v2, rc)
-   !    type(ESMF_State), intent(inout) :: export
-   !    character(len=*), intent(in) :: name
-   !    real(kind=r4), intent(in) :: v1(:, :, :), v2(:, :, :)
-   !    integer, optional, intent(out) :: rc
-
-   !    real(kind=r4), pointer :: x1(:, :, :), x2(:, :, :)
-   !    real(kind=r8), pointer :: x1_r8(:, :, :), x2_r8(:, :, :)
-   !    type(ESMF_FieldBundle) :: bundle
-   !    integer :: field_count, status
-
-   !    call ESMF_StateGet(export, name, bundle, _RC)
-   !    call ESMF_FieldBundleGet(bundle, fieldCount=field_count, _RC)
-   !    if (field_count == 2) then ! export bundle is connected
-   !       ! TODO: pchakrab - check the typekind of the fields first
-   !       call MAPL_FieldBundleGetPointer(bundle, 1, x1, _RC)
-   !       call MAPL_FieldBundleGetPointer(bundle, 2, x2, _RC)
-   !       x1 = v1
-   !       x2 = v2
-   !    end if
-
-   !    _RETURN(_SUCCESS)
-   ! end subroutine fillout_vector_r4
 
    subroutine FILLOUT2(export, name, v, rc)
       type(ESMF_State), intent(inout) :: export

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -403,7 +403,7 @@ contains
 
       type(DynState), pointer :: self
       type(ESMF_State) :: internal
-      type(ESMF_FieldBundle) :: uv, uv_exp
+      type(ESMF_FieldBundle) :: uv_exp
       real(kind=r4), pointer :: pref(:)
       real(kind=r4), pointer :: u(:, :, :), v(:, :, :), t(:, :, :)
       real(kind=r4), pointer :: temp2d(:, :)
@@ -458,9 +458,8 @@ contains
          km = self%grid%npz
          allocate(ur(ifirst:ilast, jfirst:jlast, km))
          allocate(vr(ifirst:ilast, jfirst:jlast, km))
-         call ESMF_StateGet(internal, "UV", uv, _RC)
-         call MAPL_FieldBundleGetPointer(uv, 1, ud, _RC)
-         call MAPL_FieldBundleGetPointer(uv, 2, vd, _RC)
+         call MAPL_StateGetPointer(internal, ud, "U", _RC)
+         call MAPL_StateGetPointer(internal, vd, "V", _RC)
          call getAllWinds(ud, vd, ur=ur, vr=vr)
          u = ur
          v = vr
@@ -636,8 +635,6 @@ contains
 
       real(kind=r4), pointer :: dudtana(:, :, :)
       real(kind=r4), pointer :: dvdtana(:, :, :)
-      real(kind=r4), pointer :: u_dyn_in(:, :, :)
-      real(kind=r4), pointer :: v_dyn_in(:, :, :)
       real(kind=r4), pointer :: dtdtana(:, :, :)
       real(kind=r4), pointer :: ddpdtana(:, :, :)
       real(kind=r4), pointer :: qctmp(:, :, :)
@@ -655,6 +652,7 @@ contains
       real(kind=r4), pointer :: vtmp3d(:, :, :)
       real(kind=r4), pointer :: area(:, :)
       real(kind=r4), pointer :: temp2d(:, :)
+      real(kind=r4), pointer :: u_dyn_in(:, :, :), v_dyn_in(:, :, :)
       real(kind=r4), pointer :: uke(:, :), vke(:, :)
       real(kind=r4), pointer :: uphi(:, :), vphi(:, :)
       real(kind=r4), pointer :: uqv(:, :), vqv(:, :)
@@ -1434,7 +1432,7 @@ contains
 
       call FILLOUT3(export, "QV_DYN_IN", qv, _RC)
       call FILLOUT3(export, "T_DYN_IN", tempxy, _RC)
-      call fillout_vector_r8(export, "UV_DYN_IN", ur, vr, _RC)
+      call FILLOUT3r8_VECTOR(export, "UV_DYN_IN", ur, vr, _RC)
       call FILLOUT3(export, "PLE_DYN_IN", vars%pe, _RC)
       call FILLOUT3(export, "PLE4", vars%pe, _RC)
 
@@ -1628,8 +1626,7 @@ contains
          call FILLOUT3(export, "V_DGRID", vars%v, _RC)
          call FILLOUT3(export, "U_CGRID", uc, _RC)
          call FILLOUT3(export, "V_CGRID", vc, _RC)
-         call FILLOUT3(export, "U_AGRID", ua, _RC)
-         call FILLOUT3(export, "V_AGRID", va, _RC)
+         call FILLOUT3r8_VECTOR(export, 'UV_AGRID', ua, va, _RC)
 
          call FILLOUT3(export, "U", ur, _RC)
          call FILLOUT3(export, "V", vr, _RC)
@@ -1757,8 +1754,7 @@ contains
          call FILLOUT3(export, 'V_DGRID', vars%v, _RC)
          call FILLOUT3(export, 'U_CGRID', uc, _RC)
          call FILLOUT3(export, 'V_CGRID', vc, _RC)
-         call FILLOUT3(export, 'U_AGRID', ua, _RC)
-         call FILLOUT3(export, 'V_AGRID', va, _RC)
+         call FILLOUT3r8_VECTOR(export, 'UV_AGRID', ua, va, _RC)
 
          ! if (DEBUG_DYN) then
          !    block
@@ -1830,7 +1826,7 @@ contains
          call FILLOUT3r8(export, 'MFZ', mfzxyz, _RC)
          call FILLOUT3(export, 'MZ', mfzxyz, _RC)
 
-         call fillout_vector_r8(export, "UV", ur, vr, _RC)
+         call FILLOUT3r8_VECTOR(export, "UV", ur, vr, _RC)
          call FILLOUT3(export, 'T', tempxy, _RC)
          call FILLOUT3(export, 'Q', qv, _RC)
          call FILLOUT3(export, 'PL', pl, _RC)
@@ -2955,8 +2951,7 @@ contains
          call FILLOUT3(export, 'V_DGRID', vars%v, _RC)
          call FILLOUT3(export, 'U_CGRID', uc, _RC)
          call FILLOUT3(export, 'V_CGRID', vc, _RC)
-         call FILLOUT3(export, 'U_AGRID', ua, _RC)
-         call FILLOUT3(export, 'V_AGRID', va, _RC)
+         call FILLOUT3r8_VECTOR(export, 'UV_AGRID', ua, va, _RC)
 
          ! Compute Energetics After Diabatic Forcing
          thv = vars%pt * (1.0 + EPS * qv)
@@ -3016,7 +3011,7 @@ contains
          ! end if
 
          call FILLOUT3(export, "DELP", dp, _RC)
-         call fillout_vector_r8(export, "UV", ur, vr, _RC)
+         call FILLOUT3r8_VECTOR(export, "UV", ur, vr, _RC)
          call FILLOUT3(export, "T", tempxy, _RC)
          call FILLOUT3(export, "Q", qv, _RC)
          call FILLOUT3(export, "PL", pl, _RC)
@@ -3805,7 +3800,7 @@ contains
       _RETURN(_SUCCESS)
    end subroutine FILLOUT3
 
-   subroutine fillout_vector_r8(export, vector_name, v1, v2, rc)
+   subroutine FILLOUT3r8_VECTOR(export, vector_name, v1, v2, rc)
       type(ESMF_State), intent(inout) :: export
       character(len=*), intent(in) :: vector_name
       real(kind=r8), intent(in) :: v1(:, :, :), v2(:, :, :)
@@ -3834,11 +3829,11 @@ contains
          x1_r8 = v1
          x2_r8 = v2
       else
-         _FAIL("Unsupported typekind in fillout_vector_r8")
+         _FAIL("Unsupported typekind in FILLOUT3r8_VECTOR")
       end if
 
       _RETURN(_SUCCESS)
-   end subroutine fillout_vector_r8
+   end subroutine FILLOUT3r8_VECTOR
 
    subroutine FILLOUT2(export, name, v, rc)
       type(ESMF_State), intent(inout) :: export
@@ -4097,7 +4092,6 @@ contains
       type(ESMF_State) :: internal
 
       real(kind=REAL8), pointer :: ak1(:), bk1(:), ak(:), bk(:)
-      type(ESMF_FieldBundle) :: uv
       real(kind=REAL8), pointer :: u(:, :, :), v(:, :, :), pt(:, :, :)
       real(kind=REAL8), pointer :: pe1(:, :, :), pkz(:, :, :)
       real(kind=REAL8), allocatable :: pe(:, :, :)
@@ -4154,9 +4148,8 @@ contains
          lats(:, :) = 15.0 * PI / 180.0
       end if
 
-      call ESMF_StateGet(internal, "UV", uv, _RC)
-      call MAPL_FieldBundleGetPointer(uv, 1, u, _RC) ! A-Grid U Wind
-      call MAPL_FieldBundleGetPointer(uv, 2, v, _RC) ! A-Grid V Wind
+      call MAPL_StateGetPointer(internal, u, "U", _RC) ! A-Grid U Wind
+      call MAPL_StateGetPointer(internal, v, "V", _RC) ! A-Grid V Wind
       is = lbound(u, 1)
       ie = ubound(u, 1)
       js = lbound(u, 2)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -4148,8 +4148,8 @@ contains
          lats(:, :) = 15.0 * PI / 180.0
       end if
 
-      call MAPL_StateGetPointer(internal, u, "U", _RC) ! A-Grid U Wind
-      call MAPL_StateGetPointer(internal, v, "V", _RC) ! A-Grid V Wind
+      call MAPL_StateGetPointer(internal, u, "U", _RC) ! D-Grid U Wind
+      call MAPL_StateGetPointer(internal, v, "V", _RC) ! D-Grid V Wind
       is = lbound(u, 1)
       ie = ubound(u, 1)
       js = lbound(u, 2)

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -333,67 +333,6 @@ contains
 #include "DynCore_Export___.h"
 #include "DynCore_Internal___.h"
 
-      ! TODO: pchakrab - till we have a way to specify a VECTOR in acg
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_INTERNAL, &
-           short_name="UV", &
-           standard_name="(eastward_wind, northward_wind)", &
-           dims="xyz", &
-           vstagger=VERTICAL_STAGGER_CENTER, &
-           units="m/s", &
-           typekind=ESMF_TYPEKIND_R8, &
-           itemtype=MAPL_STATEITEM_VECTOR, &
-           restart=MAPL_RESTART_REQUIRED, _RC)
-
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_EXPORT, &
-           short_name="UV", &
-           standard_name="(eastward_wind, northward_wind)", &
-           dims="xyz", &
-           vstagger=VERTICAL_STAGGER_CENTER, &
-           units="m/s", &
-           itemtype=MAPL_STATEITEM_VECTOR, _RC)
-
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_EXPORT, &
-           short_name="D_UV_DTANA", &
-           standard_name="(tendency_of_eastward_wind_due_to_analysis, &
-           tendency_of_northward_wind_due_to_analysis)", &
-           dims="xyz", &
-           vstagger=VERTICAL_STAGGER_CENTER, &
-           units="m/s/s", &
-           itemtype=MAPL_STATEITEM_VECTOR, _RC)
-
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_EXPORT, &
-           short_name="UV_KE", &
-           standard_name="(eastward_flux_of_atmospheric_kinetic_energy, &
-           northward_flux_of_atmospheric_kinetic_energy)", &
-           dims="xy", &
-           vstagger=VERTICAL_STAGGER_NONE, &
-           units="J m-1 s-1", &
-           itemtype=MAPL_STATEITEM_VECTOR, _RC)
-
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_EXPORT, &
-           short_name="UV_PHI", &
-           standard_name="(eastward_flux_of_atmospheric_potential_energy, &
-           northward_flux_of_atmospheric_potential_energy)", &
-           dims="xy", &
-           vstagger=VERTICAL_STAGGER_NONE, &
-           units="J m-1 s-1", &
-           itemtype=MAPL_STATEITEM_VECTOR, _RC)
-
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_EXPORT, &
-           short_name="UV_QV", &
-           standard_name="(eastward_flux_of_atmospheric_water_vapor, &
-           northward_flux_of_atmospheric_water_vapor)", &
-           dims="xy", &
-           vstagger=VERTICAL_STAGGER_NONE, &
-           units="kg m-1 s-1", &
-           itemtype=MAPL_STATEITEM_VECTOR, _RC)
-
       ! pchakrab - DynCore is the provider here, so the service items are not needed
       ! NOTE: SERVICE, irrespective of whether you are a provider or subscriber, adds the bundle
       ! to BOTH the export and import states
@@ -3860,12 +3799,11 @@ contains
       type(ESMF_FieldBundle) :: bundle
       type(ESMF_Field), allocatable :: field_list(:)
       type(ESMF_TypeKind_Flag) :: typekind
-      integer :: field_count, status
+      integer :: status
 
       call ESMF_StateGet(export, vector_name, bundle, _RC)
-      ! field_list is in the order they were added to the bundle
-      call MAPL_FieldBundleGet(bundle, fieldCount=field_count, fieldList=field_list, _RC)
-      _RETURN_UNLESS(field_count == 2)
+      call MAPL_FieldBundleGet(bundle, fieldList=field_list, _RC) ! addorder
+      _RETURN_UNLESS(size(field_list) == 2)
       ! Both fields are expected to have the same typekind, so just check one
       call MAPL_FieldGet(field_list(1), typekind=typekind, _RC)
       if (typekind == ESMF_TYPEKIND_R4) then

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -25,6 +25,7 @@ module FVdycoreCubed_GridComp
    use MAPL, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
    use MAPL, only: MAPL_GridGetCoordinates, MAPL_StateGetPointer, MAPL_FieldCreate, MAPL_FieldGet
    use MAPL, only: MAPL_FieldBundleAdd, MAPL_FieldBundleSameData, MAPL_FieldBundleGetPointer
+   use MAPL, only: MAPL_FieldBundleGet
    use MAPL, only: MAPL_RESTART_SKIP, MAPL_RESTART_REQUIRED, MAPL_ArrayGather
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_CP, MAPL_PI, MAPL_PI_R8, MAPL_OMEGA, MAPL_KAPPA
    use MAPL_Constants, only: MAPL_P00, MAPL_GRAV, MAPL_RGAS, MAPL_RVAP, MAPL_CPVAP, MAPL_O3MW, MAPL_AIRMW
@@ -1848,7 +1849,8 @@ contains
          call FILLOUT3(export, 'DQVDTDYN', dqdt, _RC)
          call FILLOUT3(export, 'DDELPDTDYN', ddpdt, _RC)
          ! pchakrab - TODO: figure out the issue with DPLEDTDYN
-         ! call FILLOUT3(export, 'DPLEDTDYN' , dpedt, _RC)
+         ! Updated DPLEDTDYN in StateSpecs to be an edge variable
+         call FILLOUT3(export, 'DPLEDTDYN' , dpedt, _RC)
 
          ! fill pressure exports (PLE0: Before) & (PLE1: After) from FV3
          call FILLOUT3r8(export, 'PLE0', pe0, _RC)
@@ -1884,8 +1886,7 @@ contains
          call FILLOUT3r8(export, 'MFZ', mfzxyz, _RC)
          call FILLOUT3(export, 'MZ', mfzxyz, _RC)
 
-         ! call FILLOUT3(export, 'U', ur, _RC)
-         ! call FILLOUT3(export, 'V', vr, _RC)
+         call fillout_vector_r8(export, "UV", ur, vr, _RC)
          call FILLOUT3(export, 'T', tempxy, _RC)
          call FILLOUT3(export, 'Q', qv, _RC)
          call FILLOUT3(export, 'PL', pl, _RC)
@@ -3060,15 +3061,7 @@ contains
          ! end if
 
          call FILLOUT3(export, "DELP", dp, _RC)
-         ! TODO: pchakrab - we need another FILLOUT3 routine for vectors
-         call ESMF_StateGet(export, "UV", uv, _RC)
-         call ESMF_FieldBundleGet(uv, fieldCount=field_count, _RC)
-         if (field_count == 2) then ! export bundle is connected
-            call MAPL_FieldBundleGetPointer(uv, 1, u, _RC)
-            call MAPL_FieldBundleGetPointer(uv, 2, v, _RC)
-            u = ur
-            v = vr
-         end if
+         call fillout_vector_r8(export, "UV", ur, vr, _RC)
          call FILLOUT3(export, "T", tempxy, _RC)
          call FILLOUT3(export, "Q", qv, _RC)
          call FILLOUT3(export, "PL", pl, _RC)
@@ -3855,6 +3848,66 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine FILLOUT3
+
+   subroutine fillout_vector_r8(export, vector_name, v1, v2, rc)
+      type(ESMF_State), intent(inout) :: export
+      character(len=*), intent(in) :: vector_name
+      real(kind=r8), intent(in) :: v1(:, :, :), v2(:, :, :)
+      integer, optional, intent(out) :: rc
+
+      real(kind=r4), pointer :: x1(:, :, :), x2(:, :, :)
+      real(kind=r8), pointer :: x1_r8(:, :, :), x2_r8(:, :, :)
+      type(ESMF_FieldBundle) :: bundle
+      type(ESMF_Field), allocatable :: field_list(:)
+      type(ESMF_TypeKind_Flag) :: typekind
+      integer :: field_count, status
+
+      call ESMF_StateGet(export, vector_name, bundle, _RC)
+      ! field_list is in the order they were added to the bundle
+      call MAPL_FieldBundleGet(bundle, fieldCount=field_count, fieldList=field_list, _RC)
+      _RETURN_UNLESS(field_count == 2)
+      ! Both fields are expected to have the same typekind, so just check one
+      call MAPL_FieldGet(field_list(1), typekind=typekind, _RC)
+      if (typekind == ESMF_TYPEKIND_R4) then
+         call ESMF_FieldGet(field_list(1), farrayPtr=x1, _RC)
+         call ESMF_FieldGet(field_list(2), farrayPtr=x2, _RC)
+         x1 = v1
+         x2 = v2
+      else if (typekind == ESMF_TYPEKIND_R8) then
+         call ESMF_FieldGet(field_list(1), farrayPtr=x1_r8, _RC)
+         call ESMF_FieldGet(field_list(2), farrayPtr=x2_r8, _RC)
+         x1_r8 = v1
+         x2_r8 = v2
+      else
+         _FAIL("Unsupported typekind in fillout_vector_r8")
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine fillout_vector_r8
+
+   ! subroutine fillout_vector_r4(export, name, v1, v2, rc)
+   !    type(ESMF_State), intent(inout) :: export
+   !    character(len=*), intent(in) :: name
+   !    real(kind=r4), intent(in) :: v1(:, :, :), v2(:, :, :)
+   !    integer, optional, intent(out) :: rc
+
+   !    real(kind=r4), pointer :: x1(:, :, :), x2(:, :, :)
+   !    real(kind=r8), pointer :: x1_r8(:, :, :), x2_r8(:, :, :)
+   !    type(ESMF_FieldBundle) :: bundle
+   !    integer :: field_count, status
+
+   !    call ESMF_StateGet(export, name, bundle, _RC)
+   !    call ESMF_FieldBundleGet(bundle, fieldCount=field_count, _RC)
+   !    if (field_count == 2) then ! export bundle is connected
+   !       ! TODO: pchakrab - check the typekind of the fields first
+   !       call MAPL_FieldBundleGetPointer(bundle, 1, x1, _RC)
+   !       call MAPL_FieldBundleGetPointer(bundle, 2, x2, _RC)
+   !       x1 = v1
+   !       x2 = v2
+   !    end if
+
+   !    _RETURN(_SUCCESS)
+   ! end subroutine fillout_vector_r4
 
    subroutine FILLOUT2(export, name, v, rc)
       type(ESMF_State), intent(inout) :: export

--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -656,6 +656,8 @@ contains
       real(kind=r4), pointer :: uke(:, :), vke(:, :)
       real(kind=r4), pointer :: uphi(:, :), vphi(:, :)
       real(kind=r4), pointer :: uqv(:, :), vqv(:, :)
+      real(kind=r4), pointer :: uql(:, :), vql(:, :)
+      real(kind=r4), pointer :: uqi(:, :), vqi(:, :)
 
       real(kind=r4), pointer :: uh25(:, :), uh03(:, :)
       real(kind=r4), pointer :: srh01(:, :), srh03(:, :), srh25(:, :), shr06(:, :)
@@ -2082,77 +2084,79 @@ contains
          end if
 
          ! Fluxes: UQL & VQL
-         call MAPL_StateGetPointer(export, temp2d, 'UQL', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+         call ESMF_StateGet(export, "UV_QL", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            ! UQL
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, uql, _RC)
+            uql = 0.0
             do n = 1, size(names)
                if (trim(names(n)) == 'QLCN' .or. &
                     trim(names(n)) == 'QLLS') then
                   do k = 1, km
                      if (self%vars%tracer(n)%is_r4) then
-                        temp2d = temp2d + ur(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
+                        uql = uql + ur(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
                      else
-                        temp2d = temp2d + ur(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
+                        uql = uql + ur(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
                      end if
                   end do
                end if
             end do
-            temp2d = temp2d / GRAV
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, 'VQL', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+            uql = uql / GRAV
+            ! VQL
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vql, _RC)
+            vql = 0.0
             do n = 1, size(names)
                if (trim(names(n)) == 'QLCN' .or. &
                     trim(names(n)) == 'QLLS') then
                   do k = 1, km
                      if (self%vars%tracer(n)%is_r4) then
-                        temp2d = temp2d + vr(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
+                        vql = vql + vr(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
                      else
-                        temp2d = temp2d + vr(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
+                        vql = vql + vr(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
                      end if
                   end do
                end if
             end do
-            temp2d = temp2d / GRAV
+            vql = vql / GRAV
          end if
 
          ! Fluxes: UQI & VQI
-         call MAPL_StateGetPointer(export, temp2d, 'UQI', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+         call ESMF_StateGet(export, "UV_QI", tmp_bundle, _RC)
+         call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+         if (field_count == 2) then ! export bundle is connected
+            ! UQI
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 1, uqi, _RC)
+            uqi = 0.0
             do n = 1, size(names)
                if (trim(names(n)) == 'QICN' .or. &
                     trim(names(n)) == 'QILS') then
                   do k = 1, km
                      if (self%vars%tracer(n)%is_r4) then
-                        temp2d = temp2d + ur(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
+                        uqi = uqi + ur(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
                      else
-                        temp2d = temp2d + ur(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
+                        uqi = uqi + ur(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
                      end if
                   end do
                end if
             end do
-            temp2d = temp2d / GRAV
-         end if
-
-         call MAPL_StateGetPointer(export, temp2d, 'VQI', _RC)
-         if (associated(temp2d)) then
-            temp2d = 0.0
+            uqi = uqi / GRAV
+            ! VQI
+            call MAPL_FieldBundleGetPointer(tmp_bundle, 2, vqi, _RC)
+            vqi = 0.0
             do n = 1, size(names)
                if (trim(names(n)) == 'QICN' .or. &
                     trim(names(n)) == 'QILS') then
                   do k = 1, km
                      if (self%vars%tracer(n)%is_r4) then
-                        temp2d = temp2d + vr(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
+                        vqi = vqi + vr(:, :, k) * self%vars%tracer(n)%content_r4(:, :, k) * delp(:, :, k)
                      else
-                        temp2d = temp2d + vr(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
+                        vqi = vqi + vr(:, :, k) * self%vars%tracer(n)%content(:, :, k) * delp(:, :, k)
                      end if
                   end do
                end if
             end do
-            temp2d = temp2d / GRAV
+            vqi = vqi / GRAV
          end if
 
          ! Height related diagnostics

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -102,13 +102,12 @@ category: EXPORT
   TA             | K                | xy   |  N   |           |          | surface_air_temperature
   QA             | 1                | xy   |  N   |           |          | surface_specific_humidity
 #
-  US             | m s-1            | xy   |  N   |           |          | surface_eastward_wind
-  VS             | m s-1            | xy   |  N   |           |          | surface_northward_wind
+  UV_S           | m s-1            | xy   |  N   | V         |          | (surface_eastward_wind, surface_northward_wind)
 #
   SPEED          | m s-1            | xy   |  N   |           |          | surface_wind_speed
   WSPD_10M       | m s-1            | xy   |  N   |           |          | wind_speed_at_10m
-VVEL_UP_100_1000 | m s-1            | xy   |  N   |           |          |max_vertical_velocity_up_between_100_1000_hPa
-VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_vertical_velocity_down_between_100_1000_hPa
+VVEL_UP_100_1000 | m s-1            | xy   |  N   |           |          | max_vertical_velocity_up_between_100_1000_hPa
+VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_vertical_velocity_down_between_100_1000_hPa
   DZ             | m                | xy   |  N   |           |          | surface_layer_height
   SLP            | Pa               | xy   |  N   |           |          | sea_level_pressure
   H1000          | m                | xy   |  N   |           |          | height_at_1000_mb
@@ -133,8 +132,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   DPLEDTDYN      | Pa s-1           | xyz  |  E   |           |          | tendency_of_edge_pressure_due_to_dynamics
   DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
   UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_kinetic_energy)
-  UCPT           | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_enthalpy
-  VCPT           | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_enthalpy
+  UV_CPT         | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_enthalpy
   UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_potential_energy
   UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_water_vapor
   UV_QL          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_liquid_water
@@ -163,46 +161,29 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   DIVG700        | s-1              | xy   |  N   |           |          | divergence_at_700_hPa
   DIVG500        | s-1              | xy   |  N   |           |          | divergence_at_500_hPa
   DIVG200        | s-1              | xy   |  N   |           |          | divergence_at_200_hPa
-#
-  U850           | m s-1            | xy   |  N   |           |          | eastward_wind_at_850_hPa
-  V850           | m s-1            | xy   |  N   |           |          | northward_wind_at_850_hPa
+  UV_850         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_850_hPa
   T850           | K                | xy   |  N   |           |          | air_temperature_at_850_hPa
   Q850           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_850_hPa
-#
-  U700           | m s-1            | xy   |  N   |           |          | eastward_wind_at_700_hPa
-  V700           | m s-1            | xy   |  N   |           |          | northward_wind_at_700_hPa
+  UV_700         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_700_hPa
   T700           | K                | xy   |  N   |           |          | air_temperature_at_700_hPa
   Q700           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_700_hPa
-#
-  U500           | m s-1            | xy   |  N   |           |          | eastward_wind_at_500_hPa
-  V500           | m s-1            | xy   |  N   |           |          | northward_wind_at_500_hPa
+  UV_500         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_500_hPa
   T500           | K                | xy   |  N   |           |          | air_temperature_at_500_hPa
   Q500           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_500_hPa
-#
-  U300           | m s-1            | xy   |  N   |           |          | eastward_wind_at_300_hPa
-  V300           | m s-1            | xy   |  N   |           |          | northward_wind_at_300_hPa
+  UV_300         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_300_hPa
   T300           | K                | xy   |  N   |           |          | air_temperature_at_300_hPa
   Q300           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_300_hPa
-#
-  U250           | m s-1            | xy   |  N   |           |          | eastward_wind_at_250_hPa
-  V250           | m s-1            | xy   |  N   |           |          | northward_wind_at_250_hPa
+  UV_250         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_250_hPa
   T250           | K                | xy   |  N   |           |          | air_temperature_at_250_hPa
   Q250           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_250_hPa
-#
-  U200           | m s-1            | xy   |  N   |           |          | eastward_wind_at_200_hPa
-  V200           | m s-1            | xy   |  N   |           |          | northward_wind_at_200_hPa
+  UV_200         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_200_hPa
   T200           | K                | xy   |  N   |           |          | air_temperature_at_200_hPa
   Q200           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_200_hPa
-#
-  U100           | m s-1            | xy   |  N   |           |          | eastward_wind_at_100_hPa
-  V100           | m s-1            | xy   |  N   |           |          | northward_wind_at_100_hPa
+  UV_100         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_100_hPa
   T100           | K                | xy   |  N   |           |          | air_temperature_at_100_hPa
   Q100           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_100_hPa
-#
-  UTOP           | m s-1            | xy   |  N   |           |          | eastward_wind_at_model_top
-  VTOP           | m s-1            | xy   |  N   |           |          | northward_wind_at_model_top
+  UV_TOP         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_model_top
   TTOP           | K                | xy   |  N   |           |          | air_temperature_at_model_top
-#
   Z700           | m                | xy   |  N   |           |          | geopotential_height_at_700_hPa
   Z500           | m                | xy   |  N   |           |          | geopotential_height_at_500_hPa
   Z300           | m                | xy   |  N   |           |          | geopotential_height_at_300_hPa
@@ -222,10 +203,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   W500           | m s-1            | xy   |  N   |           |          | w_at_500_hPa
   W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
   W10            | m s-1            | xy   |  N   |           |          | w_at_10_hPa
-#
-  U50M           | m s-1            | xy   |  N   |           |          | eastward_wind_at_50_meters
-  V50M           | m s-1            | xy   |  N   |           |          | northward_wind_at_50_meters
-#
+  UV_50M         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_50_meters
   DXC            | m                | xy   |  N   |           |          | cgrid_delta_x
   DYC            | m                | xy   |  N   |           |          | cgrid_delta_y
   AREA           | m+2              | xy   |  N   |           |          | agrid_cell_area

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -100,9 +100,7 @@ category: EXPORT
   PS             | Pa               | xy   |  N   |           |          | surface_pressure
   TA             | K                | xy   |  N   |           |          | surface_air_temperature
   QA             | 1                | xy   |  N   |           |          | surface_specific_humidity
-#
   UV_S           | m s-1            | xy   |  N   | V         |          | (surface_eastward_wind, surface_northward_wind)
-#
   SPEED          | m s-1            | xy   |  N   |           |          | surface_wind_speed
   WSPD_10M       | m s-1            | xy   |  N   |           |          | wind_speed_at_10m
 VVEL_UP_100_1000 | m s-1            | xy   |  N   |           |          | max_vertical_velocity_up_between_100_1000_hPa
@@ -161,14 +159,19 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   DIVG500        | s-1              | xy   |  N   |           |          | divergence_at_500_hPa
   DIVG200        | s-1              | xy   |  N   |           |          | divergence_at_200_hPa
   UV_850         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_850_hPa
+  W850           | m s-1            | xy   |  N   |           |          | w_at_850_hPa
   T850           | K                | xy   |  N   |           |          | air_temperature_at_850_hPa
   Q850           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_850_hPa
+  OMEGA850       | Pa s-1           | xy   |  N   |           |          | omega_at_850_hPa
   UV_700         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_700_hPa
   T700           | K                | xy   |  N   |           |          | air_temperature_at_700_hPa
   Q700           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_700_hPa
+  OMEGA700       | Pa s-1           | xy   |  N   |           |          | omega_at_700_hPa
   UV_500         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_500_hPa
+  W500           | m s-1            | xy   |  N   |           |          | w_at_500_hPa
   T500           | K                | xy   |  N   |           |          | air_temperature_at_500_hPa
   Q500           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_500_hPa
+  OMEGA500       | Pa s-1           | xy   |  N   |           |          | omega_at_500_hPa
   UV_300         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_300_hPa
   T300           | K                | xy   |  N   |           |          | air_temperature_at_300_hPa
   Q300           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_300_hPa
@@ -176,8 +179,10 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   T250           | K                | xy   |  N   |           |          | air_temperature_at_250_hPa
   Q250           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_250_hPa
   UV_200         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_200_hPa
+  W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
   T200           | K                | xy   |  N   |           |          | air_temperature_at_200_hPa
   Q200           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_200_hPa
+  OMEGA200       | Pa s-1           | xy   |  N   |           |          | omega_at_200_hPa
   UV_100         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_100_hPa
   T100           | K                | xy   |  N   |           |          | air_temperature_at_100_hPa
   Q100           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_100_hPa
@@ -193,14 +198,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   H250           | m                | xy   |  N   |           |          | height_at_250_hPa
   H200           | m                | xy   |  N   |           |          | height_at_200_hPa
   H100           | m                | xy   |  N   |           |          | height_at_100_hPa
-  OMEGA850       | Pa s-1           | xy   |  N   |           |          | omega_at_850_hPa
-  OMEGA700       | Pa s-1           | xy   |  N   |           |          | omega_at_700_hPa
-  OMEGA500       | Pa s-1           | xy   |  N   |           |          | omega_at_500_hPa
-  OMEGA200       | Pa s-1           | xy   |  N   |           |          | omega_at_200_hPa
   OMEGA10        | Pa s-1           | xy   |  N   |           |          | omega_at_10_hPa
-  W850           | m s-1            | xy   |  N   |           |          | w_at_850_hPa
-  W500           | m s-1            | xy   |  N   |           |          | w_at_500_hPa
-  W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
   W10            | m s-1            | xy   |  N   |           |          | w_at_10_hPa
   UV_50M         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_50_meters
   DXC            | m                | xy   |  N   |           |          | cgrid_delta_x
@@ -217,7 +215,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   U_DYN_IN       | m s-1            | xyz  |  C   |           |          | u_wind_at_begin_of_time_step
   V_DYN_IN       | m s-1            | xyz  |  C   |           |          | v_wind_at_begin_of_time_step
   PLE_DYN_IN     | Pa               | xyz  |  E   |           |          | edge_pressure_at_begin_of_time_step
-  PLE4           | Pa               | xyz  |  E   |           |          | blah_blah_blah
+  PLE4           | Pa               | xyz  |  E   |           |          | pressure_at_layer_edges_r4
 
 
 category: IMPORT

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -132,7 +132,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   V_DGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_native_D-Grid
   TV             | K                | xyz  |  C   |           |          | air_virtual_temperature
   THV            | K/Pa$^\kappa$    | xyz  |  C   |           |          | scaled_virtual_potential_temperature
-  DPLEDTDYN      | Pa s-1           | xyz  |  C   |           |          | tendency_of_edge_pressure_due_to_dynamics
+  DPLEDTDYN      | Pa s-1           | xyz  |  E   |           |          | tendency_of_edge_pressure_due_to_dynamics
   DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
 #
 # UKE            | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_kinetic_energy

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -86,11 +86,7 @@ category: EXPORT
   DUDT_RAY       | m s-2            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_Rayleigh_friction
   DVDT_RAY       | m s-2            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_Rayleigh_friction
   DWDT_RAY       | m/s/s            | xyz  |  C   |           |          | vertical_velocity_tendency_due_to_Rayleigh_friction
-#
-# DUDTANA        | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_analysis
-# DVDTANA        | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_analysis
   D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(eastward, northward)_wind_due_to_analysis
-#
   DTDTANA        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_analysis
   DDELPDTANA     | K s-1            | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_analysis
   DUDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_dynamics
@@ -136,28 +132,13 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   THV            | K/Pa$^\kappa$    | xyz  |  C   |           |          | scaled_virtual_potential_temperature
   DPLEDTDYN      | Pa s-1           | xyz  |  E   |           |          | tendency_of_edge_pressure_due_to_dynamics
   DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
-#
-# UKE            | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_kinetic_energy
-# VKE            | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_kinetic_energy
   UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_kinetic_energy)
-#
   UCPT           | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_enthalpy
   VCPT           | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_enthalpy
-#
-# UPHI           | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_potential_energy
-# VPHI           | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_potential_energy
   UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_potential_energy
-#
-# UQV            | kg m-1 s-1       | xy   |  N   |           |          | eastward_flux_of_atmospheric_water_vapor
-# VQV            | kg m-1 s-1       | xy   |  N   |           |          | northward_flux_of_atmospheric_water_vapor
   UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_water_vapor
-#
-  UQL            | kg m-1 s-1       | xy   |  N   |           |          | eastward_flux_of_atmospheric_liquid_water
-  VQL            | kg m-1 s-1       | xy   |  N   |           |          | northward_flux_of_atmospheric_liquid_water
-#
-  UQI            | kg m-1 s-1       | xy   |  N   |           |          | eastward_flux_of_atmospheric_ice
-  VQI            | kg m-1 s-1       | xy   |  N   |           |          | northward_flux_of_atmospheric_ice
-#
+  UV_QL          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_liquid_water
+  UV_QI          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_ice
   DKE            | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics
   DCPT           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_dry_energy_content_due_to_dynamics
   DPET           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -212,8 +212,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   PID            | 1                | xy   |  N   |           |          | process_id
   QV_DYN_IN      | kg kg-1          | xyz  |  C   |           |          | spec_humidity_at_begin_of_time_step
   T_DYN_IN       | K                | xyz  |  C   |           |          | temperature_at_begin_of_time_step
-  U_DYN_IN       | m s-1            | xyz  |  C   |           |          | u_wind_at_begin_of_time_step
-  V_DYN_IN       | m s-1            | xyz  |  C   |           |          | v_wind_at_begin_of_time_step
+  UV_DYN_IN      | m s-1            | xyz  |  C   | V         |          | (u, v)_wind_at_begin_of_time_step
   PLE_DYN_IN     | Pa               | xyz  |  E   |           |          | edge_pressure_at_begin_of_time_step
   PLE4           | Pa               | xyz  |  E   |           |          | pressure_at_layer_edges_r4
 
@@ -222,9 +221,8 @@ category: IMPORT
 #----------------------------------------------------------------------
  SHORT_NAME |  UNITS   | DIMS | StateItem | VLOC | RESTART | LONG_NAME
 #----------------------------------------------------------------------
-  DUDT      | m s-2    | xyz  | V         |  C   |         | eastward_wind_tendency
-  DVDT      | m s-2    | xyz  | V         |  C   |         | northward_wind_tendency
-  DWDT      | m s-2    | xyz  | V         |  C   |         | vertical_velocity_tendency
+  D_UV_DT   | m s-2    | xyz  | V         |  C   |         | (eastward, northward)_wind_tendency
+  DWDT      | m s-2    | xyz  |           |  C   |         | vertical_velocity_tendency
   DTDT      | Pa K s-1 | xyz  |           |  C   |         | delta-p_weighted_temperature_tendency
   DQVANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_increment_from_analysis
   DQLANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_liquid_increment_from_analysis

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -50,7 +50,7 @@ category: EXPORT
   CONVTHV        | W m-2            | xy   |  N   |           |          | vertically_integrated_thetav_convergence
   CONVCPT        | W m-2            | xy   |  N   |           |          | vertically_integrated_enthalpy_convergence
   CONVPHI        | W m-2            | xy   |  N   |           |          | vertically_integrated_geopotential_convergence
-  UV             | m s-1            | xyz  |  C   | V         |          | (eastward_wind, northward_wind)
+  UV             | m s-1            | xyz  |  C   | V         |          | (x,y)_wind
   T              | K                | xyz  |  C   |           |          | air_temperature
   PL             | Pa               | xyz  |  C   |           |          | mid_level_pressure
   ZLE0           | m                | xyz  |  E   |           |          | edge_heights_above_surface
@@ -78,18 +78,18 @@ category: EXPORT
   EPV            | K m+2 kg-1 s-1   | xyz  |  C   |           |          | ertels_potential_vorticity
   Q              | 1                | xyz  |  C   |           |          | specific_humidity
   QC             | 1                | xyz  |  C   |           |          | specific_mass_of_condensate
-# DUDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_subgrid_dz
-# DVDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_subgrid_dz
+# DUDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_x_wind_due_to_subgrid_dz
+# DVDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_y_wind_due_to_subgrid_dz
 # DTDTSUBZ       | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_subgrid_dz
 # DWDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_vertical_velocity_due_to_subgrid_dz
   DTDT_RAY       | K s-1            | xyz  |  C   |           |          | air_temperature_tendency_due_to_Rayleigh_friction
-  D_UV_DT_RAY    | m s-2            | xyz  |  C   | V         |          | tendency_of_(eastward, northward)_wind_due_to_Rayleigh_friction
+  D_UV_DT_RAY    | m s-2            | xyz  |  C   | V         |          | tendency_of_(x,y)_wind_due_to_Rayleigh_friction
   DWDT_RAY       | m/s/s            | xyz  |  C   |           |          | vertical_velocity_tendency_due_to_Rayleigh_friction
-  D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(eastward, northward)_wind_due_to_analysis
+  D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(x,y)_wind_due_to_analysis
   DTDTANA        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_analysis
   DDELPDTANA     | K s-1            | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_analysis
-  DUDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_dynamics
-  DVDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_dynamics
+  DUDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_x_wind_due_to_dynamics
+  DVDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_y_wind_due_to_dynamics
   DTDTDYN        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_dynamics
   DQVDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_specific_humidity_due_to_dynamics
   DQIDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_ice_water_due_to_dynamics
@@ -100,7 +100,7 @@ category: EXPORT
   PS             | Pa               | xy   |  N   |           |          | surface_pressure
   TA             | K                | xy   |  N   |           |          | surface_air_temperature
   QA             | 1                | xy   |  N   |           |          | surface_specific_humidity
-  UV_S           | m s-1            | xy   |  N   | V         |          | (surface_eastward_wind, surface_northward_wind)
+  UV_S           | m s-1            | xy   |  N   | V         |          | surface_(x,y)_wind
   SPEED          | m s-1            | xy   |  N   |           |          | surface_wind_speed
   WSPD_10M       | m s-1            | xy   |  N   |           |          | wind_speed_at_10m
 VVEL_UP_100_1000 | m s-1            | xy   |  N   |           |          | max_vertical_velocity_up_between_100_1000_hPa
@@ -118,22 +118,21 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   PLE1           | Pa               | xyz  |  E   |           | R8       | pressure_at_layer_edges_after_dynamics
   DELP           | Pa               | xyz  |  C   |           |          | pressure_thickness
   DELPTOP        | Pa               | xy   |  N   |           |          | pressure_thickness_at_model_top
-  U_AGRID        | m s-1            | xyz  |  C   |           |          | eastward_wind_on_A-Grid
-  V_AGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_A-Grid
-  U_CGRID        | m s-1            | xyz  |  C   |           |          | eastward_wind_on_C-Grid
-  V_CGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_C-Grid
-  U_DGRID        | m s-1            | xyz  |  C   |           |          | eastward_wind_on_native_D-Grid
-  V_DGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_native_D-Grid
+  UV_AGRID       | m s-1            | xyz  |  C   | V         |          | (x,y)_wind_on_A-Grid
+  U_CGRID        | m s-1            | xyz  |  C   |           |          | x_wind_on_C-Grid
+  V_CGRID        | m s-1            | xyz  |  C   |           |          | y_wind_on_C-Grid
+  U_DGRID        | m s-1            | xyz  |  C   |           |          | x_wind_on_native_D-Grid
+  V_DGRID        | m s-1            | xyz  |  C   |           |          | y_wind_on_native_D-Grid
   TV             | K                | xyz  |  C   |           |          | air_virtual_temperature
   THV            | K/Pa$^\kappa$    | xyz  |  C   |           |          | scaled_virtual_potential_temperature
   DPLEDTDYN      | Pa s-1           | xyz  |  E   |           |          | tendency_of_edge_pressure_due_to_dynamics
   DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
-  UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_kinetic_energy)
-  UV_CPT         | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_enthalpy
-  UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_potential_energy
-  UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_water_vapor
-  UV_QL          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_liquid_water
-  UV_QI          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_ice
+  UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_kinetic_energy
+  UV_CPT         | J m-1 s-1        | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_enthalpy
+  UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_potential_energy
+  UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_water_vapor
+  UV_QL          | kg m-1 s-1       | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_liquid_water
+  UV_QI          | kg m-1 s-1       | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_ice
   DKE            | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics
   DCPT           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_dry_energy_content_due_to_dynamics
   DPET           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics
@@ -158,35 +157,35 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   DIVG700        | s-1              | xy   |  N   |           |          | divergence_at_700_hPa
   DIVG500        | s-1              | xy   |  N   |           |          | divergence_at_500_hPa
   DIVG200        | s-1              | xy   |  N   |           |          | divergence_at_200_hPa
-  UV_850         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_850_hPa
+  UV_850         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_850_hPa
   W850           | m s-1            | xy   |  N   |           |          | w_at_850_hPa
   T850           | K                | xy   |  N   |           |          | air_temperature_at_850_hPa
   Q850           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_850_hPa
   OMEGA850       | Pa s-1           | xy   |  N   |           |          | omega_at_850_hPa
-  UV_700         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_700_hPa
+  UV_700         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_700_hPa
   T700           | K                | xy   |  N   |           |          | air_temperature_at_700_hPa
   Q700           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_700_hPa
   OMEGA700       | Pa s-1           | xy   |  N   |           |          | omega_at_700_hPa
-  UV_500         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_500_hPa
+  UV_500         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_500_hPa
   W500           | m s-1            | xy   |  N   |           |          | w_at_500_hPa
   T500           | K                | xy   |  N   |           |          | air_temperature_at_500_hPa
   Q500           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_500_hPa
   OMEGA500       | Pa s-1           | xy   |  N   |           |          | omega_at_500_hPa
-  UV_300         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_300_hPa
+  UV_300         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_300_hPa
   T300           | K                | xy   |  N   |           |          | air_temperature_at_300_hPa
   Q300           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_300_hPa
-  UV_250         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_250_hPa
+  UV_250         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_250_hPa
   T250           | K                | xy   |  N   |           |          | air_temperature_at_250_hPa
   Q250           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_250_hPa
-  UV_200         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_200_hPa
+  UV_200         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_200_hPa
   W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
   T200           | K                | xy   |  N   |           |          | air_temperature_at_200_hPa
   Q200           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_200_hPa
   OMEGA200       | Pa s-1           | xy   |  N   |           |          | omega_at_200_hPa
-  UV_100         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_100_hPa
+  UV_100         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_100_hPa
   T100           | K                | xy   |  N   |           |          | air_temperature_at_100_hPa
   Q100           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_100_hPa
-  UV_TOP         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_model_top
+  UV_TOP         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_model_top
   TTOP           | K                | xy   |  N   |           |          | air_temperature_at_model_top
   Z700           | m                | xy   |  N   |           |          | geopotential_height_at_700_hPa
   Z500           | m                | xy   |  N   |           |          | geopotential_height_at_500_hPa
@@ -200,7 +199,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   H100           | m                | xy   |  N   |           |          | height_at_100_hPa
   OMEGA10        | Pa s-1           | xy   |  N   |           |          | omega_at_10_hPa
   W10            | m s-1            | xy   |  N   |           |          | w_at_10_hPa
-  UV_50M         | m s-1            | xy   |  N   | V         |          | (eastward, northward)_wind_at_50_meters
+  UV_50M         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_50_meters
   DXC            | m                | xy   |  N   |           |          | cgrid_delta_x
   DYC            | m                | xy   |  N   |           |          | cgrid_delta_y
   AREA           | m+2              | xy   |  N   |           |          | agrid_cell_area
@@ -221,7 +220,7 @@ category: IMPORT
 #----------------------------------------------------------------------
  SHORT_NAME |  UNITS   | DIMS | StateItem | VLOC | RESTART | LONG_NAME
 #----------------------------------------------------------------------
-  D_UV_DT   | m s-2    | xyz  | V         |  C   |         | (eastward, northward)_wind_tendency
+  D_UV_DT   | m s-2    | xyz  | V         |  C   |         | (x,y)_wind_tendency
   DWDT      | m s-2    | xyz  |           |  C   |         | vertical_velocity_tendency
   DTDT      | Pa K s-1 | xyz  |           |  C   |         | delta-p_weighted_temperature_tendency
   DQVANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_increment_from_analysis
@@ -242,7 +241,8 @@ category: INTERNAL
 #--------------------------------------------------------------------------------------------------------------------
   AK        | Pa               | R8       |   z  | REQUIRED |  E   |          | T          |             | hybrid_sigma_pressure_a
   BK        | 1                | R8       |   z  | REQUIRED |  E   |          | T          |             | hybrid_sigma_pressure_b
-  UV        | m s-1            | R8       | xyz  | REQUIRED |  C   | V        | F          |             | (eastward_wind, northward_wind)
+  U         | m s-1            | R8       | xyz  | REQUIRED |  C   |          | F          |             | x_wind
+  V         | m s-1            | R8       | xyz  | REQUIRED |  C   |          | F          |             | y_wind
   W         | m s-1            | R8       | xyz  |          |  C   |          | F          |             | vertical_velocity
   PT        | K Pa$^{-\kappa}$ | R8       | xyz  | REQUIRED |  C   |          | F          |             | scaled_potential_temperature
   PE        | Pa               | R8       | xyz  | REQUIRED |  E   |          | T          | PLE         | air_pressure

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -50,7 +50,7 @@ category: EXPORT
   CONVTHV        | W m-2            | xy   |  N   |           |          | vertically_integrated_thetav_convergence
   CONVCPT        | W m-2            | xy   |  N   |           |          | vertically_integrated_enthalpy_convergence
   CONVPHI        | W m-2            | xy   |  N   |           |          | vertically_integrated_geopotential_convergence
-  UV             | m s-1            | xyz  |  C   | V         |          | (x,y)_wind
+  UV             | m s-1            | xyz  |  C   | V         |          | (eastward,northward)_wind
   T              | K                | xyz  |  C   |           |          | air_temperature
   PL             | Pa               | xyz  |  C   |           |          | mid_level_pressure
   ZLE0           | m                | xyz  |  E   |           |          | edge_heights_above_surface
@@ -78,18 +78,18 @@ category: EXPORT
   EPV            | K m+2 kg-1 s-1   | xyz  |  C   |           |          | ertels_potential_vorticity
   Q              | 1                | xyz  |  C   |           |          | specific_humidity
   QC             | 1                | xyz  |  C   |           |          | specific_mass_of_condensate
-# DUDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_x_wind_due_to_subgrid_dz
-# DVDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_y_wind_due_to_subgrid_dz
+# DUDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_subgrid_dz
+# DVDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_subgrid_dz
 # DTDTSUBZ       | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_subgrid_dz
 # DWDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_vertical_velocity_due_to_subgrid_dz
   DTDT_RAY       | K s-1            | xyz  |  C   |           |          | air_temperature_tendency_due_to_Rayleigh_friction
-  D_UV_DT_RAY    | m s-2            | xyz  |  C   | V         |          | tendency_of_(x,y)_wind_due_to_Rayleigh_friction
+  D_UV_DT_RAY    | m s-2            | xyz  |  C   | V         |          | tendency_of_(eastward,northward)_wind_due_to_Rayleigh_friction
   DWDT_RAY       | m/s/s            | xyz  |  C   |           |          | vertical_velocity_tendency_due_to_Rayleigh_friction
-  D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(x,y)_wind_due_to_analysis
+  D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(eastward,northward)_wind_due_to_analysis
   DTDTANA        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_analysis
   DDELPDTANA     | K s-1            | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_analysis
-  DUDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_x_wind_due_to_dynamics
-  DVDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_y_wind_due_to_dynamics
+  DUDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_dynamics
+  DVDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_dynamics
   DTDTDYN        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_dynamics
   DQVDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_specific_humidity_due_to_dynamics
   DQIDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_ice_water_due_to_dynamics
@@ -100,7 +100,7 @@ category: EXPORT
   PS             | Pa               | xy   |  N   |           |          | surface_pressure
   TA             | K                | xy   |  N   |           |          | surface_air_temperature
   QA             | 1                | xy   |  N   |           |          | surface_specific_humidity
-  UV_S           | m s-1            | xy   |  N   | V         |          | surface_(x,y)_wind
+  UV_S           | m s-1            | xy   |  N   | V         |          | surface_(eastward,northward)_wind
   SPEED          | m s-1            | xy   |  N   |           |          | surface_wind_speed
   WSPD_10M       | m s-1            | xy   |  N   |           |          | wind_speed_at_10m
 VVEL_UP_100_1000 | m s-1            | xy   |  N   |           |          | max_vertical_velocity_up_between_100_1000_hPa
@@ -118,7 +118,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   PLE1           | Pa               | xyz  |  E   |           | R8       | pressure_at_layer_edges_after_dynamics
   DELP           | Pa               | xyz  |  C   |           |          | pressure_thickness
   DELPTOP        | Pa               | xy   |  N   |           |          | pressure_thickness_at_model_top
-  UV_AGRID       | m s-1            | xyz  |  C   | V         |          | (x,y)_wind_on_A-Grid
+  UV_AGRID       | m s-1            | xyz  |  C   | V         |          | (eastward,northward)_wind_on_A-Grid
   U_CGRID        | m s-1            | xyz  |  C   |           |          | x_wind_on_C-Grid
   V_CGRID        | m s-1            | xyz  |  C   |           |          | y_wind_on_C-Grid
   U_DGRID        | m s-1            | xyz  |  C   |           |          | x_wind_on_native_D-Grid
@@ -127,12 +127,12 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   THV            | K/Pa$^\kappa$    | xyz  |  C   |           |          | scaled_virtual_potential_temperature
   DPLEDTDYN      | Pa s-1           | xyz  |  E   |           |          | tendency_of_edge_pressure_due_to_dynamics
   DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
-  UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_kinetic_energy
-  UV_CPT         | J m-1 s-1        | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_enthalpy
-  UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_potential_energy
-  UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_water_vapor
-  UV_QL          | kg m-1 s-1       | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_liquid_water
-  UV_QI          | kg m-1 s-1       | xy   |  N   | V         |          | (x,y)_flux_of_atmospheric_ice
+  UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (eastward,northward)_flux_of_atmospheric_kinetic_energy
+  UV_CPT         | J m-1 s-1        | xy   |  N   | V         |          | (eastward,northward)_flux_of_atmospheric_enthalpy
+  UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (eastward,northward)_flux_of_atmospheric_potential_energy
+  UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward,northward)_flux_of_atmospheric_water_vapor
+  UV_QL          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward,northward)_flux_of_atmospheric_liquid_water
+  UV_QI          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward,northward)_flux_of_atmospheric_ice
   DKE            | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics
   DCPT           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_dry_energy_content_due_to_dynamics
   DPET           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics
@@ -157,35 +157,35 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   DIVG700        | s-1              | xy   |  N   |           |          | divergence_at_700_hPa
   DIVG500        | s-1              | xy   |  N   |           |          | divergence_at_500_hPa
   DIVG200        | s-1              | xy   |  N   |           |          | divergence_at_200_hPa
-  UV_850         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_850_hPa
+  UV_850         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_850_hPa
   W850           | m s-1            | xy   |  N   |           |          | w_at_850_hPa
   T850           | K                | xy   |  N   |           |          | air_temperature_at_850_hPa
   Q850           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_850_hPa
   OMEGA850       | Pa s-1           | xy   |  N   |           |          | omega_at_850_hPa
-  UV_700         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_700_hPa
+  UV_700         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_700_hPa
   T700           | K                | xy   |  N   |           |          | air_temperature_at_700_hPa
   Q700           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_700_hPa
   OMEGA700       | Pa s-1           | xy   |  N   |           |          | omega_at_700_hPa
-  UV_500         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_500_hPa
+  UV_500         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_500_hPa
   W500           | m s-1            | xy   |  N   |           |          | w_at_500_hPa
   T500           | K                | xy   |  N   |           |          | air_temperature_at_500_hPa
   Q500           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_500_hPa
   OMEGA500       | Pa s-1           | xy   |  N   |           |          | omega_at_500_hPa
-  UV_300         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_300_hPa
+  UV_300         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_300_hPa
   T300           | K                | xy   |  N   |           |          | air_temperature_at_300_hPa
   Q300           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_300_hPa
-  UV_250         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_250_hPa
+  UV_250         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_250_hPa
   T250           | K                | xy   |  N   |           |          | air_temperature_at_250_hPa
   Q250           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_250_hPa
-  UV_200         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_200_hPa
+  UV_200         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_200_hPa
   W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
   T200           | K                | xy   |  N   |           |          | air_temperature_at_200_hPa
   Q200           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_200_hPa
   OMEGA200       | Pa s-1           | xy   |  N   |           |          | omega_at_200_hPa
-  UV_100         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_100_hPa
+  UV_100         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_100_hPa
   T100           | K                | xy   |  N   |           |          | air_temperature_at_100_hPa
   Q100           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_100_hPa
-  UV_TOP         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_model_top
+  UV_TOP         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_model_top
   TTOP           | K                | xy   |  N   |           |          | air_temperature_at_model_top
   Z700           | m                | xy   |  N   |           |          | geopotential_height_at_700_hPa
   Z500           | m                | xy   |  N   |           |          | geopotential_height_at_500_hPa
@@ -199,7 +199,7 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   H100           | m                | xy   |  N   |           |          | height_at_100_hPa
   OMEGA10        | Pa s-1           | xy   |  N   |           |          | omega_at_10_hPa
   W10            | m s-1            | xy   |  N   |           |          | w_at_10_hPa
-  UV_50M         | m s-1            | xy   |  N   | V         |          | (x,y)_wind_at_50_meters
+  UV_50M         | m s-1            | xy   |  N   | V         |          | (eastward,northward)_wind_at_50_meters
   DXC            | m                | xy   |  N   |           |          | cgrid_delta_x
   DYC            | m                | xy   |  N   |           |          | cgrid_delta_y
   AREA           | m+2              | xy   |  N   |           |          | agrid_cell_area
@@ -220,7 +220,7 @@ category: IMPORT
 #----------------------------------------------------------------------
  SHORT_NAME |  UNITS   | DIMS | StateItem | VLOC | RESTART | LONG_NAME
 #----------------------------------------------------------------------
-  D_UV_DT   | m s-2    | xyz  | V         |  C   |         | (x,y)_wind_tendency
+  D_UV_DT   | m s-2    | xyz  | V         |  C   |         | (eastward,northward)_wind_tendency
   DWDT      | m s-2    | xyz  |           |  C   |         | vertical_velocity_tendency
   DTDT      | Pa K s-1 | xyz  |           |  C   |         | delta-p_weighted_temperature_tendency
   DQVANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_increment_from_analysis

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -2,289 +2,289 @@ schema_version: 2.0.0
 component: DynCore
 
 category: EXPORT
-#------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SHORT_NAME     |  LONG_NAME                                                                |  UNITS             |  DIMS | VLOC |  FIELD_TYPE        | TYPEKIND
-#------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  KE             |  vertically_integrated_kinetic_energy                                     |  J m-2             |  xy   |  N   |                    |
-  TAVE           |  vertically_averaged_dry_temperature                                      |  K                 |  xy   |  N   |                    |
-  UAVE           |  vertically_averaged_zonal_wind                                           |  m sec-1           |  xy   |  N   |  MAPL_VectorField  |
-  KEPHY          |  vertically_integrated_kinetic_energy_tendency_due_to_physics             |  W m-2             |  xy   |  N   |                    |
-  PEPHY          |  total_potential_energy_tendency_due_to_physics                           |  W m-2             |  xy   |  N   |                    |
-  TEPHY          |  mountain_work_tendency_due_to_physics                                    |  W m-2             |  xy   |  N   |                    |
-  KEANA          |  total_kinetic_energy_tendency_due_to_analysis                            |  W m-2             |  xy   |  N   |                    |
-  PEANA          |  total_potential_energy_tendency_due_to_analysis                          |  W m-2             |  xy   |  N   |                    |
-  TEANA          |  mountain_work_tendency_due_to_analysis                                   |  W m-2             |  xy   |  N   |                    |
-  KEHOT          |  vertically_integrated_kinetic_energy_tendency_due_to_HOT                 |  W m-2             |  xy   |  N   |                    |
-  KEDP           |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_change     |  W m-2             |  xy   |  N   |                    |
-  KEADV          |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics_advection  |  W m-2             |  xy   |  N   |                    |
-  KEPG           |  vertically_integrated_kinetic_energy_tendency_due_to_pressure_gradient   |  W m-2             |  xy   |  N   |                    |
-  KEDYN          |  vertically_integrated_kinetic_energy_tendency_due_to_dynamics            |  W m-2             |  xy   |  N   |                    |
-  PEDYN          |  vertically_integrated_potential_energy_tendency_due_to_dynamics          |  W m-2             |  xy   |  N   |                    |
-  TEDYN          |  mountain_work_tendency_due_to_dynamics                                   |  W m-2             |  xy   |  N   |                    |
-  KECDCOR        |  vertically_integrated_kinetic_energy_tendency_due_to_cdcore              |  W m-2             |  xy   |  N   |                    |
-  PECDCOR        |  vertically_integrated_potential_energy_tendency_due_to_cdcore            |  W m-2             |  xy   |  N   |                    |
-  TECDCOR        |  mountain_work_tendency_due_to_cdcore                                     |  W m-2             |  xy   |  N   |                    |
-  QFIXER         |  vertically_integrated_potential_energy_tendency_due_to_CONSV             |  W m-2             |  xy   |  N   |                    |
-  KEREMAP        |  vertically_integrated_kinetic_energy_tendency_due_to_remap               |  W m-2             |  xy   |  N   |                    |
-  PEREMAP        |  vertically_integrated_potential_energy_tendency_due_to_remap             |  W m-2             |  xy   |  N   |                    |
-  TEREMAP        |  mountain_work_tendency_due_to_remap                                      |  W m-2             |  xy   |  N   |                    |
-  KEGEN          |  vertically_integrated_generation_of_kinetic_energy                       |  W m-2             |  xy   |  N   |                    |
-  DKERESIN       |  vertically_integrated_kinetic_energy_residual_from_inertial_terms        |  W m-2             |  xy   |  N   |                    |
-  DKERESPG       |  vertically_integrated_kinetic_energy_residual_from_PG_terms              |  W m-2             |  xy   |  N   |                    |
-  DMDTANA        |  vertically_integrated_mass_tendency_due_to_analysis                      |  kg m-2 s-1        |  xy   |  N   |                    |
-  DOXDTANAINT    |  vertically_integrated_ozone_tendency_due_to_analysis                     |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQVDTANAINT    |  vertically_integrated_water_vapor_tendency_due_to_analysis               |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQLDTANAINT    |  vertically_integrated_liquid_water_tendency_due_to_analysis              |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQIDTANAINT    |  vertically_integrated_ice_water_tendency_due_to_analysis                 |  kg m-2 s-1        |  xy   |  N   |                    |
-  DMDTDYN        |  vertically_integrated_mass_tendency_due_to_dynamics                      |  kg m-2 s-1        |  xy   |  N   |                    |
-  DOXDTDYNINT    |  vertically_integrated_ozone_tendency_due_to_dynamics                     |  kg m-2 s-1        |  xy   |  N   |                    |
-  DTHVDTDYNINT   |  vertically_integrated_THV_tendency_due_to_dynamics                       |  K kg m-2 s-1      |  xy   |  N   |                    |
-  DTHVDTREMAP    |  vertically_integrated_THV_tendency_due_to_vertical_remapping             |  K kg m-2 s-1      |  xy   |  N   |                    |
-  DTHVDTCONSV    |  vertically_integrated_THV_tendency_due_to_TE_conservation                |  K kg m-2 s-1      |  xy   |  N   |                    |
-  DTHVDTPHYINT   |  vertically_integrated_THV_tendency_due_to_physics                        |  K kg m-2 s-1      |  xy   |  N   |                    |
-  DTHVDTANAINT   |  vertically_integrated_THV_tendency_due_to_analysis                       |  K kg m-2 s-1      |  xy   |  N   |                    |
-  DQVDTDYNINT    |  vertically_integrated_water_vapor_tendency_due_to_dynamics               |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQLDTDYNINT    |  vertically_integrated_liquid_water_tendency_due_to_dynamics              |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQIDTDYNINT    |  vertically_integrated_ice_water_tendency_due_to_dynamics                 |  kg m-2 s-1        |  xy   |  N   |                    |
-  CONVKE         |  vertically_integrated_kinetic_energy_convergence                         |  W m-2             |  xy   |  N   |                    |
-  CONVTHV        |  vertically_integrated_thetav_convergence                                 |  W m-2             |  xy   |  N   |                    |
-  CONVCPT        |  vertically_integrated_enthalpy_convergence                               |  W m-2             |  xy   |  N   |                    |
-  CONVPHI        |  vertically_integrated_geopotential_convergence                           |  W m-2             |  xy   |  N   |                    |
-  T              |  air_temperature                                                          |  K                 |  xyz  |  C   |                    |
-  PL             |  mid_level_pressure                                                       |  Pa                |  xyz  |  C   |                    |
-  ZLE0           |  edge_heights_above_surface                                               |  m                 |  xyz  |  E   |                    |
-  ZL0            |  mid_layer_heights_above_surface                                          |  m                 |  xyz  |  C   |                    |
-  ZLE            |  edge_heights                                                             |  m                 |  xyz  |  E   |                    |
-  ZL             |  mid_layer_heights                                                        |  m                 |  xyz  |  C   |                    |
-  S              |  mid_layer_dry_static_energy                                              |  m                 |  xyz  |  C   |                    |
-  TH             |  potential_temperature                                                    |  K                 |  xyz  |  C   |                    |
-  PLK            |  mid-layer_p$^\kappa$                                                     |  Pa$^\kappa$       |  xyz  |  C   |                    |
-  PKE            |  edge_p$^\kappa$                                                          |  Pa$^\kappa$       |  xyz  |  E   |                    |
-  DELZ           |  nonhydrostatic_layer_thickness                                           |  m s-1             |  xyz  |  C   |                    |
-  W              |  vertical_velocity                                                        |  m s-1             |  xyz  |  C   |                    |
-  OMEGA          |  hydrostatic_vertical_pressure_velocity                                   |  Pa s-1            |  xyz  |  C   |                    |
-  CX             |  eastward_accumulated_courant_number                                      |  1                 |  xyz  |  C   |                    |  R8
-  CY             |  northward_accumulated_courant_number                                     |  1                 |  xyz  |  C   |                    |  R8
-  CU             |  eastward_accumulated_courant_number                                      |  1                 |  xyz  |  C   |                    |
-  CV             |  northward_accumulated_courant_number                                     |  1                 |  xyz  |  C   |                    |
-  MX             |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |
-  MY             |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |
-  MFX            |  pressure_weighted_accumulated_eastward_mass_flux                         |  Pa m+2            |  xyz  |  C   |                    |  R8
-  MFY            |  pressure_weighted_accumulated_northward_mass_flux                        |  Pa m+2            |  xyz  |  C   |                    |  R8
-  MFZ            |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R8
-  MZ             |  vertical_mass_flux                                                       |  kg m-2 s-1        |  xyz  |  E   |                    |  R4
-  PV             |  ertels_isentropic_potential_vorticity                                    |  m+2 kg-1 s-1      |  xyz  |  C   |                    |
-  EPV            |  ertels_potential_vorticity                                               |  K m+2 kg-1 s-1    |  xyz  |  C   |                    |
-  Q              |  specific_humidity                                                        |  1                 |  xyz  |  C   |                    |
-  QC             |  specific_mass_of_condensate                                              |  1                 |  xyz  |  C   |                    |
-# DUDTSUBZ       |  tendency_of_eastward_wind_due_to_subgrid_dz                              |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
-# DVDTSUBZ       |  tendency_of_northward_wind_due_to_subgrid_dz                             |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
-# DTDTSUBZ       |  tendency_of_air_temperature_due_to_subgrid_dz                            |  K s-1             |  xyz  |  C   |                    |
-# DWDTSUBZ       |  tendency_of_vertical_velocity_due_to_subgrid_dz                          |  m/s/s             |  xyz  |  C   |                    |
-  DTDT_RAY       |  air_temperature_tendency_due_to_Rayleigh_friction                        |  K s-1             |  xyz  |  C   |                    |
-  DUDT_RAY       |  tendency_of_eastward_wind_due_to_Rayleigh_friction                       |  m s-2             |  xyz  |  C   |  MAPL_VectorField  |
-  DVDT_RAY       |  tendency_of_northward_wind_due_to_Rayleigh_friction                      |  m s-2             |  xyz  |  C   |  MAPL_VectorField  |
-  DWDT_RAY       |  vertical_velocity_tendency_due_to_Rayleigh_friction                      |  m/s/s             |  xyz  |  C   |                    |
+#------------------------------------------------------------------------------------
+  SHORT_NAME     | UNITS            | DIMS | VLOC | StateItem | TYPEKIND | LONG_NAME
+#------------------------------------------------------------------------------------
+  KE             | J m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy
+  TAVE           | K                | xy   |  N   |           |          | vertically_averaged_dry_temperature
+  UAVE           | m sec-1          | xy   |  N   | V         |          | vertically_averaged_zonal_wind
+  KEPHY          | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_physics
+  PEPHY          | W m-2            | xy   |  N   |           |          | total_potential_energy_tendency_due_to_physics
+  TEPHY          | W m-2            | xy   |  N   |           |          | mountain_work_tendency_due_to_physics
+  KEANA          | W m-2            | xy   |  N   |           |          | total_kinetic_energy_tendency_due_to_analysis
+  PEANA          | W m-2            | xy   |  N   |           |          | total_potential_energy_tendency_due_to_analysis
+  TEANA          | W m-2            | xy   |  N   |           |          | mountain_work_tendency_due_to_analysis
+  KEHOT          | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_HOT
+  KEDP           | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_pressure_change
+  KEADV          | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_dynamics_advection
+  KEPG           | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_pressure_gradient
+  KEDYN          | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_dynamics
+  PEDYN          | W m-2            | xy   |  N   |           |          | vertically_integrated_potential_energy_tendency_due_to_dynamics
+  TEDYN          | W m-2            | xy   |  N   |           |          | mountain_work_tendency_due_to_dynamics
+  KECDCOR        | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_cdcore
+  PECDCOR        | W m-2            | xy   |  N   |           |          | vertically_integrated_potential_energy_tendency_due_to_cdcore
+  TECDCOR        | W m-2            | xy   |  N   |           |          | mountain_work_tendency_due_to_cdcore
+  QFIXER         | W m-2            | xy   |  N   |           |          | vertically_integrated_potential_energy_tendency_due_to_CONSV
+  KEREMAP        | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_remap
+  PEREMAP        | W m-2            | xy   |  N   |           |          | vertically_integrated_potential_energy_tendency_due_to_remap
+  TEREMAP        | W m-2            | xy   |  N   |           |          | mountain_work_tendency_due_to_remap
+  KEGEN          | W m-2            | xy   |  N   |           |          | vertically_integrated_generation_of_kinetic_energy
+  DKERESIN       | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_residual_from_inertial_terms
+  DKERESPG       | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_residual_from_PG_terms
+  DMDTANA        | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_mass_tendency_due_to_analysis
+  DOXDTANAINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_ozone_tendency_due_to_analysis
+  DQVDTANAINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_water_vapor_tendency_due_to_analysis
+  DQLDTANAINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_liquid_water_tendency_due_to_analysis
+  DQIDTANAINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_ice_water_tendency_due_to_analysis
+  DMDTDYN        | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_mass_tendency_due_to_dynamics
+  DOXDTDYNINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_ozone_tendency_due_to_dynamics
+  DTHVDTDYNINT   | K kg m-2 s-1     | xy   |  N   |           |          | vertically_integrated_THV_tendency_due_to_dynamics
+  DTHVDTREMAP    | K kg m-2 s-1     | xy   |  N   |           |          | vertically_integrated_THV_tendency_due_to_vertical_remapping
+  DTHVDTCONSV    | K kg m-2 s-1     | xy   |  N   |           |          | vertically_integrated_THV_tendency_due_to_TE_conservation
+  DTHVDTPHYINT   | K kg m-2 s-1     | xy   |  N   |           |          | vertically_integrated_THV_tendency_due_to_physics
+  DTHVDTANAINT   | K kg m-2 s-1     | xy   |  N   |           |          | vertically_integrated_THV_tendency_due_to_analysis
+  DQVDTDYNINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_water_vapor_tendency_due_to_dynamics
+  DQLDTDYNINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_liquid_water_tendency_due_to_dynamics
+  DQIDTDYNINT    | kg m-2 s-1       | xy   |  N   |           |          | vertically_integrated_ice_water_tendency_due_to_dynamics
+  CONVKE         | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_convergence
+  CONVTHV        | W m-2            | xy   |  N   |           |          | vertically_integrated_thetav_convergence
+  CONVCPT        | W m-2            | xy   |  N   |           |          | vertically_integrated_enthalpy_convergence
+  CONVPHI        | W m-2            | xy   |  N   |           |          | vertically_integrated_geopotential_convergence
+  T              | K                | xyz  |  C   |           |          | air_temperature
+  PL             | Pa               | xyz  |  C   |           |          | mid_level_pressure
+  ZLE0           | m                | xyz  |  E   |           |          | edge_heights_above_surface
+  ZL0            | m                | xyz  |  C   |           |          | mid_layer_heights_above_surface
+  ZLE            | m                | xyz  |  E   |           |          | edge_heights
+  ZL             | m                | xyz  |  C   |           |          | mid_layer_heights
+  S              | m                | xyz  |  C   |           |          | mid_layer_dry_static_energy
+  TH             | K                | xyz  |  C   |           |          | potential_temperature
+  PLK            | Pa$^\kappa$      | xyz  |  C   |           |          | mid-layer_p$^\kappa$
+  PKE            | Pa$^\kappa$      | xyz  |  E   |           |          | edge_p$^\kappa$
+  DELZ           | m s-1            | xyz  |  C   |           |          | nonhydrostatic_layer_thickness
+  W              | m s-1            | xyz  |  C   |           |          | vertical_velocity
+  OMEGA          | Pa s-1           | xyz  |  C   |           |          | hydrostatic_vertical_pressure_velocity
+  CX             | 1                | xyz  |  C   |           | R8       | eastward_accumulated_courant_number
+  CY             | 1                | xyz  |  C   |           | R8       | northward_accumulated_courant_number
+  CU             | 1                | xyz  |  C   |           |          | eastward_accumulated_courant_number
+  CV             | 1                | xyz  |  C   |           |          | northward_accumulated_courant_number
+  MX             | Pa m+2           | xyz  |  C   |           |          | pressure_weighted_accumulated_eastward_mass_flux
+  MY             | Pa m+2           | xyz  |  C   |           |          | pressure_weighted_accumulated_northward_mass_flux
+  MFX            | Pa m+2           | xyz  |  C   |           | R8       | pressure_weighted_accumulated_eastward_mass_flux
+  MFY            | Pa m+2           | xyz  |  C   |           | R8       | pressure_weighted_accumulated_northward_mass_flux
+  MFZ            | kg m-2 s-1       | xyz  |  E   |           | R8       | vertical_mass_flux
+  MZ             | kg m-2 s-1       | xyz  |  E   |           | R4       | vertical_mass_flux
+  PV             | m+2 kg-1 s-1     | xyz  |  C   |           |          | ertels_isentropic_potential_vorticity
+  EPV            | K m+2 kg-1 s-1   | xyz  |  C   |           |          | ertels_potential_vorticity
+  Q              | 1                | xyz  |  C   |           |          | specific_humidity
+  QC             | 1                | xyz  |  C   |           |          | specific_mass_of_condensate
+# DUDTSUBZ       | m/s/s            | xyz  |  C   | V         |          | tendency_of_eastward_wind_due_to_subgrid_dz
+# DVDTSUBZ       | m/s/s            | xyz  |  C   | V         |          | tendency_of_northward_wind_due_to_subgrid_dz
+# DTDTSUBZ       | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_subgrid_dz
+# DWDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_vertical_velocity_due_to_subgrid_dz
+  DTDT_RAY       | K s-1            | xyz  |  C   |           |          | air_temperature_tendency_due_to_Rayleigh_friction
+  DUDT_RAY       | m s-2            | xyz  |  C   | V         |          | tendency_of_eastward_wind_due_to_Rayleigh_friction
+  DVDT_RAY       | m s-2            | xyz  |  C   | V         |          | tendency_of_northward_wind_due_to_Rayleigh_friction
+  DWDT_RAY       | m/s/s            | xyz  |  C   |           |          | vertical_velocity_tendency_due_to_Rayleigh_friction
 #
-# DUDTANA        |  tendency_of_eastward_wind_due_to_analysis                                |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
-# DVDTANA        |  tendency_of_northward_wind_due_to_analysis                               |  m/s/s             |  xyz  |  C   |  MAPL_VectorField  |
+# DUDTANA        | m/s/s            | xyz  |  C   | V         |          | tendency_of_eastward_wind_due_to_analysis
+# DVDTANA        | m/s/s            | xyz  |  C   | V         |          | tendency_of_northward_wind_due_to_analysis
 #
-  DTDTANA        |  tendency_of_air_temperature_due_to_analysis                              |  K s-1             |  xyz  |  C   |                    |
-  DDELPDTANA     |  tendency_of_pressure_thickness_due_to_analysis                           |  K s-1             |  xyz  |  C   |                    |
-  DUDTDYN        |  tendency_of_eastward_wind_due_to_dynamics                                |  m/s/s             |  xyz  |  C   |                    |
-  DVDTDYN        |  tendency_of_northward_wind_due_to_dynamics                               |  m/s/s             |  xyz  |  C   |                    |
-  DTDTDYN        |  tendency_of_air_temperature_due_to_dynamics                              |  K s-1             |  xyz  |  C   |                    |
-  DQVDTDYN       |  tendency_of_specific_humidity_due_to_dynamics                            |  kg/kg/s           |  xyz  |  C   |                    |
-  DQIDTDYN       |  tendency_of_ice_water_due_to_dynamics                                    |  kg/kg/s           |  xyz  |  C   |                    |
-  DQLDTDYN       |  tendency_of_liquid_water_due_to_dynamics                                 |  kg/kg/s           |  xyz  |  C   |                    |
-  DOXDTDYN       |  tendency_of_ozone_due_to_dynamics                                        |  mol mol-1 s-1     |  xyz  |  C   |                    |
-  PREF           |  reference_air_pressure                                                   |  Pa                |    z  |  E   |                    |
-  PHIS           |  surface_height                                                           |  m                 |  xy   |  N   |                    |
-  PS             |  surface_pressure                                                         |  Pa                |  xy   |  N   |                    |
-  TA             |  surface_air_temperature                                                  |  K                 |  xy   |  N   |                    |
-  QA             |  surface_specific_humidity                                                |  1                 |  xy   |  N   |                    |
+  DTDTANA        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_analysis
+  DDELPDTANA     | K s-1            | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_analysis
+  DUDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_dynamics
+  DVDTDYN        | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_dynamics
+  DTDTDYN        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_dynamics
+  DQVDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_specific_humidity_due_to_dynamics
+  DQIDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_ice_water_due_to_dynamics
+  DQLDTDYN       | kg/kg/s          | xyz  |  C   |           |          | tendency_of_liquid_water_due_to_dynamics
+  DOXDTDYN       | mol mol-1 s-1    | xyz  |  C   |           |          | tendency_of_ozone_due_to_dynamics
+  PREF           | Pa               |   z  |  E   |           |          | reference_air_pressure
+  PHIS           | m                | xy   |  N   |           |          | surface_height
+  PS             | Pa               | xy   |  N   |           |          | surface_pressure
+  TA             | K                | xy   |  N   |           |          | surface_air_temperature
+  QA             | 1                | xy   |  N   |           |          | surface_specific_humidity
 #
-  US             |  surface_eastward_wind                                                    |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  VS             |  surface_northward_wind                                                   |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  US             | m s-1            | xy   |  N   | V         |          | surface_eastward_wind
+  VS             | m s-1            | xy   |  N   | V         |          | surface_northward_wind
 #
-  SPEED          |  surface_wind_speed                                                       |  m s-1             |  xy   |  N   |                    |
-  WSPD_10M       |  wind_speed_at_10m                                                        |  m s-1             |  xy   |  N   |                    |
-  VVEL_UP_100_1000  | max_vertical_velocity_up_between_100_1000_hPa                          |  m s-1             |  xy   |  N   |                    |
-  VVEL_DN_100_1000  | max_vertical_velocity_down_between_100_1000_hPa                        |  m s-1             |  xy   |  N   |                    |
-  DZ             |  surface_layer_height                                                     |  m                 |  xy   |  N   |                    |
-  SLP            |  sea_level_pressure                                                       |  Pa                |  xy   |  N   |                    |
-  H1000          |  height_at_1000_mb                                                        |  m                 |  xy   |  N   |                    |
-  TROPP_EPV      |  tropopause_pressure_based_on_EPV_estimate                                |  Pa                |  xy   |  N   |                    |
-  TROPP_THERMAL  |  tropopause_pressure_based_on_thermal_estimate                            |  Pa                |  xy   |  N   |                    |
-  TROPP_BLENDED  |  tropopause_pressure_based_on_blended_estimate                            |  Pa                |  xy   |  N   |                    |
-  TROPK_BLENDED  |  tropopause_index_based_on_blended_estimate                               |  unitless          |  xy   |  N   |                    |
-  TROPT          |  tropopause_temperature_using_blended_TROPP_estimate                      |  K                 |  xy   |  N   |                    |
-  TROPQ          |  tropopause_specific_humidity_using_blended_TROPP_estimate                |  kg/kg             |  xy   |  N   |                    |
-  PLE0           |  pressure_at_layer_edges_before_dynamics                                  |  Pa                |  xyz  |  E   |                    |  R8
-  PLE1           |  pressure_at_layer_edges_after_dynamics                                   |  Pa                |  xyz  |  E   |                    |  R8
-  DELP           |  pressure_thickness                                                       |  Pa                |  xyz  |  C   |                    |
-  DELPTOP        |  pressure_thickness_at_model_top                                          |  Pa                |  xy   |  N   |                    |
-  U_AGRID        |  eastward_wind_on_A-Grid                                                  |  m s-1             |  xyz  |  C   |                    |
-  V_AGRID        |  northward_wind_on_A-Grid                                                 |  m s-1             |  xyz  |  C   |                    |
-  U_CGRID        |  eastward_wind_on_C-Grid                                                  |  m s-1             |  xyz  |  C   |                    |
-  V_CGRID        |  northward_wind_on_C-Grid                                                 |  m s-1             |  xyz  |  C   |                    |
-  U_DGRID        |  eastward_wind_on_native_D-Grid                                           |  m s-1             |  xyz  |  C   |                    |
-  V_DGRID        |  northward_wind_on_native_D-Grid                                          |  m s-1             |  xyz  |  C   |                    |
-  TV             |  air_virtual_temperature                                                  |  K                 |  xyz  |  C   |                    |
-  THV            |  scaled_virtual_potential_temperature                                     |  K/Pa$^\kappa$     |  xyz  |  C   |                    |
-  DPLEDTDYN      |  tendency_of_edge_pressure_due_to_dynamics                                |  Pa s-1            |  xyz  |  C   |                    |
-  DDELPDTDYN     |  tendency_of_pressure_thickness_due_to_dynamics                           |  Pa s-1            |  xyz  |  C   |                    |
+  SPEED          | m s-1            | xy   |  N   |           |          | surface_wind_speed
+  WSPD_10M       | m s-1            | xy   |  N   |           |          | wind_speed_at_10m
+VVEL_UP_100_1000 | m s-1            | xy   |  N   |           |          |max_vertical_velocity_up_between_100_1000_hPa
+VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_vertical_velocity_down_between_100_1000_hPa
+  DZ             | m                | xy   |  N   |           |          | surface_layer_height
+  SLP            | Pa               | xy   |  N   |           |          | sea_level_pressure
+  H1000          | m                | xy   |  N   |           |          | height_at_1000_mb
+  TROPP_EPV      | Pa               | xy   |  N   |           |          | tropopause_pressure_based_on_EPV_estimate
+  TROPP_THERMAL  | Pa               | xy   |  N   |           |          | tropopause_pressure_based_on_thermal_estimate
+  TROPP_BLENDED  | Pa               | xy   |  N   |           |          | tropopause_pressure_based_on_blended_estimate
+  TROPK_BLENDED  | unitless         | xy   |  N   |           |          | tropopause_index_based_on_blended_estimate
+  TROPT          | K                | xy   |  N   |           |          | tropopause_temperature_using_blended_TROPP_estimate
+  TROPQ          | kg/kg            | xy   |  N   |           |          | tropopause_specific_humidity_using_blended_TROPP_estimate
+  PLE0           | Pa               | xyz  |  E   |           | R8       | pressure_at_layer_edges_before_dynamics
+  PLE1           | Pa               | xyz  |  E   |           | R8       | pressure_at_layer_edges_after_dynamics
+  DELP           | Pa               | xyz  |  C   |           |          | pressure_thickness
+  DELPTOP        | Pa               | xy   |  N   |           |          | pressure_thickness_at_model_top
+  U_AGRID        | m s-1            | xyz  |  C   |           |          | eastward_wind_on_A-Grid
+  V_AGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_A-Grid
+  U_CGRID        | m s-1            | xyz  |  C   |           |          | eastward_wind_on_C-Grid
+  V_CGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_C-Grid
+  U_DGRID        | m s-1            | xyz  |  C   |           |          | eastward_wind_on_native_D-Grid
+  V_DGRID        | m s-1            | xyz  |  C   |           |          | northward_wind_on_native_D-Grid
+  TV             | K                | xyz  |  C   |           |          | air_virtual_temperature
+  THV            | K/Pa$^\kappa$    | xyz  |  C   |           |          | scaled_virtual_potential_temperature
+  DPLEDTDYN      | Pa s-1           | xyz  |  C   |           |          | tendency_of_edge_pressure_due_to_dynamics
+  DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
 #
-# UKE            |  eastward_flux_of_atmospheric_kinetic_energy                              |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-# VKE            |  northward_flux_of_atmospheric_kinetic_energy                             |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+# UKE            | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_kinetic_energy
+# VKE            | J m-1 s-1        | xy   |  N   | V         |          | northward_flux_of_atmospheric_kinetic_energy
 #
-  UCPT           |  eastward_flux_of_atmospheric_enthalpy                                    |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-  VCPT           |  northward_flux_of_atmospheric_enthalpy                                   |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+  UCPT           | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_enthalpy
+  VCPT           | J m-1 s-1        | xy   |  N   | V         |          | northward_flux_of_atmospheric_enthalpy
 #
-# UPHI           |  eastward_flux_of_atmospheric_potential_energy                            |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
-# VPHI           |  northward_flux_of_atmospheric_potential_energy                           |  J m-1 s-1         |  xy   |  N   |  MAPL_VectorField  |
+# UPHI           | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_potential_energy
+# VPHI           | J m-1 s-1        | xy   |  N   | V         |          | northward_flux_of_atmospheric_potential_energy
 #
-# UQV            |  eastward_flux_of_atmospheric_water_vapor                                 |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
-# VQV            |  northward_flux_of_atmospheric_water_vapor                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+# UQV            | kg m-1 s-1       | xy   |  N   | V         |          | eastward_flux_of_atmospheric_water_vapor
+# VQV            | kg m-1 s-1       | xy   |  N   | V         |          | northward_flux_of_atmospheric_water_vapor
 #
-  UQL            |  eastward_flux_of_atmospheric_liquid_water                                |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
-  VQL            |  northward_flux_of_atmospheric_liquid_water                               |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  UQL            | kg m-1 s-1       | xy   |  N   | V         |          | eastward_flux_of_atmospheric_liquid_water
+  VQL            | kg m-1 s-1       | xy   |  N   | V         |          | northward_flux_of_atmospheric_liquid_water
 #
-  UQI            |  eastward_flux_of_atmospheric_ice                                         |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
-  VQI            |  northward_flux_of_atmospheric_ice                                        |  kg m-1 s-1        |  xy   |  N   |  MAPL_VectorField  |
+  UQI            | kg m-1 s-1       | xy   |  N   | V         |          | eastward_flux_of_atmospheric_ice
+  VQI            | kg m-1 s-1       | xy   |  N   | V         |          | northward_flux_of_atmospheric_ice
 #
-  DKE            |  tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics            |  W m-2             |  xy   |  N   |                    |
-  DCPT           |  tendency_of_atmosphere_dry_energy_content_due_to_dynamics                |  W m-2             |  xy   |  N   |                    |
-  DPET           |  tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics      |  W m-2             |  xy   |  N   |                    |
-  WRKT           |  work_done_by_atmosphere_at_top                                           |  W m-2             |  xy   |  N   |                    |
-  DQV            |  tendency_of_atmosphere_water_vapor_content_due_to_dynamics               |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQL            |  tendency_of_atmosphere_liquid_water_content_due_to_dynamics              |  kg m-2 s-1        |  xy   |  N   |                    |
-  DQI            |  tendency_of_atmosphere_ice_content_due_to_dynamics                       |  kg m-2 s-1        |  xy   |  N   |                    |
-  CNV            |  generation_of_atmosphere_kinetic_energy_content                          |  W m-2             |  xy   |  N   |                    |
-  UH25           |  updraft_helicity_2_to_5_km                                               |  m+2 s-2           |  xy   |  N   |                    |
-  UH03           |  updraft_helicity_0_to_3_km                                               |  m+2 s-2           |  xy   |  N   |                    |
-  SRH01          |  storm_relative_helicity_0_to_1_km                                        |  m+2 s-2           |  xy   |  N   |                    |
-  SRH03          |  storm_relative_helicity_0_to_3_km                                        |  m+2 s-2           |  xy   |  N   |                    |
-  SRH25          |  storm_relative_helicity_2_to_5_km                                        |  m+2 s-2           |  xy   |  N   |                    |
-  SHR06          |  wind_shear_0_to_6_km                                                     |  m s-1             |  xy   |  N   |                    |
-  VORT           |  vorticity_at_mid_layer_heights                                           |  s-1               |  xyz  |  C   |                    |
-  VORT850        |  vorticity_at_850_hPa                                                     |  s-1               |  xy   |  N   |                    |
-  VORT700        |  vorticity_at_700_hPa                                                     |  s-1               |  xy   |  N   |                    |
-  VORT500        |  vorticity_at_500_hPa                                                     |  s-1               |  xy   |  N   |                    |
-  VORT200        |  vorticity_at_200_hPa                                                     |  s-1               |  xy   |  N   |                    |
-  DIVG           |  divergence_at_mid_layer_heights                                          |  s-1               |  xyz  |  C   |                    |
-  DIVG850        |  divergence_at_850_hPa                                                    |  s-1               |  xy   |  N   |                    |
-  DIVG700        |  divergence_at_700_hPa                                                    |  s-1               |  xy   |  N   |                    |
-  DIVG500        |  divergence_at_500_hPa                                                    |  s-1               |  xy   |  N   |                    |
-  DIVG200        |  divergence_at_200_hPa                                                    |  s-1               |  xy   |  N   |                    |
+  DKE            | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics
+  DCPT           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_dry_energy_content_due_to_dynamics
+  DPET           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_topographic_potential_energy_due_to_dynamics
+  WRKT           | W m-2            | xy   |  N   |           |          | work_done_by_atmosphere_at_top
+  DQV            | kg m-2 s-1       | xy   |  N   |           |          | tendency_of_atmosphere_water_vapor_content_due_to_dynamics
+  DQL            | kg m-2 s-1       | xy   |  N   |           |          | tendency_of_atmosphere_liquid_water_content_due_to_dynamics
+  DQI            | kg m-2 s-1       | xy   |  N   |           |          | tendency_of_atmosphere_ice_content_due_to_dynamics
+  CNV            | W m-2            | xy   |  N   |           |          | generation_of_atmosphere_kinetic_energy_content
+  UH25           | m+2 s-2          | xy   |  N   |           |          | updraft_helicity_2_to_5_km
+  UH03           | m+2 s-2          | xy   |  N   |           |          | updraft_helicity_0_to_3_km
+  SRH01          | m+2 s-2          | xy   |  N   |           |          | storm_relative_helicity_0_to_1_km
+  SRH03          | m+2 s-2          | xy   |  N   |           |          | storm_relative_helicity_0_to_3_km
+  SRH25          | m+2 s-2          | xy   |  N   |           |          | storm_relative_helicity_2_to_5_km
+  SHR06          | m s-1            | xy   |  N   |           |          | wind_shear_0_to_6_km
+  VORT           | s-1              | xyz  |  C   |           |          | vorticity_at_mid_layer_heights
+  VORT850        | s-1              | xy   |  N   |           |          | vorticity_at_850_hPa
+  VORT700        | s-1              | xy   |  N   |           |          | vorticity_at_700_hPa
+  VORT500        | s-1              | xy   |  N   |           |          | vorticity_at_500_hPa
+  VORT200        | s-1              | xy   |  N   |           |          | vorticity_at_200_hPa
+  DIVG           | s-1              | xyz  |  C   |           |          | divergence_at_mid_layer_heights
+  DIVG850        | s-1              | xy   |  N   |           |          | divergence_at_850_hPa
+  DIVG700        | s-1              | xy   |  N   |           |          | divergence_at_700_hPa
+  DIVG500        | s-1              | xy   |  N   |           |          | divergence_at_500_hPa
+  DIVG200        | s-1              | xy   |  N   |           |          | divergence_at_200_hPa
 #
-  U850           |  eastward_wind_at_850_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V850           |  northward_wind_at_850_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T850           |  air_temperature_at_850_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q850           |  specific_humidity_at_850_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U850           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_850_hPa
+  V850           | m s-1            | xy   |  N   | V         |          | northward_wind_at_850_hPa
+  T850           | K                | xy   |  N   |           |          | air_temperature_at_850_hPa
+  Q850           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_850_hPa
 #
-  U700           |  eastward_wind_at_700_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V700           |  northward_wind_at_700_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T700           |  air_temperature_at_700_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q700           |  specific_humidity_at_700_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U700           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_700_hPa
+  V700           | m s-1            | xy   |  N   | V         |          | northward_wind_at_700_hPa
+  T700           | K                | xy   |  N   |           |          | air_temperature_at_700_hPa
+  Q700           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_700_hPa
 #
-  U500           |  eastward_wind_at_500_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V500           |  northward_wind_at_500_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T500           |  air_temperature_at_500_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q500           |  specific_humidity_at_500_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U500           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_500_hPa
+  V500           | m s-1            | xy   |  N   | V         |          | northward_wind_at_500_hPa
+  T500           | K                | xy   |  N   |           |          | air_temperature_at_500_hPa
+  Q500           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_500_hPa
 #
-  U300           |  eastward_wind_at_300_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V300           |  northward_wind_at_300_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T300           |  air_temperature_at_300_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q300           |  specific_humidity_at_300_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U300           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_300_hPa
+  V300           | m s-1            | xy   |  N   | V         |          | northward_wind_at_300_hPa
+  T300           | K                | xy   |  N   |           |          | air_temperature_at_300_hPa
+  Q300           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_300_hPa
 #
-  U250           |  eastward_wind_at_250_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V250           |  northward_wind_at_250_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T250           |  air_temperature_at_250_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q250           |  specific_humidity_at_250_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U250           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_250_hPa
+  V250           | m s-1            | xy   |  N   | V         |          | northward_wind_at_250_hPa
+  T250           | K                | xy   |  N   |           |          | air_temperature_at_250_hPa
+  Q250           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_250_hPa
 #
-  U200           |  eastward_wind_at_200_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V200           |  northward_wind_at_200_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T200           |  air_temperature_at_200_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q200           |  specific_humidity_at_200_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U200           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_200_hPa
+  V200           | m s-1            | xy   |  N   | V         |          | northward_wind_at_200_hPa
+  T200           | K                | xy   |  N   |           |          | air_temperature_at_200_hPa
+  Q200           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_200_hPa
 #
-  U100           |  eastward_wind_at_100_hPa                                                 |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V100           |  northward_wind_at_100_hPa                                                |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  T100           |  air_temperature_at_100_hPa                                               |  K                 |  xy   |  N   |                    |
-  Q100           |  specific_humidity_at_100_hPa                                             |  kg kg-1           |  xy   |  N   |                    |
+  U100           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_100_hPa
+  V100           | m s-1            | xy   |  N   | V         |          | northward_wind_at_100_hPa
+  T100           | K                | xy   |  N   |           |          | air_temperature_at_100_hPa
+  Q100           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_100_hPa
 #
-  UTOP           |  eastward_wind_at_model_top                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  VTOP           |  northward_wind_at_model_top                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  TTOP           |  air_temperature_at_model_top                                             |  K                 |  xy   |  N   |                    |
+  UTOP           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_model_top
+  VTOP           | m s-1            | xy   |  N   | V         |          | northward_wind_at_model_top
+  TTOP           | K                | xy   |  N   |           |          | air_temperature_at_model_top
 #
-  Z700           |  geopotential_height_at_700_hPa                                           |  m                 |  xy   |  N   |                    |
-  Z500           |  geopotential_height_at_500_hPa                                           |  m                 |  xy   |  N   |                    |
-  Z300           |  geopotential_height_at_300_hPa                                           |  m                 |  xy   |  N   |                    |
-  H850           |  height_at_850_hPa                                                        |  m                 |  xy   |  N   |                    |
-  H700           |  height_at_700_hPa                                                        |  m                 |  xy   |  N   |                    |
-  H500           |  height_at_500_hPa                                                        |  m                 |  xy   |  N   |                    |
-  H300           |  height_at_300_hPa                                                        |  m                 |  xy   |  N   |                    |
-  H250           |  height_at_250_hPa                                                        |  m                 |  xy   |  N   |                    |
-  H200           |  height_at_200_hPa                                                        |  m                 |  xy   |  N   |                    |
-  H100           |  height_at_100_hPa                                                        |  m                 |  xy   |  N   |                    |
-  OMEGA850       |  omega_at_850_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
-  OMEGA700       |  omega_at_700_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
-  OMEGA500       |  omega_at_500_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
-  OMEGA200       |  omega_at_200_hPa                                                         |  Pa s-1            |  xy   |  N   |                    |
-  OMEGA10        |  omega_at_10_hPa                                                          |  Pa s-1            |  xy   |  N   |                    |
-  W850           |  w_at_850_hPa                                                             |  m s-1             |  xy   |  N   |                    |
-  W500           |  w_at_500_hPa                                                             |  m s-1             |  xy   |  N   |                    |
-  W200           |  w_at_200_hPa                                                             |  m s-1             |  xy   |  N   |                    |
-  W10            |  w_at_10_hPa                                                              |  m s-1             |  xy   |  N   |                    |
+  Z700           | m                | xy   |  N   |           |          | geopotential_height_at_700_hPa
+  Z500           | m                | xy   |  N   |           |          | geopotential_height_at_500_hPa
+  Z300           | m                | xy   |  N   |           |          | geopotential_height_at_300_hPa
+  H850           | m                | xy   |  N   |           |          | height_at_850_hPa
+  H700           | m                | xy   |  N   |           |          | height_at_700_hPa
+  H500           | m                | xy   |  N   |           |          | height_at_500_hPa
+  H300           | m                | xy   |  N   |           |          | height_at_300_hPa
+  H250           | m                | xy   |  N   |           |          | height_at_250_hPa
+  H200           | m                | xy   |  N   |           |          | height_at_200_hPa
+  H100           | m                | xy   |  N   |           |          | height_at_100_hPa
+  OMEGA850       | Pa s-1           | xy   |  N   |           |          | omega_at_850_hPa
+  OMEGA700       | Pa s-1           | xy   |  N   |           |          | omega_at_700_hPa
+  OMEGA500       | Pa s-1           | xy   |  N   |           |          | omega_at_500_hPa
+  OMEGA200       | Pa s-1           | xy   |  N   |           |          | omega_at_200_hPa
+  OMEGA10        | Pa s-1           | xy   |  N   |           |          | omega_at_10_hPa
+  W850           | m s-1            | xy   |  N   |           |          | w_at_850_hPa
+  W500           | m s-1            | xy   |  N   |           |          | w_at_500_hPa
+  W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
+  W10            | m s-1            | xy   |  N   |           |          | w_at_10_hPa
 #
-  U50M           |  eastward_wind_at_50_meters                                               |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
-  V50M           |  northward_wind_at_50_meters                                              |  m s-1             |  xy   |  N   |  MAPL_VectorField  |
+  U50M           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_50_meters
+  V50M           | m s-1            | xy   |  N   | V         |          | northward_wind_at_50_meters
 #
-  DXC            |  cgrid_delta_x                                                            |  m                 |  xy   |  N   |                    |
-  DYC            |  cgrid_delta_y                                                            |  m                 |  xy   |  N   |                    |
-  AREA           |  agrid_cell_area                                                          |  m+2               |  xy   |  N   |                    |
-  PT             |  scaled_potential_temperature                                             |  K Pa$^{-\kappa}$  |  xyz  |  C   |                    |
-  PE             |  air_pressure                                                             |  Pa                |  xyz  |  E   |                    |
-  LONS           |  Center_longitudes                                                        |  radians           |  xy   |  N   |                    |
-  LATS           |  Center_latitudes                                                         |  radians           |  xy   |  N   |                    |
-  TIME_IN_DYN    |  timer_for_main_dynamics_run                                              |  seconds           |  xy   |  N   |                    |
-  PID            |  process_id                                                               |  1                 |  xy   |  N   |                    |
-  QV_DYN_IN      |  spec_humidity_at_begin_of_time_step                                      |  kg kg-1           |  xyz  |  C   |                    |
-  T_DYN_IN       |  temperature_at_begin_of_time_step                                        |  K                 |  xyz  |  C   |                    |
-  U_DYN_IN       |  u_wind_at_begin_of_time_step                                             |  m s-1             |  xyz  |  C   |                    |
-  V_DYN_IN       |  v_wind_at_begin_of_time_step                                             |  m s-1             |  xyz  |  C   |                    |
-  PLE_DYN_IN     |  edge_pressure_at_begin_of_time_step                                      |  Pa                |  xyz  |  E   |                    |
-  PLE4           | blah_blah_blah                                                            | Pa                 |  xyz  |  E   |                    |
+  DXC            | m                | xy   |  N   |           |          | cgrid_delta_x
+  DYC            | m                | xy   |  N   |           |          | cgrid_delta_y
+  AREA           | m+2              | xy   |  N   |           |          | agrid_cell_area
+  PT             | K Pa$^{-\kappa}$ | xyz  |  C   |           |          | scaled_potential_temperature
+  PE             | Pa               | xyz  |  E   |           |          | air_pressure
+  LONS           | radians          | xy   |  N   |           |          | Center_longitudes
+  LATS           | radians          | xy   |  N   |           |          | Center_latitudes
+  TIME_IN_DYN    | seconds          | xy   |  N   |           |          | timer_for_main_dynamics_run
+  PID            | 1                | xy   |  N   |           |          | process_id
+  QV_DYN_IN      | kg kg-1          | xyz  |  C   |           |          | spec_humidity_at_begin_of_time_step
+  T_DYN_IN       | K                | xyz  |  C   |           |          | temperature_at_begin_of_time_step
+  U_DYN_IN       | m s-1            | xyz  |  C   |           |          | u_wind_at_begin_of_time_step
+  V_DYN_IN       | m s-1            | xyz  |  C   |           |          | v_wind_at_begin_of_time_step
+  PLE_DYN_IN     | Pa               | xyz  |  E   |           |          | edge_pressure_at_begin_of_time_step
+  PLE4           | Pa               | xyz  |  E   |           |          | blah_blah_blah
 
 
 category: IMPORT
-#------------------------------------------------------------------------------------------------------------------------------
- SHORT_NAME |  LONG_NAME                                          |   UNITS    |  DIMS |     FIELD_TYPE     | VLOC |  RESTART
-#------------------------------------------------------------------------------------------------------------------------------
-  DUDT      |  eastward_wind_tendency                             |  m s-2     |  xyz  |  MAPL_VectorField  |  C   |
-  DVDT      |  northward_wind_tendency                            |  m s-2     |  xyz  |  MAPL_VectorField  |  C   |
-  DWDT      |  vertical_velocity_tendency                         |  m s-2     |  xyz  |  MAPL_VectorField  |  C   |
-  DTDT      |  delta-p_weighted_temperature_tendency              |  Pa K s-1  |  xyz  |                    |  C   |
-  DQVANA    |  specific_humidity_increment_from_analysis          |  kg kg-1   |  xyz  |                    |  C   |
-  DQLANA    |  specific_humidity_liquid_increment_from_analysis   |  kg kg-1   |  xyz  |                    |  C   |
-  DQIANA    |  specific_humidity_ice_increment_from_analysis      |  kg kg-1   |  xyz  |                    |  C   |
-  DQRANA    |  specific_humidity_rain_increment_from_analysis     |  kg kg-1   |  xyz  |                    |  C   |
-  DQSANA    |  specific_humidity_snow_increment_from_analysis     |  kg kg-1   |  xyz  |                    |  C   |
-  DQGANA    |  specific_humidity_graupel_increment_from_analysis  |  kg kg-1   |  xyz  |                    |  C   |
-  DOXANA    |  ozone_increment_from_analysis                      |  kg kg-1   |  xyz  |                    |  C   |
-  DPEDT     |  edge_pressure_tendency                             |  Pa s-1    |  xyz  |                    |  E   |
-  PHIS      |  surface_geopotential_height                        |  m+2 s-2   |  xy   |                    |  N   |
-  VARFLT    |  variance_of_filtered_topography                    |  m+2       |  xy   |                    |  N   |  SKIP
+#----------------------------------------------------------------------
+ SHORT_NAME |  UNITS   | DIMS | StateItem | VLOC | RESTART | LONG_NAME
+#----------------------------------------------------------------------
+  DUDT      | m s-2    | xyz  | V         |  C   |         | eastward_wind_tendency
+  DVDT      | m s-2    | xyz  | V         |  C   |         | northward_wind_tendency
+  DWDT      | m s-2    | xyz  | V         |  C   |         | vertical_velocity_tendency
+  DTDT      | Pa K s-1 | xyz  |           |  C   |         | delta-p_weighted_temperature_tendency
+  DQVANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_increment_from_analysis
+  DQLANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_liquid_increment_from_analysis
+  DQIANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_ice_increment_from_analysis
+  DQRANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_rain_increment_from_analysis
+  DQSANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_snow_increment_from_analysis
+  DQGANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_graupel_increment_from_analysis
+  DOXANA    | kg kg-1  | xyz  |           |  C   |         | ozone_increment_from_analysis
+  DPEDT     | Pa s-1   | xyz  |           |  E   |         | edge_pressure_tendency
+  PHIS      | m+2 s-2  | xy   |           |  N   |         | surface_geopotential_height
+  VARFLT    | m+2      | xy   |           |  N   | SKIP    | variance_of_filtered_topography
 
 
 category: INTERNAL
-#--------------------------------------------------------------------------------------------------------------------------------------
- SHORT_NAME |  LONG_NAME                     |  UNITS             |  TYPEKIND  |  DIMS |   RESTART  | VLOC | ADD2EXPORT | EXPORT_NAME
-#--------------------------------------------------------------------------------------------------------------------------------------
-  AK        |  hybrid_sigma_pressure_a       |  Pa                |  R8        |    z  |  REQUIRED  |  E   |    T       |
-  BK        |  hybrid_sigma_pressure_b       |  1                 |  R8        |    z  |  REQUIRED  |  E   |    T       |
-  W         |  vertical_velocity             |  m s-1             |  R8        |  xyz  |            |  C   |    F       |
-  PT        |  scaled_potential_temperature  |  K Pa$^{-\kappa}$  |  R8        |  xyz  |  REQUIRED  |  C   |    F       |
-  PE        |  air_pressure                  |  Pa                |  R8        |  xyz  |  REQUIRED  |  E   |    T       |    PLE
-  PKZ       |  pressure_to_kappa             |  Pa$^\kappa$       |  R8        |  xyz  |  REQUIRED  |  C   |    F       |
-  DZ        |  height_thickness              |  m                 |  R8        |  xyz  |            |  C   |    F       |
+#---------------------------------------------------------------------------------------------------------
+ SHORT_NAME | UNITS            | TYPEKIND | DIMS | RESTART  | VLOC | ADD2EXPORT | EXPORT_NAME | LONG_NAME
+#---------------------------------------------------------------------------------------------------------
+  AK        | Pa               | R8       |   z  | REQUIRED |  E   |    T       |             | hybrid_sigma_pressure_a
+  BK        | 1                | R8       |   z  | REQUIRED |  E   |    T       |             | hybrid_sigma_pressure_b
+  W         | m s-1            | R8       | xyz  |          |  C   |    F       |             | vertical_velocity
+  PT        | K Pa$^{-\kappa}$ | R8       | xyz  | REQUIRED |  C   |    F       |             | scaled_potential_temperature
+  PE        | Pa               | R8       | xyz  | REQUIRED |  E   |    T       | PLE         | air_pressure
+  PKZ       | Pa$^\kappa$      | R8       | xyz  | REQUIRED |  C   |    F       |             | pressure_to_kappa
+  DZ        | m                | R8       | xyz  |          |  C   |    F       |             | height_thickness

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -3,11 +3,11 @@ component: DynCore
 
 category: EXPORT
 #------------------------------------------------------------------------------------
-  SHORT_NAME     | UNITS            | DIMS | VLOC | StateItem | TYPEKIND | LONG_NAME
+  SHORT_NAME     | UNITS            | DIMS | VLOC | itemtype  | TYPEKIND | LONG_NAME
 #------------------------------------------------------------------------------------
   KE             | J m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy
   TAVE           | K                | xy   |  N   |           |          | vertically_averaged_dry_temperature
-  UAVE           | m sec-1          | xy   |  N   | V         |          | vertically_averaged_zonal_wind
+  UAVE           | m sec-1          | xy   |  N   |           |          | vertically_averaged_zonal_wind
   KEPHY          | W m-2            | xy   |  N   |           |          | vertically_integrated_kinetic_energy_tendency_due_to_physics
   PEPHY          | W m-2            | xy   |  N   |           |          | total_potential_energy_tendency_due_to_physics
   TEPHY          | W m-2            | xy   |  N   |           |          | mountain_work_tendency_due_to_physics
@@ -50,6 +50,7 @@ category: EXPORT
   CONVTHV        | W m-2            | xy   |  N   |           |          | vertically_integrated_thetav_convergence
   CONVCPT        | W m-2            | xy   |  N   |           |          | vertically_integrated_enthalpy_convergence
   CONVPHI        | W m-2            | xy   |  N   |           |          | vertically_integrated_geopotential_convergence
+  UV             | m s-1            | xyz  |  C   | V         |          | (eastward_wind, northward_wind)
   T              | K                | xyz  |  C   |           |          | air_temperature
   PL             | Pa               | xyz  |  C   |           |          | mid_level_pressure
   ZLE0           | m                | xyz  |  E   |           |          | edge_heights_above_surface
@@ -77,17 +78,18 @@ category: EXPORT
   EPV            | K m+2 kg-1 s-1   | xyz  |  C   |           |          | ertels_potential_vorticity
   Q              | 1                | xyz  |  C   |           |          | specific_humidity
   QC             | 1                | xyz  |  C   |           |          | specific_mass_of_condensate
-# DUDTSUBZ       | m/s/s            | xyz  |  C   | V         |          | tendency_of_eastward_wind_due_to_subgrid_dz
-# DVDTSUBZ       | m/s/s            | xyz  |  C   | V         |          | tendency_of_northward_wind_due_to_subgrid_dz
+# DUDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_subgrid_dz
+# DVDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_subgrid_dz
 # DTDTSUBZ       | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_subgrid_dz
 # DWDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_vertical_velocity_due_to_subgrid_dz
   DTDT_RAY       | K s-1            | xyz  |  C   |           |          | air_temperature_tendency_due_to_Rayleigh_friction
-  DUDT_RAY       | m s-2            | xyz  |  C   | V         |          | tendency_of_eastward_wind_due_to_Rayleigh_friction
-  DVDT_RAY       | m s-2            | xyz  |  C   | V         |          | tendency_of_northward_wind_due_to_Rayleigh_friction
+  DUDT_RAY       | m s-2            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_Rayleigh_friction
+  DVDT_RAY       | m s-2            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_Rayleigh_friction
   DWDT_RAY       | m/s/s            | xyz  |  C   |           |          | vertical_velocity_tendency_due_to_Rayleigh_friction
 #
-# DUDTANA        | m/s/s            | xyz  |  C   | V         |          | tendency_of_eastward_wind_due_to_analysis
-# DVDTANA        | m/s/s            | xyz  |  C   | V         |          | tendency_of_northward_wind_due_to_analysis
+# DUDTANA        | m/s/s            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_analysis
+# DVDTANA        | m/s/s            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_analysis
+  D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(eastward, northward)_wind_due_to_analysis
 #
   DTDTANA        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_analysis
   DDELPDTANA     | K s-1            | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_analysis
@@ -104,8 +106,8 @@ category: EXPORT
   TA             | K                | xy   |  N   |           |          | surface_air_temperature
   QA             | 1                | xy   |  N   |           |          | surface_specific_humidity
 #
-  US             | m s-1            | xy   |  N   | V         |          | surface_eastward_wind
-  VS             | m s-1            | xy   |  N   | V         |          | surface_northward_wind
+  US             | m s-1            | xy   |  N   |           |          | surface_eastward_wind
+  VS             | m s-1            | xy   |  N   |           |          | surface_northward_wind
 #
   SPEED          | m s-1            | xy   |  N   |           |          | surface_wind_speed
   WSPD_10M       | m s-1            | xy   |  N   |           |          | wind_speed_at_10m
@@ -135,23 +137,26 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   DPLEDTDYN      | Pa s-1           | xyz  |  E   |           |          | tendency_of_edge_pressure_due_to_dynamics
   DDELPDTDYN     | Pa s-1           | xyz  |  C   |           |          | tendency_of_pressure_thickness_due_to_dynamics
 #
-# UKE            | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_kinetic_energy
-# VKE            | J m-1 s-1        | xy   |  N   | V         |          | northward_flux_of_atmospheric_kinetic_energy
+# UKE            | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_kinetic_energy
+# VKE            | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_kinetic_energy
+  UV_KE          | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_kinetic_energy)
 #
-  UCPT           | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_enthalpy
-  VCPT           | J m-1 s-1        | xy   |  N   | V         |          | northward_flux_of_atmospheric_enthalpy
+  UCPT           | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_enthalpy
+  VCPT           | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_enthalpy
 #
-# UPHI           | J m-1 s-1        | xy   |  N   | V         |          | eastward_flux_of_atmospheric_potential_energy
-# VPHI           | J m-1 s-1        | xy   |  N   | V         |          | northward_flux_of_atmospheric_potential_energy
+# UPHI           | J m-1 s-1        | xy   |  N   |           |          | eastward_flux_of_atmospheric_potential_energy
+# VPHI           | J m-1 s-1        | xy   |  N   |           |          | northward_flux_of_atmospheric_potential_energy
+  UV_PHI         | J m-1 s-1        | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_potential_energy
 #
-# UQV            | kg m-1 s-1       | xy   |  N   | V         |          | eastward_flux_of_atmospheric_water_vapor
-# VQV            | kg m-1 s-1       | xy   |  N   | V         |          | northward_flux_of_atmospheric_water_vapor
+# UQV            | kg m-1 s-1       | xy   |  N   |           |          | eastward_flux_of_atmospheric_water_vapor
+# VQV            | kg m-1 s-1       | xy   |  N   |           |          | northward_flux_of_atmospheric_water_vapor
+  UV_QV          | kg m-1 s-1       | xy   |  N   | V         |          | (eastward, northward)_flux_of_atmospheric_water_vapor
 #
-  UQL            | kg m-1 s-1       | xy   |  N   | V         |          | eastward_flux_of_atmospheric_liquid_water
-  VQL            | kg m-1 s-1       | xy   |  N   | V         |          | northward_flux_of_atmospheric_liquid_water
+  UQL            | kg m-1 s-1       | xy   |  N   |           |          | eastward_flux_of_atmospheric_liquid_water
+  VQL            | kg m-1 s-1       | xy   |  N   |           |          | northward_flux_of_atmospheric_liquid_water
 #
-  UQI            | kg m-1 s-1       | xy   |  N   | V         |          | eastward_flux_of_atmospheric_ice
-  VQI            | kg m-1 s-1       | xy   |  N   | V         |          | northward_flux_of_atmospheric_ice
+  UQI            | kg m-1 s-1       | xy   |  N   |           |          | eastward_flux_of_atmospheric_ice
+  VQI            | kg m-1 s-1       | xy   |  N   |           |          | northward_flux_of_atmospheric_ice
 #
   DKE            | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_kinetic_energy_content_due_to_dynamics
   DCPT           | W m-2            | xy   |  N   |           |          | tendency_of_atmosphere_dry_energy_content_due_to_dynamics
@@ -178,43 +183,43 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   DIVG500        | s-1              | xy   |  N   |           |          | divergence_at_500_hPa
   DIVG200        | s-1              | xy   |  N   |           |          | divergence_at_200_hPa
 #
-  U850           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_850_hPa
-  V850           | m s-1            | xy   |  N   | V         |          | northward_wind_at_850_hPa
+  U850           | m s-1            | xy   |  N   |           |          | eastward_wind_at_850_hPa
+  V850           | m s-1            | xy   |  N   |           |          | northward_wind_at_850_hPa
   T850           | K                | xy   |  N   |           |          | air_temperature_at_850_hPa
   Q850           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_850_hPa
 #
-  U700           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_700_hPa
-  V700           | m s-1            | xy   |  N   | V         |          | northward_wind_at_700_hPa
+  U700           | m s-1            | xy   |  N   |           |          | eastward_wind_at_700_hPa
+  V700           | m s-1            | xy   |  N   |           |          | northward_wind_at_700_hPa
   T700           | K                | xy   |  N   |           |          | air_temperature_at_700_hPa
   Q700           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_700_hPa
 #
-  U500           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_500_hPa
-  V500           | m s-1            | xy   |  N   | V         |          | northward_wind_at_500_hPa
+  U500           | m s-1            | xy   |  N   |           |          | eastward_wind_at_500_hPa
+  V500           | m s-1            | xy   |  N   |           |          | northward_wind_at_500_hPa
   T500           | K                | xy   |  N   |           |          | air_temperature_at_500_hPa
   Q500           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_500_hPa
 #
-  U300           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_300_hPa
-  V300           | m s-1            | xy   |  N   | V         |          | northward_wind_at_300_hPa
+  U300           | m s-1            | xy   |  N   |           |          | eastward_wind_at_300_hPa
+  V300           | m s-1            | xy   |  N   |           |          | northward_wind_at_300_hPa
   T300           | K                | xy   |  N   |           |          | air_temperature_at_300_hPa
   Q300           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_300_hPa
 #
-  U250           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_250_hPa
-  V250           | m s-1            | xy   |  N   | V         |          | northward_wind_at_250_hPa
+  U250           | m s-1            | xy   |  N   |           |          | eastward_wind_at_250_hPa
+  V250           | m s-1            | xy   |  N   |           |          | northward_wind_at_250_hPa
   T250           | K                | xy   |  N   |           |          | air_temperature_at_250_hPa
   Q250           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_250_hPa
 #
-  U200           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_200_hPa
-  V200           | m s-1            | xy   |  N   | V         |          | northward_wind_at_200_hPa
+  U200           | m s-1            | xy   |  N   |           |          | eastward_wind_at_200_hPa
+  V200           | m s-1            | xy   |  N   |           |          | northward_wind_at_200_hPa
   T200           | K                | xy   |  N   |           |          | air_temperature_at_200_hPa
   Q200           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_200_hPa
 #
-  U100           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_100_hPa
-  V100           | m s-1            | xy   |  N   | V         |          | northward_wind_at_100_hPa
+  U100           | m s-1            | xy   |  N   |           |          | eastward_wind_at_100_hPa
+  V100           | m s-1            | xy   |  N   |           |          | northward_wind_at_100_hPa
   T100           | K                | xy   |  N   |           |          | air_temperature_at_100_hPa
   Q100           | kg kg-1          | xy   |  N   |           |          | specific_humidity_at_100_hPa
 #
-  UTOP           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_model_top
-  VTOP           | m s-1            | xy   |  N   | V         |          | northward_wind_at_model_top
+  UTOP           | m s-1            | xy   |  N   |           |          | eastward_wind_at_model_top
+  VTOP           | m s-1            | xy   |  N   |           |          | northward_wind_at_model_top
   TTOP           | K                | xy   |  N   |           |          | air_temperature_at_model_top
 #
   Z700           | m                | xy   |  N   |           |          | geopotential_height_at_700_hPa
@@ -237,8 +242,8 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          |max_ve
   W200           | m s-1            | xy   |  N   |           |          | w_at_200_hPa
   W10            | m s-1            | xy   |  N   |           |          | w_at_10_hPa
 #
-  U50M           | m s-1            | xy   |  N   | V         |          | eastward_wind_at_50_meters
-  V50M           | m s-1            | xy   |  N   | V         |          | northward_wind_at_50_meters
+  U50M           | m s-1            | xy   |  N   |           |          | eastward_wind_at_50_meters
+  V50M           | m s-1            | xy   |  N   |           |          | northward_wind_at_50_meters
 #
   DXC            | m                | xy   |  N   |           |          | cgrid_delta_x
   DYC            | m                | xy   |  N   |           |          | cgrid_delta_y
@@ -278,13 +283,14 @@ category: IMPORT
 
 
 category: INTERNAL
-#---------------------------------------------------------------------------------------------------------
- SHORT_NAME | UNITS            | TYPEKIND | DIMS | RESTART  | VLOC | ADD2EXPORT | EXPORT_NAME | LONG_NAME
-#---------------------------------------------------------------------------------------------------------
-  AK        | Pa               | R8       |   z  | REQUIRED |  E   |    T       |             | hybrid_sigma_pressure_a
-  BK        | 1                | R8       |   z  | REQUIRED |  E   |    T       |             | hybrid_sigma_pressure_b
-  W         | m s-1            | R8       | xyz  |          |  C   |    F       |             | vertical_velocity
-  PT        | K Pa$^{-\kappa}$ | R8       | xyz  | REQUIRED |  C   |    F       |             | scaled_potential_temperature
-  PE        | Pa               | R8       | xyz  | REQUIRED |  E   |    T       | PLE         | air_pressure
-  PKZ       | Pa$^\kappa$      | R8       | xyz  | REQUIRED |  C   |    F       |             | pressure_to_kappa
-  DZ        | m                | R8       | xyz  |          |  C   |    F       |             | height_thickness
+#--------------------------------------------------------------------------------------------------------------------
+ SHORT_NAME | UNITS            | TYPEKIND | DIMS | RESTART  | VLOC | itemtype | ADD2EXPORT | EXPORT_NAME | LONG_NAME
+#--------------------------------------------------------------------------------------------------------------------
+  AK        | Pa               | R8       |   z  | REQUIRED |  E   |          | T          |             | hybrid_sigma_pressure_a
+  BK        | 1                | R8       |   z  | REQUIRED |  E   |          | T          |             | hybrid_sigma_pressure_b
+  UV        | m s-1            | R8       | xyz  | REQUIRED |  C   | V        | F          |             | (eastward_wind, northward_wind)
+  W         | m s-1            | R8       | xyz  |          |  C   |          | F          |             | vertical_velocity
+  PT        | K Pa$^{-\kappa}$ | R8       | xyz  | REQUIRED |  C   |          | F          |             | scaled_potential_temperature
+  PE        | Pa               | R8       | xyz  | REQUIRED |  E   |          | T          | PLE         | air_pressure
+  PKZ       | Pa$^\kappa$      | R8       | xyz  | REQUIRED |  C   |          | F          |             | pressure_to_kappa
+  DZ        | m                | R8       | xyz  |          |  C   |          | F          |             | height_thickness

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -83,8 +83,7 @@ category: EXPORT
 # DTDTSUBZ       | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_subgrid_dz
 # DWDTSUBZ       | m/s/s            | xyz  |  C   |           |          | tendency_of_vertical_velocity_due_to_subgrid_dz
   DTDT_RAY       | K s-1            | xyz  |  C   |           |          | air_temperature_tendency_due_to_Rayleigh_friction
-  DUDT_RAY       | m s-2            | xyz  |  C   |           |          | tendency_of_eastward_wind_due_to_Rayleigh_friction
-  DVDT_RAY       | m s-2            | xyz  |  C   |           |          | tendency_of_northward_wind_due_to_Rayleigh_friction
+  D_UV_DT_RAY    | m s-2            | xyz  |  C   | V         |          | tendency_of_(eastward, northward)_wind_due_to_Rayleigh_friction
   DWDT_RAY       | m/s/s            | xyz  |  C   |           |          | vertical_velocity_tendency_due_to_Rayleigh_friction
   D_UV_DTANA     | m/s/s            | xyz  |  C   | V         |          | tendency_of_(eastward, northward)_wind_due_to_analysis
   DTDTANA        | K s-1            | xyz  |  C   |           |          | tendency_of_air_temperature_due_to_analysis

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -1244,6 +1244,9 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
   real(FVPRC) :: FQC
 
   real(REAL4), pointer     :: PTR3D(:,:,:)
+  real(REAL4), pointer     :: dudt_ray(:,:,:), dvdt_ray(:,:,:)
+  type(ESMF_FieldBundle)   :: ray_bundle
+  integer                  :: ray_field_count
 
   real(FVPRC), allocatable :: DEBUG_ARRAY(:,:,:)
   real(FVPRC) :: fac1    = 1.0
@@ -2015,10 +2018,14 @@ subroutine FV_Run (STATE, EXPORT, CLOCK, GC, PLE0, RC)
     allocate ( vdt(isc:iec,jsc:jec,npz) )
     ! go from native D-Grid tendencies to A-grid rotated exports
     call fv_getAllWinds(u_dt, v_dt, ur=udt, vr=vdt)
-    call MAPL_StateGetPointer ( export, PTR3D, 'DUDT_RAY', rc=status ); VERIFY_(STATUS)
-    if( associated(PTR3D) ) PTR3D = udt
-    call MAPL_StateGetPointer ( export, PTR3D, 'DVDT_RAY', rc=status ); VERIFY_(STATUS)
-    if( associated(PTR3D) ) PTR3D = vdt
+    call ESMF_StateGet(export, 'D_UV_DT_RAY', ray_bundle, rc=status); VERIFY_(STATUS)
+    call ESMF_FieldBundleGet(ray_bundle, fieldCount=ray_field_count, rc=status); VERIFY_(STATUS)
+    if (ray_field_count == 2) then
+       call MAPL_FieldBundleGetPointer(ray_bundle, 1, dudt_ray, rc=status); VERIFY_(STATUS)
+       call MAPL_FieldBundleGetPointer(ray_bundle, 2, dvdt_ray, rc=status); VERIFY_(STATUS)
+       dudt_ray = udt
+       dvdt_ray = vdt
+    end if
     deallocate ( udt )
     deallocate ( vdt )
     call MAPL_StateGetPointer ( export, PTR3D, 'DTDT_RAY', rc=status ); VERIFY_(STATUS)

--- a/FV_StateMod.F90
+++ b/FV_StateMod.F90
@@ -865,7 +865,6 @@ contains
 
   real(REAL8), pointer                   :: AK(:) => NULL(), AK1(:) => NULL()
   real(REAL8), pointer                   :: BK(:) => NULL(), BK1(:) => NULL()
-  type(ESMF_FieldBundle) :: uv
   real(REAL8), dimension(:,:,:), pointer :: U     => NULL()
   real(REAL8), dimension(:,:,:), pointer :: V     => NULL()
   real(REAL8), dimension(:,:,:), pointer :: PT    => NULL()
@@ -924,9 +923,10 @@ contains
   VERIFY_(STATUS)
   call MAPL_StateGetPointer(internal, bk1, "BK",rc=status)
   VERIFY_(STATUS)
-  call ESMF_StateGet(internal, "UV", uv, _RC)
-  call MAPL_FieldBundleGetPointer(uv, 1, u, _RC)
-  call MAPL_FieldBundleGetPointer(uv, 2, v, _RC)
+  call MAPL_StateGetPointer(internal, u, "U",rc=status)
+  VERIFY_(STATUS)
+  call MAPL_StateGetPointer(internal, v, "V",rc=status)
+  VERIFY_(STATUS)
   call MAPL_StateGetPointer(internal, pt, "PT",rc=status)
   VERIFY_(STATUS)
   call MAPL_StateGetPointer(internal, pe, "PE",rc=status)

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -65,6 +65,5 @@ foreach(TEST_CASE ${TEST_CASES})
   set_tests_properties("${TEST_CASE}" PROPERTIES
     LABELS "REGRESSION"
     ENVIRONMENT "${LD_PATH}=${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}}"
-    # DEPENDS sync_regression_data
   )
 endforeach()


### PR DESCRIPTION
## Summary

This PR brings four commits onto `release/MAPL-v3` that consolidate the DynCore vector field export work and migrate `DynCore_StateSpecs.rc` to the updated MAPL3 schema format.

## Changes

**Reformat `DynCore_StateSpecs.rc`**

Migrates the StateSpecs file to the new column layout where `LONG_NAME` is the last column and `FIELD_TYPE` is renamed to `itemtype`. This is a pure reformatting change — no fields are added or removed.

**Refactor UV vector export via `fillout_vector_r8` helper** (`829f888`)

Replaces the ad-hoc `ESMF_StateGet` / `ESMF_FieldBundleGet` / `MAPL_FieldBundleGetPointer` boilerplate (duplicated at two call sites) with a new internal `fillout_vector_r8` subroutine that mirrors the scalar `FILLOUT3` interface. The helper retrieves the FieldBundle, checks that it contains exactly two fields, inspects the typekind of the first field, and assigns the input `r8` arrays into either `r4` or `r8` field pointers as appropriate. Also re-enables the `DPLEDTDYN` export and fixes its `VLOC` from `C` to `E` (edge variable).

**Migrate vector specs from `GridCompAddSpec` to `StateSpecs.rc`** (`70d1f3c`)

Removes the six manual `MAPL_GridCompAddSpec` calls for vector fields (`UV`, `D_UV_DTANA`, `UV_KE`, `UV_PHI`, `UV_QV`) and replaces them with `itemtype: V` entries in `DynCore_StateSpecs.rc`, which is now the canonical way to declare vector FieldBundles. Removes the spurious `V` marker from scalar fields that were previously mislabeled as vector components.

**Migrate `UQL`/`VQL` and `UQI`/`VQI` flux exports to vector bundles** (`deb1283`)

Replaces the four scalar `MAPL_StateGetPointer`-based exports for liquid water and ice fluxes with two vector FieldBundle exports (`UV_QL`, `UV_QI`), consistent with the pattern used for `UV`, `UV_KE`, `UV_PHI`, and `UV_QV`. Updates `DynCore_StateSpecs.rc` accordingly and removes stale commented-out scalar entries.

## Testing

- Builds cleanly with ifort/Debug.
- Regression tests (`ctest -L REGRESSION`) pass for `dyn-sa` and `adv-dyn`.