### PR TITLE
FVdycoreCubed regression test: migrate to esma_sync_data and modernize run_case

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -12,42 +12,18 @@ else()
   endif()
 endif()
 
-string(ASCII 27 ESC)
-set(ORANGE "${ESC}[1;38;5;214m")
-set(RESET  "${ESC}[0m")
-
-# Sync regression test data from S3 (skipped if aws CLI, API key, or internet is not available)
-find_program(AWS_CLI aws)
-
-set(_api_key_exists FALSE)
-if(DEFINED ENV{AWS_API_KEY_GMAO_SITEAM_S3} AND NOT "$ENV{AWS_API_KEY_GMAO_SITEAM_S3}" STREQUAL "")
-  set(_api_key_exists TRUE)
-endif()
-
-set(_internet_is_available FALSE)
-file(DOWNLOAD https://www.nasa.gov/ ${CMAKE_BINARY_DIR}/.nasa_connectivity_test
-  TIMEOUT 10
-  STATUS _download_status
-)
-list(GET _download_status 0 _download_result)
-if(_download_result EQUAL 0)
-  set(_internet_is_available TRUE)
-endif()
-file(REMOVE ${CMAKE_BINARY_DIR}/.nasa_connectivity_test)
-
-if(AWS_CLI AND _api_key_exists AND _internet_is_available)
-  set(S3_URI "s3://gmao-usw2-si-team/regression-data")
-  set(LOCAL_DIR "${CMAKE_BINARY_DIR}/regression-data")
-  add_custom_target(sync_regression_data ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${LOCAL_DIR}"
-    COMMAND ${CMAKE_COMMAND} -DAWS_CLI=${AWS_CLI} -DS3_URI=${S3_URI} -DLOCAL_DIR=${LOCAL_DIR}
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/sync_data.cmake
-    BYPRODUCTS "${LOCAL_DIR}"
-    COMMENT "Syncing regression test data from ${S3_URI}"
-    VERBATIM
+# Sync regression test data from S3
+set(FV3_PATH FVdycoreCubed_GridComp)
+set(REGRESSION_DATA_DIR ${CMAKE_BINARY_DIR}/regression-data/${FV3_PATH})
+if (NOT EXISTS ${REGRESSION_DATA_DIR})
+  message(STATUS "Syncing regression data from S3: ${FV3_PATH}")
+  esma_sync_data(
+    TARGET sync_regression_data_fv3
+    URI "s3://gmao-usw2-si-team/regression-data/${FV3_PATH}"
+    DESTINATION "${REGRESSION_DATA_DIR}"
+    CREDENTIALS_URL "https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials"
+    ALL
   )
-else()
-  message(WARNING "${ORANGE}AWS CLI or AWS_API_KEY_GMAO_SITEAM_S3 not available - regression test data sync and comparisons will be skipped${RESET}")
 endif()
 
 # Regression tests
@@ -60,6 +36,7 @@ foreach(TEST_CASE ${TEST_CASES})
       -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
       -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
       "-DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}"
+      -DREGRESSION_DATA_DIR=${REGRESSION_DATA_DIR}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_case.cmake
   )
   set_tests_properties("${TEST_CASE}" PROPERTIES

--- a/regression/run_case.cmake
+++ b/regression/run_case.cmake
@@ -1,54 +1,55 @@
-macro(run_case CASE)
-  string(RANDOM LENGTH 24 tempdir)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${tempdir}
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/${CASE} ${tempdir}
-  )
-
-  # Run the case
-  set(num_procs "6")
+function(run_geos num_procs case_name expdir)
   execute_process(
     COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ${MPIEXEC_PREFLAGS} ${MY_BINARY_DIR}/GEOS.x cap.yaml
     RESULT_VARIABLE CMD_RESULT
-    WORKING_DIRECTORY ${tempdir}
+    WORKING_DIRECTORY ${expdir}
     COMMAND_ECHO STDOUT
   )
-  if(EXISTS ${tempdir}/PET0.ESMF_LogFile)
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E cat ${tempdir}/PET0.ESMF_LogFile
-    )
+  if(EXISTS ${expdir}/PET0.ESMF_LogFile)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E cat ${expdir}/PET0.ESMF_LogFile)
   endif()
   if(CMD_RESULT)
-    set(MSG "Error running ${CASE}")
-    message(FATAL_ERROR "${MSG}")
+    message(FATAL_ERROR "Error running ${case_name}")
   endif()
+endfunction()
 
-  # Compare output against baseline
-  set(BASELINE_DIR ${MY_BINARY_DIR}/../regression-data/FVdycoreCubed_GridComp/${CASE})
-  if(NOT EXISTS ${BASELINE_DIR})
-    string(ASCII 27 ESC)
-    set(ORANGE "${ESC}[1;38;5;214m")
-    set(RESET  "${ESC}[0m")
-    message(WARNING "${ORANGE}Baseline directory not found, skipping comparison: ${BASELINE_DIR}${RESET}")
+function(compare_results baseline_dir current_dir)
+  file(GLOB baseline_files ${baseline_dir}/*.nc)
+  foreach(baseline_file IN LISTS baseline_files)
+    get_filename_component(fname ${baseline_file} NAME)
+    message(STATUS "Comparing ${fname}")
+    execute_process(
+      COMMAND cmp ${baseline_file} ${current_dir}/${fname}
+      RESULT_VARIABLE CMP_RESULT
+      OUTPUT_VARIABLE CMP_OUTPUT
+      ERROR_VARIABLE CMP_OUTPUT
+    )
+    if(CMP_RESULT)
+      message(FATAL_ERROR "Files differ: ${fname}\n${CMP_OUTPUT}")
+    endif()
+  endforeach()
+endfunction()
+
+function(run_case case_name regression_data_dir)
+  string(RANDOM LENGTH 24 expdir)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${expdir}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/${case_name} ${expdir}
+  )
+
+  set(num_procs "6")
+  set(checkpoints_dir ${regression_data_dir}/${case_name}/checkpoints/last)
+
+  run_geos(${num_procs} ${case_name} ${expdir})
+  if (NOT EXISTS ${checkpoints_dir})
+    message(WARNING "Baseline directory [${checkpoints_dir}] not found. Skipping comparison.")
   else()
-    file(GLOB baseline_files ${BASELINE_DIR}/*.nc)
-    foreach(baseline_file IN LISTS baseline_files)
-      get_filename_component(fname ${baseline_file} NAME)
-      message(STATUS "Comparing ${fname}")
-      execute_process(
-        COMMAND cmp ${baseline_file} ${tempdir}/checkpoints/last/${fname}
-        RESULT_VARIABLE CMP_RESULT
-        OUTPUT_VARIABLE CMP_OUTPUT
-        ERROR_VARIABLE CMP_OUTPUT
-      )
-      if(CMP_RESULT)
-        message(FATAL_ERROR "Files differ: ${fname}\n${CMP_OUTPUT}")
-      endif()
-    endforeach()
+    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
   endif()
 
   # execute_process(
-  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${tempdir}
+  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${expdir}
   # )
-endmacro()
-run_case(${TEST_CASE})
+endfunction()
+
+run_case(${TEST_CASE} ${REGRESSION_DATA_DIR})


### PR DESCRIPTION
CMakeLists.txt
- Replace the hand-rolled S3 sync block (manual aws CLI detection, internet reachability probe, ANSI escape colouring, add_custom_target) with a single esma_sync_data() call; data is synced once at configure time and placed under ${CMAKE_BINARY_DIR}/regression-data/FVdycoreCubed_GridComp
- Pass REGRESSION_DATA_DIR to each test via cmake -P so run_case.cmake no longer hard-codes a relative path to the binary dir

run_case.cmake
- Convert the run_case macro into a function to avoid variable leakage
- Extract run_geos and compare_results as reusable helper functions (mirrors the pattern introduced in GEOSgwd_GridComp/regression)
- Replace the hard-coded baseline path (MY_BINARY_DIR/../regression-data/…) with the REGRESSION_DATA_DIR variable passed in from CMakeLists.txt
- Replace the ANSI-coloured warning for a missing baseline with a plain message(WARNING …); no behavioural change, removes the terminal-escape boilerplate
- Rename tempdir → expdir for consistency with the GWD regression driver