### PR TITLE
Removed the remaining "USE PFIO". This required the public object "Va…

### DIFF
--- a/fv_regrid_c2c.F90
+++ b/fv_regrid_c2c.F90
@@ -11,16 +11,7 @@ module fv_regrid_c2c
    use tracer_manager_mod, only: get_tracer_names, get_number_tracers, get_tracer_index
    use field_manager_mod,  only: MODEL_ATMOS
 
-   use MAPL, only: Regridder, REGRID_METHOD_BILINEAR, generate_esmf_regrid_param, &
-                   get_regridder_manager, RegridderManager, RegridderSpec, &
-                   CubedSphereGeomSpec, mapl_GridGetGlobalCellCountPerDim, &
-                   ArrDescr, ArrDescrInit, ArrDescrSet, &
-                   MAPL_VarRead, MAPL_NCIOGetFileType, &
-                   MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars, ArrayScatter, &
-                   MAPL_Verify, MAPL_Return
-   use MAPL_Constants, only: MAPL_PI_R8, MAPL_OMEGA, MAPL_GRAV, MAPL_KAPPA, &
-                              MAPL_RGAS, MAPL_RVAP, MAPL_CP, MAPL_PSDRY
-   use pfio
+   use MAPL
    use gFTL2_StringVector
    use gFTL2_StringIntegerMap
    use, intrinsic :: iso_fortran_env, only: REAL64, REAL32

--- a/interp_restarts.F90
+++ b/interp_restarts.F90
@@ -7,14 +7,7 @@ program interp_restarts
 !          to the cubed-sphere grid with optional vertical levels    !
 !--------------------------------------------------------------------!
    use ESMF
-   use pfio
-   use MAPL,           only: MAPL_VarRead, MAPL_VarWrite, MAPL_NCIOGetFileType, &
-                                MAPL_IOGetNonDimVars, MAPL_IOCountNonDimVars, &
-                                MAPL_IOChangeRes, MAPL_IOCountLevels, &
-                                ArrDescr, ArrDescrInit, ArrDescrSet, &
-                                MAPL_GetNodeInfo, MAPL_InitializeShmem, MAPL_FinalizeShmem
-   use MAPL, only: GeomManager, get_geom_manager, MaplGeom, &
-                   CubedSphereGeomSpec, CubedSphereDecomposition
+   use MAPL
    use mpp_mod,        only: mpp_error, FATAL, NOTE, mpp_root_pe, mpp_broadcast
    use fms_mod,        only: print_memory_usage, fms_init, fms_end, file_exist
    use fv_control_mod, only: fv_init1, fv_init2, fv_end


### PR DESCRIPTION
Removed the remaining `USE PFIO`. This required the public object `Variables` to be added to `pfio/API.F90`, and modifying only two files in `FVdycoreCubed_GridComp` i.e. `fv_regrid_c2c.F90` and `interp_restarts.F90`