### PR TITLE
Port FVdycoreCubed to MAPL3

### DIFF
--- a/DynCore_GridCompMod.F90
+++ b/DynCore_GridCompMod.F90
@@ -405,7 +405,9 @@ contains
       type(ESMF_State) :: internal
       type(ESMF_FieldBundle) :: uv_exp
       real(kind=r4), pointer :: pref(:)
-      real(kind=r4), pointer :: u(:, :, :), v(:, :, :), t(:, :, :)
+      real(kind=r4), pointer :: u(:, :, :), v(:, :, :)
+      real(kind=r4), pointer :: t(:, :, :)
+
       real(kind=r4), pointer :: temp2d(:, :)
       real(kind=r8), pointer :: ak(:), bk(:)
       real(kind=r8), pointer :: ud(:, :, :), vd(:, :, :)
@@ -485,6 +487,9 @@ contains
       if (associated(temp2d)) temp2d = self%grid%area
 
       ! Replay shutoff alarm
+      ! Set the intermittent replay alarm, if needed.
+      ! Note that it is a non-sticky alarm and is set to ringing on first step
+      ! So it will work whether the clock is backed-up and ticked or not
       call MAPL_GridCompGetResource(gc, "REPLAY_SHUTOFF", replay_shutoff_seconds, default=-3600, _RC)
       call ESMF_TimeIntervalSet(replay_shutoff_interval, s=abs(replay_shutoff_seconds), _RC)
       replay_shutoff_alarm = ESMF_AlarmCreate( &
@@ -1434,7 +1439,6 @@ contains
       call FILLOUT3(export, "T_DYN_IN", tempxy, _RC)
       call FILLOUT3r8_VECTOR(export, "UV_DYN_IN", ur, vr, _RC)
       call FILLOUT3(export, "PLE_DYN_IN", vars%pe, _RC)
-      call FILLOUT3(export, "PLE4", vars%pe, _RC)
 
       ! Initialize 3-D Tracer Dynamics Tendencies
       call MAPL_StateGetPointer(export, dqldt, "DQLDTDYN", _RC)
@@ -1586,8 +1590,6 @@ contains
       pe0 = vars%pe
 
       call MAPL_GridCompTimerStop(gc, "DYN_PROLOGUE", _RC)
-
-      !-------------------------------------------------------
 
       call MAPL_GridCompTimerStart(gc, "DYN_CORE", _RC)
       t1 = MPI_Wtime(status)
@@ -1830,6 +1832,7 @@ contains
          call FILLOUT3(export, 'T', tempxy, _RC)
          call FILLOUT3(export, 'Q', qv, _RC)
          call FILLOUT3(export, 'PL', pl, _RC)
+         call FILLOUT3(export, 'PLE4', vars%pe, _RC)
          call FILLOUT3(export, 'PLK', plk, _RC)
          call FILLOUT3(export, 'PKE', pkxy, _RC)
          call FILLOUT3(export, 'PT', vars%pt, _RC)
@@ -3015,6 +3018,7 @@ contains
          call FILLOUT3(export, "T", tempxy, _RC)
          call FILLOUT3(export, "Q", qv, _RC)
          call FILLOUT3(export, "PL", pl, _RC)
+         call FILLOUT3(export, "PLE4", vars%pe, _RC)
          call FILLOUT3(export, "PLK", plk, _RC)
          call FILLOUT3(export, "PKE", pke, _RC)
          call FILLOUT3(export, "THV", thv, _RC)
@@ -5065,10 +5069,10 @@ contains
 
 end module FVdycoreCubed_GridComp
 
-subroutine SetServices(gc, rc)
+subroutine FVdycoreCubed_SetServices(gc, rc)
    use ESMF
    use FVdycoreCubed_GridComp, only : mySetservices => SetServices
    type(ESMF_GridComp) :: gc
    integer, intent(out) :: rc
    call mySetservices(gc, rc=rc)
-end subroutine SetServices
+end subroutine FVdycoreCubed_SetServices

--- a/DynCore_StateSpecs.rc
+++ b/DynCore_StateSpecs.rc
@@ -213,26 +213,26 @@ VVEL_DN_100_1000 | m s-1            | xy   |  N   |           |          | max_v
   T_DYN_IN       | K                | xyz  |  C   |           |          | temperature_at_begin_of_time_step
   UV_DYN_IN      | m s-1            | xyz  |  C   | V         |          | (u, v)_wind_at_begin_of_time_step
   PLE_DYN_IN     | Pa               | xyz  |  E   |           |          | edge_pressure_at_begin_of_time_step
-  PLE4           | Pa               | xyz  |  E   |           |          | pressure_at_layer_edges_r4
+  PLE4           | Pa               | xyz  |  E   |           |          | edge_pressure
 
 
 category: IMPORT
-#----------------------------------------------------------------------
- SHORT_NAME |  UNITS   | DIMS | StateItem | VLOC | RESTART | LONG_NAME
-#----------------------------------------------------------------------
-  D_UV_DT   | m s-2    | xyz  | V         |  C   |         | (eastward,northward)_wind_tendency
-  DWDT      | m s-2    | xyz  |           |  C   |         | vertical_velocity_tendency
-  DTDT      | Pa K s-1 | xyz  |           |  C   |         | delta-p_weighted_temperature_tendency
-  DQVANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_increment_from_analysis
-  DQLANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_liquid_increment_from_analysis
-  DQIANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_ice_increment_from_analysis
-  DQRANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_rain_increment_from_analysis
-  DQSANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_snow_increment_from_analysis
-  DQGANA    | kg kg-1  | xyz  |           |  C   |         | specific_humidity_graupel_increment_from_analysis
-  DOXANA    | kg kg-1  | xyz  |           |  C   |         | ozone_increment_from_analysis
-  DPEDT     | Pa s-1   | xyz  |           |  E   |         | edge_pressure_tendency
-  PHIS      | m+2 s-2  | xy   |           |  N   |         | surface_geopotential_height
-  VARFLT    | m+2      | xy   |           |  N   | SKIP    | variance_of_filtered_topography
+#---------------------------------------------------------------------
+ SHORT_NAME |  UNITS   | DIMS | itemtype | VLOC | RESTART | LONG_NAME
+#---------------------------------------------------------------------
+  D_UV_DT   | m s-2    | xyz  | V        |  C   |         | (eastward,northward)_wind_tendency
+  DWDT      | m s-2    | xyz  |          |  C   |         | vertical_velocity_tendency
+  DTDT      | Pa K s-1 | xyz  |          |  C   |         | delta-p_weighted_temperature_tendency
+  DQVANA    | kg kg-1  | xyz  |          |  C   |         | specific_humidity_increment_from_analysis
+  DQLANA    | kg kg-1  | xyz  |          |  C   |         | specific_humidity_liquid_increment_from_analysis
+  DQIANA    | kg kg-1  | xyz  |          |  C   |         | specific_humidity_ice_increment_from_analysis
+  DQRANA    | kg kg-1  | xyz  |          |  C   |         | specific_humidity_rain_increment_from_analysis
+  DQSANA    | kg kg-1  | xyz  |          |  C   |         | specific_humidity_snow_increment_from_analysis
+  DQGANA    | kg kg-1  | xyz  |          |  C   |         | specific_humidity_graupel_increment_from_analysis
+  DOXANA    | kg kg-1  | xyz  |          |  C   |         | ozone_increment_from_analysis
+  DPEDT     | Pa s-1   | xyz  |          |  E   |         | edge_pressure_tendency
+  PHIS      | m+2 s-2  | xy   |          |  N   |         | surface_geopotential_height
+  VARFLT    | m+2      | xy   |          |  N   | SKIP    | variance_of_filtered_topography
 
 
 category: INTERNAL

--- a/regression/adv-dyn/root.yaml
+++ b/regression/adv-dyn/root.yaml
@@ -10,6 +10,7 @@ mapl:
     DYN:
       dso: libFVdycoreCubed_GridComp
       config_file: dyn.yaml
+      setservice: fvdycorecubed_setservices_
 
     ADV:
       dso: libFVdycoreCubed_GridComp
@@ -19,19 +20,22 @@ mapl:
     DataMoist:
       dso: libconfigurable_gridcomp
       config_file: data-moist.yaml
+      setservice: setservices_
 
     DataTracers:
       dso: libconfigurable_gridcomp
       config_file: data-tracers.yaml
+      setservice: setservices_
 
     DataPhisVarflt:
       dso: libconfigurable_gridcomp
       config_file: data-phis-varflt.yaml
+      setservice: setservices_
 
     DataAna:
       dso: libconfigurable_gridcomp
       config_file: data-ana.yaml
-
+      setservice: setservices_
   connections:
     - src_name: TRADV
       dst_name: TRADV

--- a/regression/dyn-sa/root.yaml
+++ b/regression/dyn-sa/root.yaml
@@ -10,9 +10,11 @@ mapl:
     DYNsa:
       dso: libFVdycoreCubed_GridComp
       config_file: dyn-sa.yaml
+      setservice: fvdycorecubed_setservices_
     DataMoist:
       dso: libconfigurable_gridcomp
       config_file: data-moist.yaml
+      setservice: setservices_
 
   connections:
     - src_name: TRADV


### PR DESCRIPTION
## Summary

Three commits porting FVdycoreCubed_GridComp to MAPL3:

### Fix PLE4 export placement and rename SetServices
- Move `FILLOUT3(export, 'PLE4', vars%pe)` calls from Initialize into the Run phase (both standard and adjoint paths), where the `pe` array is valid and populated
- Rename `SetServices` -> `FVdycoreCubed_SetServices` to avoid symbol collisions when multiple gridcomps are linked together
- Minor: split pointer declarations and add comment for replay shutoff alarm setup

### Fix PLE4 long name and update internal state spec column header
- Change PLE4 long name from `pressure_at_layer_edges_r4` to `edge_pressure`
- Rename internal state spec column header `StateItem` -> `itemtype` and reformat separator line to match MAPL3 resource file conventions

### Add explicit setservice entries to regression test configs
- Add `setservice: fvdycorecubed_setservices_` for DYN/DYNsa components and `setservice: setservices_` for other components in both adv-dyn and dyn-sa regression test cases, required after the SetServices rename