### PR TITLE
fix(regression): move data download from configure time to ctest fixture

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -12,19 +12,35 @@ else()
   endif()
 endif()
 
-# Sync regression test data from S3
 set(FV3_PATH FVdycoreCubed_GridComp)
-set(REGRESSION_DATA_DIR ${CMAKE_BINARY_DIR}/regression-data/${FV3_PATH})
-if (NOT EXISTS ${REGRESSION_DATA_DIR})
-  message(STATUS "Syncing regression data from S3: ${FV3_PATH}")
-  esma_sync_data(
-    TARGET sync_regression_data_fv3
-    URI "s3://gmao-usw2-si-team/regression-data/${FV3_PATH}"
-    DESTINATION "${REGRESSION_DATA_DIR}"
-    CREDENTIALS_URL "https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials"
-    ALL
-  )
+if(DEFINED ENV{LOCAL_REGRESSION_DATA_DIR} AND NOT "$ENV{LOCAL_REGRESSION_DATA_DIR}" STREQUAL "")
+  set(REGRESSION_DATA_DIR "$ENV{LOCAL_REGRESSION_DATA_DIR}/${FV3_PATH}")
+else()
+  set(REGRESSION_DATA_DIR ${CMAKE_BINARY_DIR}/regression-data/${FV3_PATH})
 endif()
+
+set(SYNC_WORK_DIR "${CMAKE_BINARY_DIR}/regression-data/sync_work/fv3")
+
+# Locate the cmake script used internally by esma_sync_data()
+find_file(ESMA_SYNC_DATA_SCRIPT
+  NAMES esma_sync_data_script.cmake
+  PATHS ${CMAKE_MODULE_PATH}
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+
+# Fixture test: sync regression data from S3 at ctest (NOT configure) time
+add_test(
+  NAME fv3/sync_data
+  COMMAND ${CMAKE_COMMAND}
+    "-DLOCAL_DIR=${REGRESSION_DATA_DIR}"
+    "-DWORK_DIR=${SYNC_WORK_DIR}"
+    "-DESMA_SYNC_DATA_SCRIPT=${ESMA_SYNC_DATA_SCRIPT}"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/sync_data.cmake
+)
+set_tests_properties(fv3/sync_data PROPERTIES
+  FIXTURES_SETUP fv3_regression_data
+)
 
 # Regression tests
 foreach(TEST_CASE ${TEST_CASES})
@@ -42,5 +58,6 @@ foreach(TEST_CASE ${TEST_CASES})
   set_tests_properties("${TEST_CASE}" PROPERTIES
     LABELS "REGRESSION"
     ENVIRONMENT "${LD_PATH}=${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}}"
+    FIXTURES_REQUIRED fv3_regression_data
   )
 endforeach()

--- a/regression/sync_data.cmake
+++ b/regression/sync_data.cmake
@@ -1,28 +1,21 @@
-# Retrieve temporary AWS credentials from the SI-team credentials API
-execute_process(
-  COMMAND curl -s -H "x-api-key: $ENV{AWS_API_KEY_GMAO_SITEAM_S3}"
-          https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials
-  OUTPUT_VARIABLE CREDS_JSON
-  RESULT_VARIABLE CURL_RESULT
-)
-if(CURL_RESULT)
-  message(FATAL_ERROR "Failed to retrieve AWS credentials (curl exit code: ${CURL_RESULT})")
+# sync_data.cmake
+# Downloads FVdycoreCubed regression data from S3.
+# Required inputs (via -D): LOCAL_DIR, WORK_DIR, ESMA_SYNC_DATA_SCRIPT
+
+if(DEFINED ENV{LOCAL_REGRESSION_DATA_DIR} AND NOT "$ENV{LOCAL_REGRESSION_DATA_DIR}" STREQUAL "")
+  message(STATUS "LOCAL_REGRESSION_DATA_DIR is set -- skipping S3 sync")
+  return()
 endif()
 
-string(JSON AWS_ACCESS_KEY_ID     GET "${CREDS_JSON}" AccessKeyId)
-string(JSON AWS_SECRET_ACCESS_KEY GET "${CREDS_JSON}" SecretAccessKey)
-string(JSON AWS_SESSION_TOKEN     GET "${CREDS_JSON}" SessionToken)
-
-# Sync regression test data from S3
-execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env
-    AWS_EC2_METADATA_DISABLED=true
-    AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-    AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-    AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-    ${AWS_CLI} s3 sync --only-show-errors "${S3_URI}" "${LOCAL_DIR}"
-  RESULT_VARIABLE AWS_RESULT
-)
-if(AWS_RESULT)
-  message(FATAL_ERROR "aws s3 sync failed (exit code: ${AWS_RESULT})")
+if(EXISTS "${LOCAL_DIR}")
+  message(STATUS "Regression data already present: ${LOCAL_DIR} -- skipping sync")
+  return()
 endif()
+
+set(AWS_CLI "aws")
+set(S3_URI "s3://gmao-usw2-si-team/regression-data/FVdycoreCubed_GridComp")
+set(API_KEY_ENV "AWS_API_KEY_GMAO_SITEAM_S3")
+set(CREDENTIALS_URL "https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials")
+set(REQUIRED FALSE)
+
+include("${ESMA_SYNC_DATA_SCRIPT}")


### PR DESCRIPTION
## Summary

Previously, regression data was synced from S3 via `esma_sync_data()` during cmake configuration, which meant a network call on every re-configure even when data was already present, and made it impossible to configure offline.

This follows the pattern established for GOCART2G regression tests.

## Changes

- Remove the configure-time `esma_sync_data()` call.
- Add `LOCAL_REGRESSION_DATA_DIR` support so developers can point at a local copy of the data and skip the S3 sync entirely.
- Locate `esma_sync_data_script.cmake` once at configure time via `find_file()`, passing the path as a `-D` argument to the fixture.
- Register `fv3/sync_data` as a `FIXTURES_SETUP` ctest test that runs `sync_data.cmake` only when `ctest` is invoked.
- Add `FIXTURES_REQUIRED fv3_regression_data` to every regression test so ctest enforces the correct ordering automatically.

`sync_data.cmake` is rewritten to use the shared `esma_sync_data_script` include rather than hand-rolling the AWS credential fetch and S3 sync, and gains the same two early-exit guards (`LOCAL_REGRESSION_DATA_DIR` set, or `LOCAL_DIR` already exists) present in the GOCART2G version.